### PR TITLE
📝: 別件の対応時に追加した行を消すDiffがもれているので対応

### DIFF
--- a/docs/react-native/learn/todo-app/screens/auth.mdx
+++ b/docs/react-native/learn/todo-app/screens/auth.mdx
@@ -194,6 +194,7 @@ export const UserContextProvider: React.FC = ({children}) => {
 -         component={TodoBoard}
 -         options={{
 -           headerTitle: 'Todo',
+-           headerRight: undefined,
 -         }}
 -       />
         <nav.Screen name="Instructions" component={Instructions} />


### PR DESCRIPTION
## ✅ What's done

- [x] 画面の実装で検知したDiffの漏れに対応

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

[ドキュメント](https://ws-4020.github.io/mobile-app-crib-notes/react-native/learn/todo-app/screens/stack#%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%AE%E8%BF%BD%E5%8A%A0)で追加している`headerRight`も一緒に消すべきでした

https://github.com/ws-4020/mobile-app-crib-notes/pull/303