### PR TITLE
🐛: ログインボタンにTextButtonを使うように変更

### DIFF
--- a/santoku-app/src/app/components/basics/TextButton.tsx
+++ b/santoku-app/src/app/components/basics/TextButton.tsx
@@ -6,12 +6,13 @@ import type { RnViewStyleProp } from 'native-base';
 type Props = {
   value: string;
   style?: RnViewStyleProp | Array<RnViewStyleProp>;
+  disabled?: boolean;
   onPress?: () => void;
 };
 
-const TextButton: React.FC<Props> = ({ value, style, onPress = () => true }) => {
+const TextButton: React.FC<Props> = ({ value, style, disabled = false, onPress = () => true }) => {
   return (
-    <Button full primary style={[styles.button, style]} onPress={onPress}>
+    <Button full primary style={[styles.button, style]} disabled={disabled} onPress={onPress}>
       <Text>{value}</Text>
     </Button>
   );

--- a/santoku-app/src/app/components/parts/StatefulLoginForm.tsx
+++ b/santoku-app/src/app/components/parts/StatefulLoginForm.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet, TextInput } from 'react-native';
-import { Form, Item, Input, Label, Button, Text } from 'native-base';
-import { Container, Section, Title, Description, KeyboardAvoidingView } from '../basics';
+import { Form, Item, Input, Label, Text } from 'native-base';
+import { Container, Section, Title, Description, KeyboardAvoidingView, TextButton } from '../basics';
 import { useValidation, CommonErrorKey } from '../../hooks/validation';
 import type { Errors, ErrorsKey, Values } from '../../hooks/validation';
 import type { LoginApiAdapter } from '../../context/StatefulLoginContext';
@@ -121,9 +121,7 @@ const StatefulLoginForm: React.FC<Props> = ({ login }) => {
               />
             </Item>
             {shouldShowErrorMessage(PASSWORD) && errorMessage(errors, PASSWORD)}
-            <Button style={styles.submitButton} disabled={invalid} onPress={onSubmit}>
-              <Text>ログイン</Text>
-            </Button>
+            <TextButton style={styles.submitButton} disabled={invalid} onPress={onSubmit} value={'ログイン'} />
           </Form>
         </Section>
       </KeyboardAvoidingView>


### PR DESCRIPTION
## やったこと

- [x] ログインボタンでButtonではなくTextButtonを使うように修正
- [x] 画面タイトルを「Webアプリケーションの表示」から「Webアプリとの認証情報の連携」に修正（ドキュメント側と合わせた）　定数、変数の名前もあわせて修正

## やっていないこと

- 汎用的はTextButtonを作ること(NativeBaseのButtonのpropsのtypeがすぐにわからなかった)

## 動作確認

- アプリを起動して、サイドメニューを表示する
- サイドメニューで「Webアプリとの認証情報の連携」が表示される
- Webアプリとの認証情報の連携画面を表示してタイトルが「Webアプリとの認証情報の連携」になっている「
- Webアプリとの認証情報の連携画面のログインボタンが、入力項目と同じ幅になっている、入力チェックエラーの状況におうじてDisableのスタイルが切り替わる

## デバイス

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [ ] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [ ] ~~実機 (Pixel 3a/Android 11)~~

## その他（レビュアーへの申し送り事項、懸念点など）

[AB#5164](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/5164)