### PR TITLE
⬆: Update Flipper to 0.84.0

### DIFF
--- a/SantokuApp/android/gradle.properties
+++ b/SantokuApp/android/gradle.properties
@@ -26,4 +26,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.74.0
+FLIPPER_VERSION=0.84.0

--- a/SantokuApp/ios/Podfile
+++ b/SantokuApp/ios/Podfile
@@ -19,7 +19,7 @@ target 'SantokuApp' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!({ 'Flipper' => '0.74.0' }, configurations: ['Debug', 'DebugAdvanced'])
+  use_flipper!({ 'Flipper' => '0.84.0' }, configurations: ['Debug', 'DebugAdvanced'])
   post_install do |installer|
     flipper_post_install(installer)
   end

--- a/SantokuApp/ios/Podfile.lock
+++ b/SantokuApp/ios/Podfile.lock
@@ -49,7 +49,7 @@ PODS:
     - React-Core (= 0.63.4)
     - React-jsi (= 0.63.4)
     - ReactCommon/turbomodule/core (= 0.63.4)
-  - Flipper (0.74.0):
+  - Flipper (0.84.0):
     - Flipper-Folly (~> 2.5)
     - Flipper-RSocket (~> 1.3)
   - Flipper-DoubleConversion (1.1.7)
@@ -63,36 +63,47 @@ PODS:
   - Flipper-PeerTalk (0.0.4)
   - Flipper-RSocket (1.3.1):
     - Flipper-Folly (~> 2.5)
-  - FlipperKit (0.74.0):
-    - FlipperKit/Core (= 0.74.0)
-  - FlipperKit/Core (0.74.0):
-    - Flipper (~> 0.74.0)
+  - FlipperKit (0.84.0):
+    - FlipperKit/Core (= 0.84.0)
+  - FlipperKit/Core (0.84.0):
+    - Flipper (~> 0.84.0)
     - FlipperKit/CppBridge
     - FlipperKit/FBCxxFollyDynamicConvert
     - FlipperKit/FBDefines
     - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.74.0):
-    - Flipper (~> 0.74.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.74.0):
+  - FlipperKit/CppBridge (0.84.0):
+    - Flipper (~> 0.84.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.84.0):
     - Flipper-Folly (~> 2.5)
-  - FlipperKit/FBDefines (0.74.0)
-  - FlipperKit/FKPortForwarding (0.74.0):
+  - FlipperKit/FBDefines (0.84.0)
+  - FlipperKit/FKPortForwarding (0.84.0):
     - CocoaAsyncSocket (~> 7.6)
     - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.74.0)
-  - FlipperKit/FlipperKitLayoutPlugin (0.74.0):
+  - FlipperKit/FlipperKitHighlightOverlay (0.84.0)
+  - FlipperKit/FlipperKitLayoutHelpers (0.84.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutTextSearchable
+  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.84.0):
+    - FlipperKit/Core
+    - FlipperKit/FlipperKitHighlightOverlay
+    - FlipperKit/FlipperKitLayoutHelpers
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.74.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.74.0):
+  - FlipperKit/FlipperKitLayoutPlugin (0.84.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.74.0):
+    - FlipperKit/FlipperKitHighlightOverlay
+    - FlipperKit/FlipperKitLayoutHelpers
+    - FlipperKit/FlipperKitLayoutIOSDescriptors
+    - FlipperKit/FlipperKitLayoutTextSearchable
+    - YogaKit (~> 1.18)
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.84.0)
+  - FlipperKit/FlipperKitNetworkPlugin (0.84.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.74.0):
+  - FlipperKit/FlipperKitReactPlugin (0.84.0):
     - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.74.0):
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.84.0):
+    - FlipperKit/Core
+  - FlipperKit/SKIOSNetworkPlugin (0.84.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - Folly (2020.01.13.00):
@@ -409,25 +420,25 @@ DEPENDENCIES:
   - EXUpdates (from `../node_modules/expo-updates/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
-  - Flipper (= 0.74.0)
+  - Flipper (= 0.84.0)
   - Flipper-DoubleConversion (= 1.1.7)
   - Flipper-Folly (~> 2.2)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
   - Flipper-RSocket (~> 1.1)
-  - FlipperKit (= 0.74.0)
-  - FlipperKit/Core (= 0.74.0)
-  - FlipperKit/CppBridge (= 0.74.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.74.0)
-  - FlipperKit/FBDefines (= 0.74.0)
-  - FlipperKit/FKPortForwarding (= 0.74.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.74.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.74.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.74.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.74.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.74.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.74.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.74.0)
+  - FlipperKit (= 0.84.0)
+  - FlipperKit/Core (= 0.84.0)
+  - FlipperKit/CppBridge (= 0.84.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (= 0.84.0)
+  - FlipperKit/FBDefines (= 0.84.0)
+  - FlipperKit/FKPortForwarding (= 0.84.0)
+  - FlipperKit/FlipperKitHighlightOverlay (= 0.84.0)
+  - FlipperKit/FlipperKitLayoutPlugin (= 0.84.0)
+  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.84.0)
+  - FlipperKit/FlipperKitNetworkPlugin (= 0.84.0)
+  - FlipperKit/FlipperKitReactPlugin (= 0.84.0)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.84.0)
+  - FlipperKit/SKIOSNetworkPlugin (= 0.84.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -625,13 +636,13 @@ SPEC CHECKSUMS:
   EXUpdates: 5124c03b19730078482a27b97fcb4718b06ca6b5
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
-  Flipper: c1ad50344bffdce628b1906b48f6e7cd06724236
+  Flipper: 1e9b42d953eb33b2367f372ae25e64f6b86f4361
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
-  FlipperKit: f42987ea58737ac0fb3fbc38f8e703452ba56940
+  FlipperKit: 3970c0e7566160eda3defc580980c55f4ad585e8
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
@@ -677,6 +688,6 @@ SPEC CHECKSUMS:
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 03cc962dc7bc743833274407e4532be1eede3376
+PODFILE CHECKSUM: 98f4069f9b2b801665597f223378edae2f73e478
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
## ✅ What's done

- [x] Flipperのバージョンを更新
---

## Tests

- [x] `npm run ios`
- [x] `npm run android`
- [x] Flipperで情報を見れることを確認

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

なし