### PR TITLE
💄: Fix lint errors (ja-technical-writing/max-comma)

### DIFF
--- a/docs/distribution/usecase/index.mdx
+++ b/docs/distribution/usecase/index.mdx
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 開発中にデバイスで動作確認したいときのアプリのインストール方法を紹介します。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="developerIOS"
@@ -22,7 +22,7 @@ import TabItem from '@theme/TabItem';
     {label: 'Android', value: 'developerAndroid'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="developerIOS">
 
@@ -50,10 +50,10 @@ AndroidはiOSのようにAppの高度な機能を考慮する必要はありま�
 
 ## お客様にデモを見せたい
 
-開発チームが開発用端末を操作してお客様にデモを見せたい​​​​​​​ケースでは
+開発チームが開発用端末を操作してお客様にデモを見せたいケースでは
 デモの前にあらかじめ、開発用デバイスにアプリをインストールしてください。 開発中にデバイスで動作確認する場合と同様です。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="demoIOS"
@@ -62,7 +62,7 @@ AndroidはiOSのようにAppの高度な機能を考慮する必要はありま�
     {label: 'Android', value: 'demoAndroid'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="demoIOS">
 
@@ -85,7 +85,7 @@ iOSの場合はAppの高度な機能を含むか否かによって配布方法�
 
 ## 社内や業務委託先でテストをしたい
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="devTestIOS"
@@ -94,7 +94,7 @@ iOSの場合はAppの高度な機能を含むか否かによって配布方法�
     {label: 'Android', value: 'devTestAndroid'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="devTestIOS">
 
@@ -125,7 +125,7 @@ APKファイルを自前で配布するか、内部テストまたはクロー�
 
 ## お客様や関係者に実機でテストをしてもらいたい
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="clientTestIOS"
@@ -134,7 +134,7 @@ APKファイルを自前で配布するか、内部テストまたはクロー�
     {label: 'Android', value: 'clientTestAndroid'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="clientTestIOS">
 
@@ -160,7 +160,7 @@ TestFlight(外部テスター)の場合、テスターであるお客様をApp S
 
 ## フィールドテストをしたい・ベータリリースしたい
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="betaReleaseIOS"
@@ -169,7 +169,7 @@ TestFlight(外部テスター)の場合、テスターであるお客様をApp S
     {label: 'Android', value: 'betaReleaseAndroid'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="betaReleaseIOS">
 

--- a/docs/docusaurus/index.mdx
+++ b/docs/docusaurus/index.mdx
@@ -6,7 +6,7 @@ slug: /docusaurus
 
 Docusaurusでのドキュメントの書き方についてのページです。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 import {PageList} from '../../src/components';
 const overviews = [
@@ -24,4 +24,4 @@ const overviews = [
 
 <PageList overviews={overviews} colSize={12} />
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->

--- a/docs/react-native/learn/advance/react-navigation-param.mdx
+++ b/docs/react-native/learn/advance/react-navigation-param.mdx
@@ -86,7 +86,7 @@ React Navigationでは、型定義を積極的に利用することでより詳�
 こういった理由から、React Navigationのための型定義は、定義しないとエラーになるなどの必要最低限のものだけを紹介しています。
 
 :::
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -95,7 +95,7 @@ React Navigationでは、型定義を積極的に利用することでより詳�
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts.mdx
+++ b/docs/react-native/learn/basic-concepts.mdx
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 
 アプリを実装する前に必要となる前提知識を確認した後、React Nativeの基本、React Navigationの基本について学びます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 import {PageList} from '../../../src/components';
 const overviews = [
@@ -29,4 +29,4 @@ const overviews = [
 
 <PageList overviews={overviews} colSize={12} />
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components.mdx
@@ -10,7 +10,7 @@ sidebar_label: Overview
 
 ## コアコンポーネント
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 import {PageList} from '../../../../../src/components';
 const overviews = [
@@ -46,7 +46,7 @@ const overviews = [
 
 <PageList overviews={overviews} colSize={12}/>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 ## [React Native Elements](https://reactnativeelements.com/)
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/button.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/button.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 各ネイティブプラットフォームの標準スタイルを使用したボタンを表示する場合、このコンポーネントを使用します。
 色以外のスタイルがカスタマイズ出来ないため、デザインがアプリに適していない場合、代わりに[Touchables](https://reactnative.dev/docs/handling-touches#touchables)や[Pressable](https://reactnative.dev/docs/pressable)を使用して独自のコンポーネントを作成します。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/image.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/image.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 下の例では、ネットワークからの画像を表示しています。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -23,7 +23,7 @@ import TabItem from '@theme/TabItem';
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/lists.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/lists.mdx
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
 大量のデータを画面に表示する場合、`FlatList`または`SectionList`の使用が推奨されます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 import {PageList} from '../../../../../../src/components';
 const overviews = [
@@ -25,4 +25,4 @@ const overviews = [
 
 <PageList overviews={overviews} colSize={12}/>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/lists/flat-list.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/lists/flat-list.mdx
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 変更された行を特定するために、データは一意のID値をもつ必要があります。
 `item.key`がデフォルトのIDとして用いられますが、`keyExtractor`に関数を渡すことで別のID値を指定できます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -24,7 +24,7 @@ import TabItem from '@theme/TabItem';
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/lists/section-list.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/lists/section-list.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 `props`に指定した`renderSectionHeader`および`renderItem`を用いて、`sections`に渡された項目を描画します。
 `sections`の各項目は配列型のオブジェクトである`data`をもつ必要があります。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -19,7 +19,7 @@ import TabItem from '@theme/TabItem';
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/scroll-view.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/scroll-view.mdx
@@ -13,7 +13,7 @@ ScrollViewはすべての子コンポーネントを一度にレンダリング�
 そのため、アイテムが大量にある場合はパフォーマンス上の欠点があります。
 このような場合では、FlatListの使用を検討してください。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -22,7 +22,7 @@ ScrollViewはすべての子コンポーネントを一度にレンダリング�
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/text.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/text.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 テキストを表示するためのReactコンポーネントです。
 Webと異なり、テキストは`<Text>`コンポーネントでのラップが必要です。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -17,7 +17,7 @@ Webと異なり、テキストは`<Text>`コンポーネントでのラップが
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/touchable-opacity.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/touchable-opacity.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 React Nativeアプリでは、一般的にボタンとして使用されます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -20,7 +20,7 @@ React Nativeアプリでは、一般的にボタンとして使用されます�
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/components/view.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/components/view.mdx
@@ -13,7 +13,7 @@ React Nativeにおける最も基本的なコンポーネントです。
 - Android - `android.view`
 - Web - `<div>`
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -22,7 +22,7 @@ React Nativeにおける最も基本的なコンポーネントです。
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/design.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/design.mdx
@@ -9,7 +9,7 @@ React Nativeでは、JavaScriptを使用してアプリケーションのスタ�
 スタイル名とその設定値は、キャメルケースを使用しているという点を除き、WebのCSSのそれと通常は一致します。
 例えば、`background-color`は`backgroundColor`となります。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 import {PageList} from '../../../../../src/components';
 const overviews = [
@@ -29,4 +29,4 @@ const overviews = [
 
 <PageList overviews={overviews} colSize={12}/>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->

--- a/docs/react-native/learn/basic-concepts/react-native-basics/design/flexbox.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/design/flexbox.mdx
@@ -11,7 +11,7 @@ Flexboxのアルゴリズムを利用することで、多様なサイズの画�
 
 > 内部的には[Yoga](https://yogalayout.com/)ライブラリを用いてFlexboxが実装されています。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -20,7 +20,7 @@ Flexboxのアルゴリズムを利用することで、多様なサイズの画�
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/design/height-and-width.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/design/height-and-width.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 一般的な方法は、`width`と`height`に固定値を指定することです。
 React Nativeでは単位の指定がなく、すべて（密度に依存しない）ピクセルとなります。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -18,7 +18,7 @@ React Nativeでは単位の指定がなく、すべて（密度に依存しな�
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-native-basics/design/style.mdx
+++ b/docs/react-native/learn/basic-concepts/react-native-basics/design/style.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 `style` propに直接JavaScriptのオブジェクトを設定することも出来ますが、`StyleSheet.create`を用いて一か所でスタイル定義する方が複雑さに対応できます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -19,7 +19,7 @@ import TabItem from '@theme/TabItem';
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-navigation-basics.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics.mdx
@@ -69,7 +69,7 @@ export const App = () => {
 };
 ```
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -78,7 +78,7 @@ export const App = () => {
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-navigation-basics/modal.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics/modal.mdx
@@ -57,7 +57,7 @@ const Main = () => {
 - ナビゲーション操作は現在のナビゲータによって処理され、処理できなかった場合は上位のナビゲータに処理を移譲する
 - 親ナビゲータのUIは、子ナビゲータの上に描画される
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -66,7 +66,7 @@ const Main = () => {
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
@@ -21,7 +21,7 @@ Stackの操作として次のAPIが用意されています。
 
 ![Stack operations](stack_image.png)
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -30,7 +30,7 @@ Stackの操作として次のAPIが用意されています。
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/basic-concepts/react-navigation-basics/tab.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics/tab.mdx
@@ -43,7 +43,7 @@ React Navigationでは、次のAPIを使用してタブナビゲーションを�
 
 ![Tab navigator](tab_image.png)
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="image"
@@ -52,7 +52,7 @@ React Navigationでは、次のAPIを使用してタブナビゲーションを�
     {label: 'ソースコード', value: 'source'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="image">
 

--- a/docs/react-native/learn/getting-started.mdx
+++ b/docs/react-native/learn/getting-started.mdx
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 
 React Nativeでのアプリ開発に必要な環境を用意し、アプリを起動できることを確認します。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 import {PageList} from '../../../src/components';
 const overviews = [
@@ -29,4 +29,4 @@ const overviews = [
 
 <PageList overviews={overviews} colSize={12}/>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->

--- a/docs/react-native/learn/getting-started/launch-created-app.mdx
+++ b/docs/react-native/learn/getting-started/launch-created-app.mdx
@@ -13,7 +13,7 @@ iOSアプリはiPhoneシミュレータ、AndroidアプリはAndroidエミュレ
 
 うまく起動できない場合は、[トラブルシュート](../../troubleshooting.md)を参照してください。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="expo"
@@ -23,7 +23,7 @@ iOSアプリはiPhoneシミュレータ、AndroidアプリはAndroidエミュレ
     {label: 'Androidエミュレータ', value: 'android'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="expo">
 
@@ -81,7 +81,7 @@ Expo DevTools is running at http://localhost:19003
 
 React Nativeアプリ実行の仕組みをかんたんに説明します。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="rn-build"
@@ -90,7 +90,7 @@ React Nativeアプリ実行の仕組みをかんたんに説明します。
     {label: 'Expo + React Native', value: 'expo-build'},
   ]}>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="rn-build">
 

--- a/docs/react-native/learn/getting-started/setting-up-development-environment.mdx
+++ b/docs/react-native/learn/getting-started/setting-up-development-environment.mdx
@@ -108,7 +108,7 @@ Android SDK Platform-Toolsがインストールされていない場合はイン
 
 つづいて環境変数の`PATH`に以下のパスが含まれていることを確認してください。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   groupId="operating-systems"
@@ -119,7 +119,7 @@ Android SDK Platform-Toolsがインストールされていない場合はイン
   ]
 }>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="mac">
 
@@ -161,7 +161,7 @@ proxy環境下で開発環境を構築する場合、追加の設定が必要で
 
   環境構築および、実行時等に使用する一部ツール（npmやCocoaPods等）のproxy設定です。次のコマンドで環境変数を設定してください。
 
-  <!-- textlint-disable ja-technical-writing/sentence-length -->
+  <!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
   <Tabs
     groupId="operating-systems"
@@ -172,7 +172,7 @@ proxy環境下で開発環境を構築する場合、追加の設定が必要で
     ]
   }>
 
-  <!-- textlint-enable ja-technical-writing/sentence-length -->
+  <!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
   <TabItem value="mac">
 
@@ -214,7 +214,7 @@ proxy環境下で開発環境を構築する場合、追加の設定が必要で
 
   - 設定先
 
-    <!-- textlint-disable ja-technical-writing/sentence-length -->
+    <!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
       <Tabs
         groupId="operating-systems"
@@ -225,7 +225,7 @@ proxy環境下で開発環境を構築する場合、追加の設定が必要で
         ]
       }>
 
-    <!-- textlint-enable ja-technical-writing/sentence-length -->
+    <!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
       <TabItem value="mac">
 

--- a/docs/react-native/santoku/development/build-variants.mdx
+++ b/docs/react-native/santoku/development/build-variants.mdx
@@ -35,7 +35,7 @@ jp.fintan.mobile.SantokuApp<flavorSuffix><typeSuffix>
 
 このアプリでは、4つのビルドタイプを用意しています。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   groupId="build-type"
@@ -48,7 +48,7 @@ jp.fintan.mobile.SantokuApp<flavorSuffix><typeSuffix>
   ]
 }>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="debug">
 
@@ -111,7 +111,7 @@ Android向けのビルドには、Google Playのアップロード鍵を保存�
 
 このアプリでは、2つのプロダクトフレーバーを用意しています。プロダクトフレーバー名はXcode Organizerでアプリを選択するときのアプリ名としても表示されるので、プロダクトフレーバー名にアプリ名も含めるようにしています。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   groupId="product-flavor"
@@ -122,7 +122,7 @@ Android向けのビルドには、Google Playのアップロード鍵を保存�
   ]
 }>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="development">
 
@@ -147,7 +147,7 @@ Android向けのビルドには、Google Playのアップロード鍵を保存�
 `npm run android`や`npm run ios`のみで実行した場合は、ビルドタイプ`Debug`、プロダクトフレーバー`Development`でビルドされて実行されます。
 :::
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   groupId="operating-systems"
@@ -158,7 +158,7 @@ Android向けのビルドには、Google Playのアップロード鍵を保存�
   ]
 }>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="android">
 

--- a/docs/react-native/troubleshooting/unable-to-load-script.mdx
+++ b/docs/react-native/troubleshooting/unable-to-load-script.mdx
@@ -27,7 +27,7 @@ Metro Bundlerにアクセスできない場合は、`8081`ポートを利用し�
 
 `8081`ポートを利用しているプロセスは、次のコマンドで確認できます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   groupId="operating-systems"
@@ -38,7 +38,7 @@ Metro Bundlerにアクセスできない場合は、`8081`ポートを利用し�
   ]
 }>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="mac">
 
@@ -62,7 +62,7 @@ netstat -nao | find "8081"
 
 Metro Bundlerのポートは、次の方法で変更できます。
 
-<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- textlint-disable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <Tabs
   defaultValue="android"
@@ -72,7 +72,7 @@ Metro Bundlerのポートは、次の方法で変更できます。
   ]
 }>
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
+<!-- textlint-enable ja-technical-writing/sentence-length,ja-technical-writing/max-comma -->
 
 <TabItem value="android">
 


### PR DESCRIPTION
## ✅ What's done

- [x] `textlint-rule-preset-ja-technical-writing`の更新によってLintエラーとなった箇所を修正
- [x] ゼロ幅スペースを見つけたので除去
---

## Other (messages to reviewers, concerns, etc.)

#159 で`textlint-rule-preset-ja-technical-writing`が6系に更新された際に、[カンマは1文中に3つまで](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing#%E3%82%AB%E3%83%B3%E3%83%9E%E3%81%AF1%E6%96%87%E4%B8%AD%E3%81%AB3%E3%81%A4%E3%81%BE%E3%81%A7)のルールで一文ずつに分割する規則が変更されたためLintエラーになったようです。

以前 #159 のブランチで修正していたのですが、RenovateにPRを再作成してもらった後の再反映が漏れていました🙇‍♂️ 

#159 の差分には含まれない箇所でのエラーだったのでGitHub Actionsでは検知できませんでした。

#159 のGitHub Actions: https://github.com/ws-4020/mobile-app-crib-notes/runs/2551083985
検知したGitHub Actions（master）: https://github.com/ws-4020/mobile-app-crib-notes/runs/2551641061