### PR TITLE
🐛: REST API呼びだしの中で表記が間違っているものなどを修正

### DIFF
--- a/docs/react-native/learn/todo-app/networking/api-request.mdx
+++ b/docs/react-native/learn/todo-app/networking/api-request.mdx
@@ -10,7 +10,7 @@ ToDoアプリからREST APIを呼び出して、サーバから取得したデ�
 
 共通的な設定をしている`config`と自動生成された`TodosApi`を`backend`からimportします。
 
-```typescript title="src/services/TodoService.ts"
+```typescript title="/src/services/TodoService.ts"
 import {TodosApi, config} from 'backend';
 ```
 
@@ -43,7 +43,7 @@ const putTodo = async (id: number, completed: boolean) => {
 画面の実装の演習問題で[ToDoの削除](../screens/exercise.mdx#ToDoの削除)を実装している場合は削除メソッドもAPIクライアントを呼びだすように修正してください。
 :::
 
-```typescript title="src/services/TodoService.ts"
+```typescript title="/src/services/TodoService.ts"
 import {TodosApi, config} from 'backend';
 
 const todosApi = new TodosApi(config);
@@ -59,7 +59,7 @@ const postTodo = async (text: string) => {
 };
 
 const putTodo = async (id: number, completed: boolean) => {
-  return await todosApi.putTodo({todoId: id, toDoStatus: {completed}});
+  return await todosApi.putTodo({todoId: id, todoStatus: {completed}});
 };
 
 export const TodoService = {

--- a/docs/react-native/learn/todo-app/networking/generate-api-client.mdx
+++ b/docs/react-native/learn/todo-app/networking/generate-api-client.mdx
@@ -64,7 +64,7 @@ npm install -D @openapitools/openapi-generator-cli
 ## APIクライアントの簡単な説明
 
 それでは、自動生成されたAPIクライアントを簡単に見ていきましょう。
-APIクライアントは`src/backend/generated-rest-client` に作成されています。
+APIクライアントは`/src/backend/generated-rest-client` に作成されています。
 
 ```console
 todo_app
@@ -80,7 +80,7 @@ APIクライアントを利用するとエラーレスポンス（ステータ�
 
 `runtime.ts`では、すべてのREST APIの呼びだしに共通する機能が実装されています。この中でREST APIへの接続先も定義されているのですが、OpenAPIドキュメントの`server`に指定されている値がデフォルト値として設定されています。
 
-```typescript title="src/backend/generated-rest-client/runtime.ts"
+```typescript title="/src/backend/generated-rest-client/runtime.ts"
 export const BASE_PATH = "http://localhost:9080/api".replace(/\/+$/, "");
 ```
 
@@ -93,12 +93,12 @@ export const BASE_PATH = "http://localhost:9080/api".replace(/\/+$/, "");
 
 `${端末のIP}`には[APIサーバへの接続確認](./setting-up-local-server.mdx#apiサーバへの接続確認)で確認したIPを設定してください。
 
-```typescript title="src/backend/config.ts"
+```typescript title="/src/backend/config.ts"
 import {Configuration} from './generated-rest-client';
 export const config = new Configuration({basePath: 'http://${端末のIP}:9080/api'});
 ```
 
-```typescript title="src/backend/index.ts"
+```typescript title="/src/backend/index.ts"
 export * from './generated-rest-client';
 export * from './config';
 ```


### PR DESCRIPTION
## ✅ What's done

- [x] `src/` -> `/src/`
- [x]  自動生成と一致しないので `toDo` -> `todo`

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

なし