### PR TITLE
android のリリース用IDについている.release suffixを除去

### DIFF
--- a/santoku-app/android/app/build.gradle
+++ b/santoku-app/android/app/build.gradle
@@ -174,7 +174,6 @@ android {
             signingConfig signingConfigs.debug
         }
         release {
-            applicationIdSuffix ".release"
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- android のリリース用IDについている `.release` suffixが不要（不自然）なため除去

## ✅ What's done

- [x] suffixを除去してビルド。
- [x] ビルドしたapkファイルを配布してPush通知の動作確認

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし