### PR TITLE
🔨: Serve built html files from nginx

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,6 +70,7 @@
         '@testing-library/react-native',
         '@typescript-eslint/eslint-plugin',
         '@typescript-eslint/parser',
+        'cross-env',
         'eslint',
         'eslint-config-universe',
         'jest-junit',

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 ## インストール
 
-```console
+```bash
 npm install
 ```
 
 ## ローカルで表示する
 
-```console
+```bash
 npm start
 ```
 
@@ -30,7 +30,7 @@ npm start
 
 ## ビルド
 
-```console
+```bash
 npm run build
 ```
 
@@ -41,7 +41,13 @@ npm run build
 `build`ディレクトリ内のファイルを`/mobile-app-crib-notes/`というコンテキストパスで表示します。Dockerでnginxを起動すると簡単です。
 
 ```bash
-docker run -v $(pwd)/build:/usr/share/nginx/html/mobile-app-crib-notes/ --rm -p 3001:80 nginx
+NGINX_PORT=3001 docker run -v $(pwd)/nginx:/etc/nginx/templates -v $(pwd)/build:/usr/share/nginx/html/mobile-app-crib-notes/ --rm -e NGINX_PORT -p 3001:$NGINX_PORT nginx
+```
+
+このコマンドを実行するnpm scriptを用意しているので、次のコマンドを実行すればビルドされたHTMLファイルを表示することができます。
+
+```bash
+npm run serve
 ```
 
 ## Lint

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ npm run build
 `build`ディレクトリ内のファイルを`/mobile-app-crib-notes/`というコンテキストパスで表示します。Dockerでnginxを起動すると簡単です。
 
 ```bash
-NGINX_PORT=3001 docker run -v $(pwd)/nginx:/etc/nginx/templates -v $(pwd)/build:/usr/share/nginx/html/mobile-app-crib-notes/ --rm -e NGINX_PORT -p 3001:$NGINX_PORT nginx
+NGINX_PORT=3001 docker run -v $(pwd)/nginx:/etc/nginx/templates -v $(pwd)/build:/usr/share/nginx/html/mobile-app-crib-notes/ --rm -e NGINX_PORT -p 3001:3001 nginx
 ```
 
-このコマンドを実行するnpm scriptを用意しているので、次のコマンドを実行すればビルドされたHTMLファイルを表示することができます。
+このコマンドを実行するnpm scriptを用意してあります。
+次のコマンドを実行して`http://localhost:3001/mobile-app-crib-notes/`にアクセスすれば、ビルドされたHTMLファイルを表示することができます。
 
 ```bash
 npm run serve

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,7 @@
+server {
+  listen     ${NGINX_PORT};
+  root       /usr/share/nginx/html;
+  index      index.html;
+  error_page 404 /404.html;
+  expires    1d;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4691,6 +4691,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-fetch": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",
+    "serve": "cross-env NGINX_PORT=3001 docker run -v $(pwd)/nginx:/etc/nginx/templates -v $(pwd)/build:/usr/share/nginx/html/mobile-app-crib-notes/ --rm -e NGINX_PORT -p 3001:3001 nginx",
     "lint": "run-s --print-name --continue-on-error lint:*",
     "lint:text": "textlint \"*.md\" \"!(node_modules|build|santoku-app)/**/*.md\" \"santoku-app/*.md\" \"santoku-app/!(node_modules|ios|android|vendor)/**/*.md\" || echo",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#{node_modules,build,**/node_modules,**/ios,**/android,**/vendor}\" || echo",
@@ -25,6 +26,7 @@
     "react-dom": "^16.8.4"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "markdownlint-cli2": "0.0.13",
     "npm-run-all": "^4.1.5",
     "textlint": "^11.7.6",


### PR DESCRIPTION
## ✅ What's done

- [x] ビルドされたHTMLファイルを表示するための設定と手順を追加
- [x] [Docker Hubのnginx](https://hub.docker.com/_/nginx) に設定ファイルを追加して、任意のポートをlistenできるように設定
  - 末尾スラッシュなしでアクセスすると、80番ポートにリダイレクトされてしまう
    - `http://localhost:3001/mobile-app-crib-notes/reference` が `http://localhost/mobile-app-crib-notes/reference/` に
  - Nginxのレスポンスの`Location`は、Dockerでマッピングしたポートではなく、Nginxがlistenしているポートを指すため（あるある）
  - NginxがlistenするポートとDockerでマッピングするポートを合わせることで回避
- [x] 簡単に起動できるように、npm scriptsを追加

---

## Other (messages to reviewers, concerns, etc.)

たまにHTMLで確認しておいたほうがいいことがあるので、追加しました。