### PR TITLE
🖋: 学習コンテンツ後半の画面遷移関連を改善

### DIFF
--- a/docs/react-native/learn/todo-app/app-project-desc.md
+++ b/docs/react-native/learn/todo-app/app-project-desc.md
@@ -20,7 +20,6 @@ todo_app
    │  └─parts
    ├─contexts
    ├─navigation
-   │  └─hooks
    ├─screens
    └─services
 ```
@@ -31,6 +30,5 @@ todo_app
 - components/parts: アプリ機能に特化したコンポーネント
 - contexts: コンテクスト
 - navigation: ナビゲーション定義
-- navigation/hooks: ナビゲーションのカスタムフック
 - screens: 画面
 - services: 外部（APIや内部ストレージなど）と連携するサービスやビジネスロジック

--- a/docs/react-native/learn/todo-app/basic-components.mdx
+++ b/docs/react-native/learn/todo-app/basic-components.mdx
@@ -100,9 +100,9 @@ export * from './view';
 ```
 
 ```diff title="/src/screens/todo/TodoForm.tsx"
+  import {useNavigation} from '@react-navigation/native';
 + import {KeyboardView} from 'components/basics';
   import {useFormik} from 'formik';
-  import {useAuthedStackNavigation} from 'navigation/hooks';
   import React, {useCallback, useEffect} from 'react';
 - import {Alert, KeyboardAvoidingView, Platform, StyleSheet, View} from 'react-native';
 + import {Alert, StyleSheet, View} from 'react-native';

--- a/docs/react-native/learn/todo-app/logo.mdx
+++ b/docs/react-native/learn/todo-app/logo.mdx
@@ -78,14 +78,14 @@ export * from './Logo';
 - `/src/screens/home/Welcome.tsx`
 
 ```diff title="/src/screens/home/Welcome.tsx"
+  import {useNavigation} from '@react-navigation/native';
 + import {Logo} from 'components/basics';
