### PR TITLE
🐛: Fix renovate packageRules of Docusaurus

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,11 +57,16 @@
     {
       // Docusaurusの関連パッケージはまとめて更新するようにします
       groupName: 'Docusaurus',
+      matchPackagePrefixes: ['@docusaurus'],
+      allowedVersions: "/^[0-9]+\\\\.[0-9]+\\\\.[0-9]+(-[\\w]+(\\\\.[0-9]{1,5})?)?$/"
+    },
+    {
+      // Docusaurusの依存パッケージは手動で更新する必要があるのでRenovateの対象外とします
+      groupName: 'Docusaurus dependencies',
+      enabled: false,
       // SantokuAppのReactなどのパッケージとまとめられないように、ルートディレクトリのpackage.jsonだけを対象にしています
       matchFiles: ['package.json'],
       matchPackageNames: ['@mdx-js/react', 'clsx', 'react', 'react-dom', '@tsconfig/docusaurus'],
-      matchPackagePrefixes: ['@docusaurus'],
-      allowedVersions: "/^[0-9]+\\\\.[0-9]+\\\\.[0-9]+(-[\\w]+(\\\\.[0-9]{1,5})?)?$/"
     },
     {
       // ツール系のパッケージはまとめて更新するようにします

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,7 +58,7 @@
       // Docusaurusの関連パッケージはまとめて更新するようにします
       groupName: 'Docusaurus',
       matchPackagePrefixes: ['@docusaurus'],
-      allowedVersions: "/^[0-9]+\\\\.[0-9]+\\\\.[0-9]+(-[\\w]+(\\\\.[0-9]{1,5})?)?$/"
+      allowedVersions: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-[\\w]+(\\.[0-9]{1,5})?)?$/"
     },
     {
       // Docusaurusの依存パッケージは手動で更新する必要があるのでRenovateの対象外とします


### PR DESCRIPTION
## ✅ What's done

- [x] Docusaurus用のpackageRulesが誤っていて、おそらく何もマッチしない状態になっていたため修正
- [x] Docusaurusのバージョンに合わせて更新するパッケージは自動更新の対象外に修正
---

## Other (messages to reviewers, concerns, etc.)

これでDocusaurusを2.0.0-alpha.75に更新するPRが作成されれば成功ですが、テストの仕方がわからない。。。