### PR TITLE
🔨: Fix reset-cache script to use bundle exec

### DIFF
--- a/SantokuApp/.script/jobs/reset-cache-macos.js
+++ b/SantokuApp/.script/jobs/reset-cache-macos.js
@@ -67,24 +67,8 @@ module.exports = [
     enabled: true,
     commands: [
       {
-        command: 'pod',
-        args: ['cache', 'clean', '--all'],
-        cwd: 'ios',
-      },
-    ],
-  },
-  {
-    name: 'Update CocoaPods dependency',
-    enabled: false,
-    commands: [
-      {
-        command: 'ls',
-        args: ['Pods'],
-        cwd: 'ios',
-      },
-      {
-        command: 'pod',
-        args: ['update'],
+        command: 'bundle',
+        args: ['exec', 'pod', 'cache', 'clean', '--all'],
         cwd: 'ios',
       },
     ],

--- a/SantokuApp/README.md
+++ b/SantokuApp/README.md
@@ -11,7 +11,8 @@
   - （macOSのみ）CocoaPodsのバージョンによっては、`pod install`でエラーとなる場合があります。CocoaPodsは[Bundler](https://bundler.io/)を利用して、次の方法でインストールしてください。
     - `bundle install`をSantokuAppのルートディレクトリで実行してください。
     - Bundler自体のインストールが必要な場合は、`gem install bundler`でインストールしてください。
-    - 以降の`Podfile.lock`の更新には、`npm run pod-install`を実行してください。
+    - `npm run pod-install`を実行して、Podsをインストールしてください。
+    - 以降、`Podfile.lock`が更新された場合も`npm run pod-install`を実行してください。
 
 ## アプリをビルドしてiOSデバイスにインストールする
 


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- `reset-cache:all`を実行しても`pod update`は実行されないようにしました

## ✅ What's done

- [x] `reset-cache`のタスク一覧から`pod update`を削除
- [x] `reset-cache`のCocoaPods系のタスクを実行するときに`bundle exec`を使うように修正
---

## Tests

- [x] Ruby 2.6で`git clean -fdX && bundle install && npm ci && npm run pod-install && npm run reset-cache:all`

## Other (messages to reviewers, concerns, etc.)

CocoaPodsをHomebrewでもインストールしている環境でテストできていないので、確認をお願いしたいです。