-  import {useUnauthedStackNavigation} from 'navigation/hooks';
   import React from 'react';
   import {StyleSheet, View} from 'react-native';
   import {Button, Text} from 'react-native-elements';
   
   export const Welcome: React.FC = () => {
-    const navigation = useUnauthedStackNavigation<'Welcome'>();
+    const navigation = useNavigation();
     return (
       <View style={styles.container}>
 +       <Logo />

--- a/docs/react-native/learn/todo-app/modal.mdx
+++ b/docs/react-native/learn/todo-app/modal.mdx
@@ -11,7 +11,7 @@ React Navigation公式ドキュメントの[Opening a full-screen modal](https:/
 > The modal prop has no effect on Android because full-screen modals don't have any different transition behavior on the platform.
 
 画面遷移アニメーションは、各プラットフォームのネイティブ動作に従います。
-上記とおり、Androidのフルスクリーンモーダルには異なるトランジションが用意されていないため、`mode`属性の変更によるアニメーションの変更はありません。
+上記のとおり、Androidのフルスクリーンモーダルには異なるトランジションが用意されていないため、`mode`属性の変更によるアニメーションの変更はありません。
 :::
 
 では実装していきましょう。
@@ -21,51 +21,98 @@ React Navigation公式ドキュメントの[Opening a full-screen modal](https:/
 - ヘッダの右にクローズボタンを追加
 - ヘッダの背景を非表示（`headerTransparent`を`true`に設定）
 
-修正量が多いので、次のソースコードで`AuthedStackNav.tsx`を上書きしてください。
+まずは、`AuthedStackNav`ナビゲータの`mode`属性を`modal`に変更します。
 
-```typescript jsx title="/src/navigation/AuthedStackNav.tsx"
-import {Ionicons} from '@expo/vector-icons';
-import {createStackNavigator} from '@react-navigation/stack';
-import {MainTabNav} from 'navigation/MainTabNav';
-import {AuthedStackParamList} from 'navigation/types';
-import React, {useCallback, useContext} from 'react';
-import {Button, ThemeContext} from 'react-native-elements';
-import {TodoForm} from 'screens';
+```diff title="/src/navigation/AuthedStackNav.tsx"
+  import {createStackNavigator} from '@react-navigation/stack';
+  import React from 'react';
+  import {MainTabNav} from 'navigation/MainTabNav';
+  import {TodoForm} from 'screens';
+  
+  const nav = createStackNavigator();
+  export const AuthedStackNav: React.FC = () => {
+    return (
+-     <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main">
++     <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
+        <nav.Screen name="Main" component={MainTabNav} />
+        <nav.Screen
+          name="TodoForm"
+          component={TodoForm}
+          options={{
+            headerShown: true,
+          }}
+        />
+      </nav.Navigator>
+    );
+  };
+```
 
-import {useAuthedStackNavigation} from './hooks';
+次に、ヘッダの右にクローズボタンを追加します。
 
-const CloseButton: React.FC = () => {
-  const {theme} = useContext(ThemeContext);
-  const navigation = useAuthedStackNavigation<'TodoForm'>();
-  const onClose = useCallback(() => navigation.goBack(), [navigation]);
+```diff title="/src/navigation/AuthedStackNav.tsx"
++ import {Ionicons} from '@expo/vector-icons';
+  import {createStackNavigator} from '@react-navigation/stack';
+- import React from 'react';
++ import React, {useCallback, useContext} from 'react';
++ import {Button, ThemeContext} from 'react-native-elements';
+  import {MainTabNav} from 'navigation/MainTabNav';
+  import {TodoForm} from 'screens';
+  
++ const CloseButton: React.FC = () => {
++   const {theme} = useContext(ThemeContext);
++   const navigation = useNavigation();
++   const onClose = useCallback(() => navigation.goBack(), [navigation]);
++ 
++   return (
++     <Button
++       type="clear"
++       icon={<Ionicons name="md-close" color={theme.colors?.primary} size={30} />}
++       onPress={onClose}
++     />
++   );
++ };
++ 
+  const nav = createStackNavigator();
+  export const AuthedStackNav: React.FC = () => {
+    return (
+      <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
+        <nav.Screen name="Main" component={MainTabNav} />
+        <nav.Screen
+          name="TodoForm"
+          component={TodoForm}
+          options={{
+            headerShown: true,
++           headerLeft: () => undefined,
++           headerRight: () => <CloseButton />,
+          }}
+        />
+      </nav.Navigator>
+    );
+  };
+```
 
-  return (
-    <Button
-      type="clear"
-      icon={<Ionicons name="md-close" color={theme.colors?.primary} size={30} />}
-      onPress={onClose}
-    />
-  );
-};
+最後に、ヘッダの背景を透明にします。
 
-const nav = createStackNavigator<AuthedStackParamList>();
-export const AuthedStackNav: React.FC = () => {
-  return (
-    <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
-      <nav.Screen name="Main" component={MainTabNav} />
-      <nav.Screen
-        name="TodoForm"
-        component={TodoForm}
-        options={{
-          headerShown: true,
-          headerLeft: () => undefined,
-          headerRight: () => <CloseButton />,
-          headerTransparent: true,
-        }}
-      />
-    </nav.Navigator>
-  );
-};
+```diff title="/src/navigation/AuthedStackNav.tsx"
+  /* ～省略～ */  
+  
+  export const AuthedStackNav: React.FC = () => {
+    return (
+      <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
+        <nav.Screen name="Main" component={MainTabNav} />
+        <nav.Screen
+          name="TodoForm"
+          component={TodoForm}
+          options={{
+            headerShown: true,
+            headerLeft: () => undefined,
+            headerRight: () => <CloseButton />,
++           headerTransparent: true,
+          }}
+        />
+      </nav.Navigator>
+    );
+  };
 ```
 
 修正できたら実行してください。

--- a/docs/react-native/learn/todo-app/todo-form.mdx
+++ b/docs/react-native/learn/todo-app/todo-form.mdx
@@ -47,37 +47,21 @@ const styles = StyleSheet.create({
 ```
 
 つぎに、`AuthedStackNav`ナビゲータに`TodoForm`という名前でタスク登録画面（`TodoForm`）を追加します。
-次のファイルを追加・修正してください。
+次のファイルを修正してください。
 
-- `/src/navigation/types.ts`
 - `/src/navigation/AuthedStackNav.tsx`
-
-```diff title="/src/navigation/types.ts"
-  export type UnauthedStackParamList = {
-    Welcome: undefined;
-    Login: undefined;
-    Instructions: undefined;
-  };
-  
-  export type AuthedStackParamList = {
-    Main: undefined;
-+   TodoForm: undefined;
-  };
-  /* ～省略～ */  
-```
 
 ```diff title="/src/navigation/AuthedStackNav.tsx"
   import {createStackNavigator} from '@react-navigation/stack';
-  import {MainTabNav} from 'navigation/MainTabNav';
   import React from 'react';
+  import {MainTabNav} from 'navigation/MainTabNav';
 + import {TodoForm} from 'screens';
   
-  import {AuthedStackParamList} from './types';
-  
-  const nav = createStackNavigator<AuthedStackParamList>();
+  const nav = createStackNavigator();
   export const AuthedStackNav: React.FC = () => {
     return (
-      <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main">
+-     <nav.Navigator screenOptions={{headerShown: false}}>
++     <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main">
         <nav.Screen name="Main" component={MainTabNav} />
 +       <nav.Screen
 +         name="TodoForm"
@@ -94,23 +78,23 @@ const styles = StyleSheet.create({
 タスク一覧画面からの画面遷移を追加します。`/src/screens/todo/TodoBoard.tsx`を修正してください。
 
 ```diff title="/src/screens/todo/TodoBoard.tsx"
++ import {useNavigation} from '@react-navigation/native';
   import {FilterType, TodoFilter, TodoList} from 'components/parts';
-+ import {useTodoStackNavigation} from 'navigation/hooks';
   import React, {useContext, useEffect, useState} from 'react';
   import {Alert, StyleSheet, View} from 'react-native';
   import {Icon, ThemeContext} from 'react-native-elements';
   import {Todo, TodoService} from 'services';
-
+  
   /* ～省略～ */  
-
+  
   export const TodoBoard: React.FC = () => {
     const {theme} = useContext(ThemeContext);
-+   const navigation = useTodoStackNavigation<'TodoBoard'>();
++   const navigation = useNavigation();
     const [todos, setTodos] = useState<Todo[]>([]);
     const [filterType, setFilterType] = useState<FilterType>(FilterType.ALL);
-
+  
   /* ～省略～ */  
-
+  
         <Icon
           name="plus"
           type="font-awesome-5"
@@ -135,8 +119,8 @@ const styles = StyleSheet.create({
 修正量が多いので、次のソースコードで`TodoForm.tsx`を上書きしてください。
 
 ```typescript jsx title="/src/screens/todo/TodoForm.tsx"
+import {useNavigation} from '@react-navigation/native';
 import {useFormik} from 'formik';
-import {useAuthedStackNavigation} from 'navigation/hooks';
 import React, {useCallback, useEffect} from 'react';
 import {Alert, KeyboardAvoidingView, Platform, StyleSheet, View} from 'react-native';
 import {Button, Input, Text} from 'react-native-elements';
@@ -144,7 +128,7 @@ import {TodoService} from 'services';
 import * as Yup from 'yup';
 
 export const TodoForm: React.FC = () => {
-  const navigation = useAuthedStackNavigation<'TodoForm'>();
+  const navigation = useNavigation();
 
   const onAdd = useCallback<(values: {task: string}) => void>(
     async ({task}) => {

--- a/docs/react-native/learn/todo-app/use-focus-effect.mdx
+++ b/docs/react-native/learn/todo-app/use-focus-effect.mdx
@@ -43,7 +43,8 @@ title: useFocusEffect
 `/src/screens/todo/TodoBoard.tsx`を修正してください。
 
 ```diff title="/src/screens/todo/TodoBoard.tsx"
-+ import {useFocusEffect} from '@react-navigation/native';
+- import {useNavigation} from '@react-navigation/native';
++ import {useNavigation, useFocusEffect} from '@react-navigation/native';
   import {FilterType, TodoFilter, TodoList} from 'components/parts';
 - import React, {useContext, useEffect, useState} from 'react';
 + import React, {useCallback, useContext, useState} from 'react';
@@ -55,7 +56,7 @@ title: useFocusEffect
   
   export const TodoBoard: React.FC = () => {
     const {theme} = useContext(ThemeContext);
-    const navigation = useTodoStackNavigation<'TodoBoard'>();
+    const navigation = useNavigation();
     const [todos, setTodos] = useState<Todo[]>([]);
     const [filterType, setFilterType] = useState<FilterType>(FilterType.ALL);
   


### PR DESCRIPTION
## ✅ What's done

- [x] #193 の続き「認証制御」以降のページから型定義を使用した画面遷移を削除
- [x] Modalスクリーンの実装をステップ分けてわかりやすく
- [x] srcディレクトリ構成の説明から `navigation/hooks` を削除