### PR TITLE
🐛: bugfix inputtext hides behind keyboard on iOS

### DIFF
--- a/santoku-app/src/app/components/parts/StatefulLoginForm.tsx
+++ b/santoku-app/src/app/components/parts/StatefulLoginForm.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
-import { StyleSheet, TextInput } from 'react-native';
+import { StyleSheet, TextInput, Platform, KeyboardAvoidingView, StatusBar, ScrollView } from 'react-native';
 import { Form, Item, Input, Label, Button, Text } from 'native-base';
+import {useHeaderHeight} from '@react-navigation/stack';
 import { Container, Section, Title, Description } from '../basics';
 import { useValidation, CommonErrorKey } from '../../hooks/validation';
 import type { Errors, ErrorsKey, Values } from '../../hooks/validation';
@@ -53,6 +54,7 @@ type Props = {
 };
 
 const StatefulLoginForm: React.FC<Props> = ({ login }) => {
+  const headerHeight = useHeaderHeight();
   const { values, onBlur, onChangeText, errors, setCommonErrors, invalid, shouldShowErrorMessage, clearStatus } = useValidation<FormData>(
     initialValues,
     validate
@@ -79,52 +81,68 @@ const StatefulLoginForm: React.FC<Props> = ({ login }) => {
 
   return (
     <Container>
-      <Description>
-        ネイティブ側で既存Web資産にログインすれば、そのままWebViewで認証が必要な画面を開けるという例を示します。{'\n\n'}
-        まずはネイティブ側から既存Web資産にログインAPIを読んでセッションIDを取得します。{'\n\n'}
-        以下ログインフォームにログインIDに10000001にパスワードにpass123-を入力してログインボタンをタップしてください。
-      </Description>
-      <Section>
-        <Title>ログインフォーム</Title>
+      <KeyboardAvoidingView
+        behavior={Platform.select({
+          ios: 'padding',
+          android: 'height'
+        })}
+        style={{flex: 1}}
+        keyboardVerticalOffset={Platform.select({
+          ios: headerHeight,
+          android: headerHeight + (StatusBar.currentHeight ?? 0),
+        })}>
+        {/* 一旦キーボードを表示して非表示にした時に、画面の高さが大幅に下に伸びてしまわないようにScrollViewを設定しておく */}
+        <ScrollView>
 
-        {shouldShowErrorMessage(COMMON) && errorMessage(errors, COMMON)}
-        <Form>
-          <Item floatingLabel error={shouldShowErrorMessage(USER_ID)}>
-            <Label>ユーザーID</Label>
-            <Input
-              value={values[USER_ID]}
-              onBlur={() => onBlur(USER_ID)}
-              onChangeText={(value: string) => onChangeText(USER_ID, value)}
-              getRef={setUserIdRef}
-              onSubmitEditing={() => {
-                if (passwordRef) {
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore: maybe NativeBase bug? https://github.com/GeekyAnts/NativeBase/issues/1803
-                  passwordRef._root.focus();
-                  // TODO: passwordRefがTextInputなら、`_root`を経由しないで直接`focus`を呼べるのでは、、、？型定義が間違えている？
-                }
-              }}
-              returnKeyType="next"
-            />
-          </Item>
-          {shouldShowErrorMessage(USER_ID) && errorMessage(errors, USER_ID)}
+          <Description>
+            ネイティブ側で既存Web資産にログインすれば、そのままWebViewで認証が必要な画面を開けるという例を示します。{'\n\n'}
+            まずはネイティブ側から既存Web資産にログインAPIを読んでセッションIDを取得します。{'\n\n'}
+            以下ログインフォームにログインIDに10000001にパスワードにpass123-を入力してログインボタンをタップしてください。
+          </Description>
+          <Section>
+            <Title>ログインフォーム</Title>
 
-          <Item floatingLabel last error={shouldShowErrorMessage(PASSWORD)}>
-            <Label>パスワード</Label>
-            <Input
-              value={values[PASSWORD]}
-              onBlur={() => onBlur(PASSWORD)}
-              onChangeText={(value: string) => onChangeText(PASSWORD, value)}
-              getRef={setPasswordRef}
-              returnKeyType="done"
-            />
-          </Item>
-          {shouldShowErrorMessage(PASSWORD) && errorMessage(errors, PASSWORD)}
-          <Button style={styles.submitButton} disabled={invalid} onPress={onSubmit}>
-            <Text>ログイン</Text>
-          </Button>
-        </Form>
-      </Section>
+            {shouldShowErrorMessage(COMMON) && errorMessage(errors, COMMON)}
+            <Form>
+              <Item floatingLabel error={shouldShowErrorMessage(USER_ID)}>
+                <Label>ユーザーID</Label>
+                <Input
+                  value={values[USER_ID]}
+                  onBlur={() => onBlur(USER_ID)}
+                  onChangeText={(value: string) => onChangeText(USER_ID, value)}
+                  getRef={setUserIdRef}
+                  onSubmitEditing={() => {
+                    if (passwordRef) {
+                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                      // @ts-ignore: maybe NativeBase bug? https://github.com/GeekyAnts/NativeBase/issues/1803
+                      passwordRef._root.focus();
+                      // TODO: passwordRefがTextInputなら、`_root`を経由しないで直接`focus`を呼べるのでは、、、？型定義が間違えている？
+                    }
+                  }}
+                  returnKeyType="next"
+                />
+              </Item>
+              {shouldShowErrorMessage(USER_ID) && errorMessage(errors, USER_ID)}
+
+              <Item floatingLabel last error={shouldShowErrorMessage(PASSWORD)}>
+                <Label>パスワード</Label>
+                <Input
+                  value={values[PASSWORD]}
+                  onBlur={() => onBlur(PASSWORD)}
+                  onChangeText={(value: string) => onChangeText(PASSWORD, value)}
+                  getRef={setPasswordRef}
+                  returnKeyType="done"
+                />
+              </Item>
+              {shouldShowErrorMessage(PASSWORD) && errorMessage(errors, PASSWORD)}
+              <Button style={styles.submitButton} disabled={invalid} onPress={onSubmit}>
+                <Text>ログイン</Text>
+              </Button>
+            </Form>
+          </Section>
+
+        </ScrollView>
+      </KeyboardAvoidingView>
     </Container>
   );
 };


### PR DESCRIPTION
## やったこと

- [x] Add KeyboardAvoidingView to avoid that inputtext hides behind keyboard on iOS
- [x] Add ScrollView to avoid that page height extends after hiding keybord 

## やっていないこと

None

## 動作確認

- [x] launch app
- [x] show login form in display web application page
- [x] tap input text of password
- [x] input text doesn't hide behind keyboard 

## デバイス

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Pixel 3a/Android 11)

## その他（レビュアーへの申し送り事項、懸念点など）
[AB#5148](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/5148)
