### PR TITLE
🐛: Remove expo from devDependencies, upgrade Podfile.lock

### DIFF
--- a/santoku-app/ios/Podfile.lock
+++ b/santoku-app/ios/Podfile.lock
@@ -603,19 +603,19 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  EXConstants: 6ec1ea4a13ec734c7e2274bc9e5b7408d73007a1
-  EXErrorRecovery: cfb65ec51567cf57a00b2720a2367ac009298319
-  EXFileSystem: efd6c0225f90c8b2c85131d578a09e13197e8b70
-  EXFont: 91111ccdce7c739ff51c5fcb484f2dd9a9a4ce45
-  EXImageLoader: 0b33400e65955c5510a09afc2f9bb369a81e1c6e
-  EXKeepAwake: 4502a0ed7b7c5135587004e6d118acf8cea055fc
-  EXLinearGradient: 54bec9b1b4940407fc498cab6a0c49c617c8cf54
-  EXLocation: 210d39a6e5d793f9721117a11c0b27dc523a3183
-  EXPermissions: 5797c6c72efb411b2bbf502cd5acd841e3ffeefa
-  EXSecureStore: a14319939c62681ec183834e3e6cf47d496f334c
-  EXSplashScreen: accde6b1aaa87f395d6c5e0542e23d5c09a549ab
-  EXSQLite: 246074ef810a3b5e41c0cf8cde141adccc3b0f6b
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  EXConstants: f486f6b4a36b86e47ab258d4d2b7b2699786fdce
+  EXErrorRecovery: 16696fe023fb46a32c3b09033abc361cfcf150a7
+  EXFileSystem: afe9b1fd937d30270bf5108ba44e2f4a1d1ad694
+  EXFont: a6a4353271395f3bb4ee528b52a5035b4b0e412a
+  EXImageLoader: 7153fb1307ac643299a9072b71da0d276f4c7789
+  EXKeepAwake: 76eed36786534f6a476748e600fa6faf07ac3d09
+  EXLinearGradient: c7ca1c2933ac240ffbc805c014a72947e227ac75
+  EXLocation: 90232c6f2773b04a3c146bfda9f181035722c10a
+  EXPermissions: 30cbe5b72bd209b65c00884180ad058a60bb413d
+  EXSecureStore: 579cbccd9cd093e6f4336aba073b059008bd78e0
+  EXSplashScreen: 7ea40b8524f27e7444e3892411c8a4782ab6b4ce
+  EXSQLite: d0d8677c13e60d5db2812387f059c697be27d3fb
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
   FBReactNativeSpec: 7da9338acfb98d4ef9e5536805a0704572d33c2f
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
@@ -626,7 +626,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCTRequired: 48884c74035a0b5b76dbb7a998bd93bcfc5f2047
   RCTTypeSafety: edf4b618033c2f1c5b7bc3d90d8e085ed95ba2ab
@@ -638,11 +638,11 @@ SPEC CHECKSUMS:
   React-jsi: df07aa95b39c5be3e41199921509bfa929ed2b9d
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
-  react-native-app-auth: d7a1884e56c208d50c3fec8cb5a5b860a6ea1378
+  react-native-app-auth: 3a8af9e5f62aa3d7a9391d5aa89ab91aeb5a0062
   react-native-config: d8b45133fd13d4f23bd2064b72f6e2c08b2763ed
   react-native-cookies: ff2e6865dff2e5feeca8f1ed082ae7898e4fa912
