### PR TITLE
🖋: StackナビゲーションページでToDo一覧画面のヘッダーにログインボタンが表示されていたので表示しないように修正

### DIFF
--- a/docs/react-native/learn/todo-app/screens/stack.mdx
+++ b/docs/react-native/learn/todo-app/screens/stack.mdx
@@ -200,11 +200,19 @@ Stackナビゲーションではオプションを指定することでヘッダ
 +           headerRight: undefined,
           }}
         />
+        <nav.Screen
+          name="TodoBoard"
+          component={TodoBoard}
+          options={{
+            headerTitle: 'Todo',
++           headerRight: undefined,
+          }}
+        />
   /* ～省略～ */
 ```
 
 共通定義は`Navigator`の`screenOptions`に、画面ごとの定義は`Screen`の`options`に定義します。
-今回はログインボタンを共通定義として、ログイン画面のみ表示しないよう設定しました。
+今回はログインボタンを共通定義として、ログイン画面とToDo一覧画面にログインボタンを表示しないよう設定しました。
 
 :::info
 Stackナビゲータに指定できるオプションの種類については[公式ドキュメントのAPI定義](https://reactnavigation.org/docs/stack-navigator#options)を参照してください。


### PR DESCRIPTION
## ✅ What's done

- [x] ToDo一覧画面のヘッダーにログインボタンが表示されていたので表示しないようにソースコードを修正
- [x] ログイン画面だけでなく、ToDo一覧画面もヘッダーのログインボタンを表示しない旨の文言に修正

---

## Tests

- [x] npm run lint:text
- [x] npm run lint:md
- [x] ToDo一覧画面のヘッダーにログインボタンが表示されないこと

## Devices

- [x] 動作確認に利用したデバイスにチェックをつけてください
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし