### PR TITLE
✨: docusaurusで書くmarkdownにグローバル変数を適用できるように修正

### DIFF
--- a/docs/react-native/learn/getting-started/create-project.md
+++ b/docs/react-native/learn/getting-started/create-project.md
@@ -20,7 +20,7 @@ RN Spoilerは、Expoの[expo-template-bare-typescript](https://github.com/expo/e
 [npm](https://www.npmjs.com/)ではなく[Yarn](https://yarnpkg.com/)を利用したい場合は、`--npm`というオプションを削除してください。Yarnがインストールされている場合は、Yarnを利用してパッケージがインストールされます。
 
 ```bash
-npx react-native init --template https://github.com/ws-4020/rn-spoiler#2021.05.0 <YourAppName>
+npx react-native init --template https://github.com/ws-4020/rn-spoiler#{@inject: rn_spoiler_ver} <YourAppName>
 ```
 
 :::

--- a/package-lock.json
+++ b/package-lock.json
@@ -11761,6 +11761,11 @@
         "mdast-util-to-markdown": "^0.6.0"
       }
     },
+    "remarkable-embed": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/remarkable-embed/-/remarkable-embed-0.4.1.tgz",
+      "integrity": "sha1-RH0+6M1Rrb4WiD558EXWfgTkfEs="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "medium-zoom": "^1.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "remarkable-embed": "^0.4.1",
     "url-loader": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## ✅ What's done

- [ ] `{@inject: $key}`でmarkdownを書き換えるプラグインを追加
- [ ] 破壊的なことがないか確認

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [ ] rn-spoilerのタグを修正して向き先が変わること

## Other (messages to reviewers, concerns, etc.)

https://github.com/facebook/docusaurus/issues/395 を参照したけど、他の方法でもっといいのあるかもしれないけど、Syntaxがわかりやすいかなーと思って採用してみた