### PR TITLE
🌱: Use `expo-keep-awake` while running in development mode

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,7 @@
       packageNames: [
         '@react-native-community/masked-view',
         'expo',
+        'expo-keep-awake',
         'expo-splash-screen',
         'expo-updates',
         'react',

--- a/SantokuApp/package.json
+++ b/SantokuApp/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/native": "~5.9.0",
     "@react-navigation/stack": "~5.14.0",
     "expo": "~40.0.0",
+    "expo-keep-awake": "~8.4.0",
     "expo-splash-screen": "~0.8.1",
     "expo-updates": "~0.4.1",
     "react": "16.13.1",

--- a/SantokuApp/src/App.tsx
+++ b/SantokuApp/src/App.tsx
@@ -1,8 +1,14 @@
 import {NavigationContainer} from '@react-navigation/native';
+import {activateKeepAwake} from 'expo-keep-awake';
 import {RootStackNav} from 'navigation';
 import React from 'react';
 
 export const App = () => {
+  // 開発中は画面がスリープしないようにしておきます。
+  if (__DEV__) {
+    activateKeepAwake();
+  }
+
   return (
     <NavigationContainer>
       <RootStackNav />


### PR DESCRIPTION
## ✅ What's done

- [x] 開発中は、`expo-keep-awake`を利用して画面がスリープしないように設定
---

## Tests

- [x] `npm run ios`
- [x] `npm run android`

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

実機でテストしていると、不便だと感じるので、、、