### PR TITLE
💄: ナビゲーションバーのラベルを英語に統一

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,7 +91,7 @@ module.exports = {
               ? [{label: 'Example App', to: 'react-native/santoku', position: 'left'}]
               : []),
             {
-              label: 'ハマりがちな落とし穴',
+              label: 'Pitfalls',
               to: 'react-native/common-pitfalls',
               position: 'left',
             },
@@ -126,7 +126,7 @@ module.exports = {
               to: 'react-native/learn',
             },
             {
-              label: 'ハマりがちな落とし穴',
+              label: 'Pitfalls',
               to: 'react-native/common-pitfalls',
             },
             ...(process.env.NODE_ENV === 'development'


### PR DESCRIPTION
## ✅ What's done

- [x] ナビゲーションバーのラベル「ハマりがちな落とし穴」を「Pitfalls」に変更
---

## Tests

- [x] `npm start`

## Other (messages to reviewers, concerns, etc.)

なんとなく、統一感がなくなってるなぁ、と思ったので提案です。分かりにくくなりそうとかだったら取り下げます。