### PR TITLE
🐛: 入力チェックのタイミングはonChangeTextやonBlurから切り離した

### DIFF
--- a/santoku-app/src/app/hooks/validation/useValidation.ts
+++ b/santoku-app/src/app/hooks/validation/useValidation.ts
@@ -11,7 +11,7 @@ export type Errors<T extends string> = { [key in T]: string[] } & BaseErrors;
 export type ErrorsKey<T extends string> = T | keyof BaseErrors;
 export type Values<T extends string> = { [key in T]: string };
 
-export function useValidation<T extends string>(initialValues: Values<T>, validate: (values: Values<T>) => Errors<T>, doInitialValidation? = true) {
+export function useValidation<T extends string>(initialValues: Values<T>, validate: (values: Values<T>) => Errors<T>) {
   const keys = useMemo(() => Object.keys(initialValues), [initialValues]);
   const initialTouched: Touched<T> = keys.reduce((result, key) => ({ ...result, ...{ [key]: false } }), {});
   const initialDirty: Dirty<T> = keys.reduce((result, key) => ({ ...result, ...{ [key]: false } }), {});
@@ -21,46 +21,43 @@ export function useValidation<T extends string>(initialValues: Values<T>, valida
   const [dirty, setDirty] = useState(initialDirty);
   const [errors, setErrors] = useState<Errors<T>>(keys.reduce((result, key) => ({ ...result, ...{ [key]: [] } }), { common: [] }));
 
-  const validateAll = useCallback(
-    (removeCommonError = false) => {
-      const commonError = errors[CommonErrorKey.COMMON] ? { [CommonErrorKey.COMMON]: errors[CommonErrorKey.COMMON] } : {};
-      const newCommonError = removeCommonError ? {} : commonError;
-
-      setErrors({ ...validate(values), ...newCommonError });
-    },
-    [errors, values, validate]
-  );
-
-  const invalid = useMemo(() => {
-    return !!Object.keys(errors).find((key) => !!errors[key].find((e) => !!e));
-  }, [errors]);
+  const touchedSome = useMemo(() => {
+    return Object.keys(touched).some((key: T) => touched[key]);
+  }, [touched]);
 
   const dirtySome = useMemo(() => {
     return Object.keys(dirty).some((key: T) => dirty[key]);
   }, [dirty]);
 
-  const touchedSome = useMemo(() => {
-    return Object.keys(touched).some((key: T) => touched[key]);
-  }, [touched]);
+  const invalid = useMemo(() => {
+    return !!Object.keys(errors).find((key) => !!errors[key].find((e) => !!e));
+  }, [errors]);
+
+  const validateAll = (newValues: Values<T>) => {
+    const removeCommonError = touchedSome || dirtySome;
+    const commonError = errors[CommonErrorKey.COMMON] ? { [CommonErrorKey.COMMON]: errors[CommonErrorKey.COMMON] } : {};
+    const newCommonError = removeCommonError ? {} : commonError;
+
+    setErrors({ ...validate(newValues), ...newCommonError });
+  };
+
+  useEffect(() => {
+    validateAll(values);
+  }, [values]);
 
   const onChangeText = useCallback(
     (key: T, newValue: string) => {
       setDirty({ ...dirty, ...{ [key]: true } });
       setValues({ ...values, ...{ [key]: newValue } });
-
-      const removeCommonError = touchedSome;
-      validateAll(removeCommonError);
     },
-    [dirty, values, touchedSome, validateAll]
+    [dirty, values]
   );
 
   const onBlur = useCallback(
     (key: T) => {
       setTouched({ ...touched, ...{ [key]: true } });
-      const removeCommonError = dirtySome;
-      validateAll(removeCommonError);
     },
-    [touched, dirtySome, validateAll]
+    [touched]
   );
 
   const setCommonErrors = useCallback(
@@ -103,14 +100,6 @@ export function useValidation<T extends string>(initialValues: Values<T>, valida
     setTouched(initialTouched);
     setDirty(initialDirty);
   }, [initialDirty, initialTouched]);
-
-  useEffect(() => {
-    if (doInitialValidation) {
-      validateAll();
-    }
-    // 初回のみ実行のため第2引数に空配列を指定している
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return {
     errors,


### PR DESCRIPTION
## やったこと

- [x]  validateAllの実行タイミングはonChangeTextとonBlurから切り離して、valuesが変わったタイミングで実行するようにした

## やっていないこと

None