### PR TITLE
⏪️: pull request target から pull request に変更

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     branches:
       - master
     paths:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
     paths:


### PR DESCRIPTION
## ✅ What's done

- [x] GitHub Actionsのトリガーを`pull_request`に変更
---

## Other (messages to reviewers, concerns, etc.)

GitHub Actionsのトリガーとして`pull_request_target`を利用していましたが、使い方が間違えていたようなのでいったんリバートします。
`triage.yaml`は、`pull_request_target`が適切だと思うのでそのままにしています。

参考: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

This reverts commit 3110f7b7