### PR TITLE
🐛: 不要な判定を削除してアプリが処理できない場合はユーザーに通知する

### DIFF
--- a/santoku-app/src/app/components/parts/notification/DeviseTokenNotificationForm.tsx
+++ b/santoku-app/src/app/components/parts/notification/DeviseTokenNotificationForm.tsx
@@ -53,7 +53,7 @@ const DeviseTokenNotificationForm: React.FC<Props> = ({deviseToken}) => {
           placeholder="通知メッセージの本文を入力してください"
         />
         <FormInput
-          label="(任意) データとしてアプリが受け取る値 (文字列)"
+          label="データとしてアプリが受け取る値 (文字列)"
           value={text}
           onChangeText={(value) => setText(value)}
           placeholder="データを入力してください"

--- a/santoku-app/src/app/components/parts/notification/DeviseTokenNotificationForm.tsx
+++ b/santoku-app/src/app/components/parts/notification/DeviseTokenNotificationForm.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useState} from 'react';
 import {Description, Section, TextButton, Title} from '../../basics';
 import FormInput from './FormInput';
 import pushNotificationService from '../../../backend/notification/PushNotificationService';
+import {Alert} from 'react-native';
 
 type Props = {
   deviseToken?: string;
@@ -14,8 +15,14 @@ const DeviseTokenNotificationForm: React.FC<Props> = ({deviseToken}) => {
 
   const sendMessage = useCallback(
     (delay) => {
-      if (deviseToken && title && body && text) {
+      if (!deviseToken) {
+        Alert.alert('通知を許可してください');
+        return;
+      }
+      if (title && body && text) {
         pushNotificationService.sendMessage({token: deviseToken, notification: {title, body}, data: {text}, delay});
+      } else {
+        Alert.alert('タイトル、本文、データは必須です');
       }
     },
     [deviseToken, title, body, text],
@@ -49,7 +56,7 @@ const DeviseTokenNotificationForm: React.FC<Props> = ({deviseToken}) => {
           label="(任意) データとしてアプリが受け取る値 (文字列)"
           value={text}
           onChangeText={(value) => setText(value)}
-          placeholder="データのValueを入力してください"
+          placeholder="データを入力してください"
         />
         <TextButton
           onPress={() => {

--- a/santoku-app/src/app/components/parts/notification/TopicNotificationForm.tsx
+++ b/santoku-app/src/app/components/parts/notification/TopicNotificationForm.tsx
@@ -17,11 +17,17 @@ const TopicNotificationForm: React.FC<Props> = ({deviseToken}) => {
 
   const subscribeToTopic = useCallback(() => {
     setTopicNameError(undefined);
-    if (topicName && deviseToken) {
+    if (!deviseToken) {
+      Alert.alert('通知を許可してください');
+      return;
+    }
+    if (topicName) {
       pushNotificationService.subscribeToTopic(topicName, deviseToken).catch((e) => {
         setTopicNameError(`トピック ${topicName} の登録に失敗しました`);
         console.warn(`fail to subscribe topic [${topicName}]`, e);
       });
+    } else {
+      setTopicNameError('トピック名は必須です');
     }
   }, [topicName, deviseToken]);
 
@@ -34,7 +40,7 @@ const TopicNotificationForm: React.FC<Props> = ({deviseToken}) => {
   }, [topicName, deviseToken]);
 
   const sendTopic = useCallback(() => {
-    if (deviseToken && sendTopicName && topicTitle && topicText) {
+    if (sendTopicName && topicTitle && topicText) {
       pushNotificationService.sendTopic({
         topic: sendTopicName,
         notification: {title: topicTitle, body: topicText},
@@ -43,7 +49,7 @@ const TopicNotificationForm: React.FC<Props> = ({deviseToken}) => {
     } else {
       Alert.alert('トピック名、タイトル、本文は必須です');
     }
-  }, [deviseToken, sendTopicName, topicTitle, topicText]);
+  }, [sendTopicName, topicTitle, topicText]);
 
   return (
     <>


### PR DESCRIPTION
## ✅ What's done

- [x] sendTopicはToken不要なので `deviseToken` の判定処理を削除
- [x] `deviseToken` がない場合は通知を許可するように依頼するAlertを表示
- [x] 必須項目がない場合は黙って終わらず、Alertする


<!-- 該当するものがなければ、このセクション（この行から「---」の前の行まで）を削除してください。 -->
## ⏸ What's not done

- API呼び出し後の結果通知（onSendやonSentErrorなど）
- エラーハンドリング

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] Androidエミュレータで動作確認
- [x] iOSで実機確認

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [x] iOS
  - [x] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし