### PR TITLE
🐛: FCMのダミーの設定ファイルだと起動していなかったので修正

### DIFF
--- a/santoku-app/ios/GoogleService-Info.dummy.plist
+++ b/santoku-app/ios/GoogleService-Info.dummy.plist
@@ -29,6 +29,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>dummy</string>
+	<string>1:111111111111:ios:0000000000111111111122</string>
 </dict>
 </plist>


### PR DESCRIPTION
# ダミーファイルをコピーしても起動できないので修正

## ✅ What's done

- [x] 設定ファイルの形式を登録済みのものを参照して、合わせる
---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] シミュレータのアプリの起動確認

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)

## Other (messages to reviewers, concerns, etc.)

なし