-  react-native-safe-area-context: 0ed9288ed4409beabb0817b54efc047286fc84da
-  react-native-webview: 67b9024de02e7c0af9400283b0e3ca6eec55dc26
+  react-native-safe-area-context: eb91fe1fb3f7b87d9c30a7f0808407d8569d539d
+  react-native-webview: 6edf4d6f71b9161fc3e96083726a538ee395304d
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40
@@ -653,26 +653,26 @@ SPEC CHECKSUMS:
   React-RCTText: 65a6de06a7389098ce24340d1d3556015c38f746
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
-  RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
+  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: b748efec66e095134c7166ca333b628cd7e6f3e2
-  UMAppLoader: 939854a42e69527ee11dd17b39ebafcbfbefd05c
-  UMBarCodeScannerInterface: 198ced513a0cf8143d822620f1620bce467d02be
-  UMCameraInterface: dbcaade8d0364ba5518ae4519c63c59bf010aa89
-  UMConstantsInterface: 2ad180a29afdf28607d11d6e23c90793d294ea0e
-  UMCore: 9b6c0ae27349356ed39c9e78b99b7830bb093856
-  UMFaceDetectorInterface: 24faf81d90fb00d477c674fd00b9cb005176f4a0
-  UMFileSystemInterface: 5216dca58177014de7f1157d69c70a1ec5c620bb
-  UMFontInterface: 4d0f13001fc59436125d7424cdfa7c897b699724
-  UMImageLoaderInterface: 575357942cc57ad31662659df9d5a73daa6de54c
-  UMPermissionsInterface: 208b2c5fd6756dcad739d806dfe32b9e44b9311b
-  UMReactNativeAdapter: 2c175f151cfe5ff011ced7bc79ccb08bf124f6c3
-  UMSensorsInterface: 1df848f22690ccd23a821777f00df230fe5a28e3
-  UMTaskManagerInterface: dfc62edf51844ae87dafc1fe849b594871fda1e5
+  UMAppLoader: 5db5dc03176c6238da9c8b3657a370137882a4ad
+  UMBarCodeScannerInterface: 017672479f93de88d94c3a50dfb66b5348b65989
+  UMCameraInterface: 22bd2c4bf15dcf68530368fa5704af7490818457
+  UMConstantsInterface: ff612789417aace6fd01a9c35616bc87dcdc8d97
+  UMCore: 94e4725ab2efbbe247b5910a2a954a2dab64f7eb
+  UMFaceDetectorInterface: 9bc6a197ad9d4d16ba13bfdf2340dd7f24964308
+  UMFileSystemInterface: e7795274eee76beaadaf6015bcc7f5da3054b925
+  UMFontInterface: bc5dd878b2f6fffdac80e41fd36893c619683712
+  UMImageLoaderInterface: 78ab0fd45c2bcaee61957fa23858bf31f2bcb122
+  UMPermissionsInterface: 4f21b0c2aaf953cf041109ff44231b2a69e22836
+  UMReactNativeAdapter: 61ae88818058b7849bbf5b79bf97872cb3c8e0eb
+  UMSensorsInterface: 49bea41dcfcc041f0bbab27cfe4a6006f1dde0c0
+  UMTaskManagerInterface: 6cad5929dbc0a5b986ad4d77caac497d4de730a7
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 9bf753753601678fd43c1ce4cf1318a2e07eab61
+PODFILE CHECKSUM: 55eea96676ae49a9bdf6a937e1e47625c1e32452
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/santoku-app/package.json
+++ b/santoku-app/package.json
@@ -42,7 +42,6 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-preset-expo": "^8.3.0",
     "eslint": "7.5.0",
-    "expo": "^38.0.9",
     "ini": "^1.3.5",
     "jest": "26.0.0",
     "jest-expo": "^39.0.0",


### PR DESCRIPTION
## `npm clean-install` failed

> npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
> npm ERR!
> npm ERR!
> npm ERR! Invalid: lock file's expo@39.0.4 does not satisfy expo@^38.0.9
> npm ERR!
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /Users/ryotan/.npm/_logs/2020-11-20T02_42_47_821Z-debug.log

→ Remove old `expo` from `devDependencies`.

## `npx pod-install` failed

> Analyzing dependencies
> [!] CocoaPods could not find compatible versions for pod "Folly":
>   In snapshot (Podfile.lock):
>     Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
> 
>   In Podfile:
>     Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
> 
> It seems like you've changed the version of the dependency `Folly` and it differs from the version stored in `Pods/Local Podspecs`.
> You should run `pod update Folly --no-repo-update` to apply changes made locally.
> 
> Aborting run
> An unexpected error was encountered. Please report it as a bug:
> Error
>     at CocoaPodsPackageManager._installAsync (/Users/ryotan/.npm/_npx/52727/lib/node_modules/pod-install/build/index.js:2:85721)
>     at processTicksAndRejections (internal/process/task_queues.js:97:5)

→ Remove `Podfile.lock` and re-run `npx pod-install`