### PR TITLE
♻️: VSCode上でコンパイルエラーになるソースを修正

### DIFF
--- a/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
@@ -54,6 +54,11 @@ import React from 'react';
 import {Text, View, ScrollView, StyleSheet} from 'react-native';
 import {Button} from 'react-native-elements';
 
+type RootParamList = {
+  Screen1: undefined;
+  Screen2: undefined;
+};
+
 const Root = createStackNavigator();
 
 export const App = () => {
@@ -68,7 +73,7 @@ export const App = () => {
 };
 
 const Screen1: React.FC = () => {
-  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
+  const navigation = useNavigation<StackNavigationProp<RootParamList>>();
   const state = useNavigationState((state) => state);
 
   return (
@@ -92,7 +97,7 @@ const Screen1: React.FC = () => {
 };
 
 const Screen2: React.FC = () => {
-  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
+  const navigation = useNavigation<StackNavigationProp<RootParamList>>();
   const state = useNavigationState((state) => state);
 
   return (

--- a/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
@@ -41,7 +41,6 @@ Stackの操作として次のAPIが用意されています。
 <TabItem value="source">
 
 ```typescript jsx title="/src/App.tsx"
-import { ParamListBase } from '@react-navigation/native';
 import {
   NavigationContainer,
   useNavigation,
@@ -59,7 +58,7 @@ type RootParamList = {
   Screen2: undefined;
 };
 
-const Root = createStackNavigator();
+const Root = createStackNavigator<RootParamList>();
 
 export const App = () => {
   return (
@@ -73,7 +72,7 @@ export const App = () => {
 };
 
 const Screen1: React.FC = () => {
-  const navigation = useNavigation<StackNavigationProp<RootParamList>>();
+  const navigation = useNavigation<StackNavigationProp<RootParamList, 'Screen1'>>();
   const state = useNavigationState((state) => state);
 
   return (
@@ -97,7 +96,7 @@ const Screen1: React.FC = () => {
 };
 
 const Screen2: React.FC = () => {
-  const navigation = useNavigation<StackNavigationProp<RootParamList>>();
+  const navigation = useNavigation<StackNavigationProp<RootParamList, 'Screen2'>>();
   const state = useNavigationState((state) => state);
 
   return (

--- a/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
+++ b/docs/react-native/learn/basic-concepts/react-navigation-basics/stack.mdx
@@ -41,13 +41,14 @@ Stackの操作として次のAPIが用意されています。
 <TabItem value="source">
 
 ```typescript jsx title="/src/App.tsx"
+import { ParamListBase } from '@react-navigation/native';
 import {
   NavigationContainer,
   useNavigation,
   useNavigationState,
 } from '@react-navigation/native';
 import {
-  createStackNavigator,
+  createStackNavigator, StackNavigationProp,
 } from '@react-navigation/stack';
 import React from 'react';
 import {Text, View, ScrollView, StyleSheet} from 'react-native';
@@ -67,7 +68,7 @@ export const App = () => {
 };
 
 const Screen1: React.FC = () => {
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
   const state = useNavigationState((state) => state);
 
   return (
@@ -91,7 +92,7 @@ const Screen1: React.FC = () => {
 };
 
 const Screen2: React.FC = () => {
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
   const state = useNavigationState((state) => state);
 
   return (


### PR DESCRIPTION
## ✅ What's done

- [x] `useNavigation()`を`const navigation = useNavigation<StackNavigationProp<ParamListBase>>()`に修正
  - StackNavigationPropに何かしらジェネリクスを指定する必要があるが、今回はパラメータ定義は不要であるため、ベースとなるParamListBaseを指定。（anyを指定するよりは良いと判断）
 
---

## Tests

- [x] npm run lint:text
- [x] npm run lint:md
- [x] 修正したApp.tsxを張り付け、VSCode上でコンパイルエラーが発生しないこと
- [x] 修正したApp.tsxを張り付け、アプリが動作すること。 

## Devices

- [x] 動作確認に利用したデバイスにチェックをつけてください
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし