### PR TITLE
🐛:  KeyStoreとKeychainに関する説明を修正

### DIFF
--- a/santoku-app/src/app/components/pages/auth/StatelessAuth.tsx
+++ b/santoku-app/src/app/components/pages/auth/StatelessAuth.tsx
@@ -52,7 +52,7 @@ const StatelessAuthInner: React.FC = () => {
                 取得結果を以下に示します。AWS CognitoのOIDC認証ではIDトークン、アクセストークン、リフレッシュトークンの3つが取得できます。{'\n'}
                 ここでは便宜上取得結果を画面に表示していますが、
                 通常のアプリであれば、ユーザーまたは第三者の目に触れることのないようにセキュアなストレージに保管して管理してください。
-                このアプリでは、AndroidではKeyStore、iOSではKeychainに保管しています。
+                このアプリでは、AndroidではKeyStoreに保存した鍵で暗号化して、SharedPreferenceに保管し、iOSではKeychainに保管しています。
               </Description>
               <Section>
                 <TextButton onPress={signOut} value={'サインアウト'} />

--- a/santoku-app/src/app/components/pages/auth/StatelessAuth.tsx
+++ b/santoku-app/src/app/components/pages/auth/StatelessAuth.tsx
@@ -52,7 +52,7 @@ const StatelessAuthInner: React.FC = () => {
                 取得結果を以下に示します。AWS CognitoのOIDC認証ではIDトークン、アクセストークン、リフレッシュトークンの3つが取得できます。{'\n'}
                 ここでは便宜上取得結果を画面に表示していますが、
                 通常のアプリであれば、ユーザーまたは第三者の目に触れることのないようにセキュアなストレージに保管して管理してください。
-                このアプリでは、AndroidではKeyStoreに保存した鍵で暗号化して、SharedPreferenceに保管し、iOSではKeychainに保管しています。
+                このアプリでは、AndroidではKeyStoreに保存した鍵で暗号化してSharedPreferenceに保管し、iOSではKeychainに保管しています。
               </Description>
               <Section>
                 <TextButton onPress={signOut} value={'サインアウト'} />


### PR DESCRIPTION
## やったこと

- [x]  KeyStoreとKeychainに関する説明を修正
  - Androidの場合KeyStoreには鍵を保存していて実際のデーターはSharedPreferenceに保管する旨を記載

## やっていないこと

None

## 動作確認

- アプリを起動して、サイドメニューを表示する
- ステートレスな認証の画面を表示する


## デバイス

- [ ] iOS
  - [ ] ~~シミュレータ (iPhone Xs/iOS 14)~~
  - [ ] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [ ] ~~実機 (Pixel 3a/Android 11)~~


## その他（レビュアーへの申し送り事項、懸念点など）

[AB#5166](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/5166)