### PR TITLE
🖋: 演習課題をREST APIとの接続の後ろに移動

### DIFF
--- a/docs/react-native/learn/todo-app/networking/activity-indicator-each-todo.mdx
+++ b/docs/react-native/learn/todo-app/networking/activity-indicator-each-todo.mdx
@@ -109,11 +109,10 @@ REST APIで正常に処理出来なかった場合、実際には完了状態の
    completed: boolean;
 +  processing: boolean;
    toggleTodoCompletion: (id: number) => void;
-   onRemove: (id: number) => void;
  }
  
--export const TodoItem: React.FC<Props> = ({id, text, completed, toggleTodoCompletion, onRemove}) => {
-+export const TodoItem: React.FC<Props> = ({id, text, completed, toggleTodoCompletion, onRemove, processing}) => {
+-export const TodoItem: React.FC<Props> = ({id, text, completed, toggleTodoCompletion}) => {
++export const TodoItem: React.FC<Props> = ({id, text, completed, toggleTodoCompletion, processing}) => {
 ```
 
 `TodoList.tsx`で判定した値を`TodoItem`に渡します。
@@ -147,7 +146,6 @@ REST APIで正常に処理出来なかった場合、実際には完了状態の
        <View style={styles.todo}>
          <CheckBox title={text} checked={completed} containerStyle={styles.checkbox} onPress={onToggle} />
        </View>
-       <AntDesign name="delete" size={24} onPress={onDelete} />
 +      {processing && (
 +        <View style={styles.processing}>
 +          <ActivityIndicator animating={processing} size="large" color="white" style={styles.indicator} />

--- a/docs/react-native/learn/todo-app/networking/api-request.mdx
+++ b/docs/react-native/learn/todo-app/networking/api-request.mdx
@@ -39,10 +39,6 @@ const putTodo = async (id: number, completed: boolean) => {
 
 `TodoService`を次のソースコードで上書きしてください。
 
-:::note
-画面の実装の演習問題で[ToDoの削除](../screens/exercise.mdx#ToDoの削除)を実装している場合は削除メソッドもAPIクライアントを呼びだすように修正してください。
-:::
-
 ```typescript title="/src/services/TodoService.ts"
 import {TodosApi, config} from 'backend';
 

--- a/docs/react-native/learn/todo-app/screens/exercise.mdx
+++ b/docs/react-native/learn/todo-app/screens/exercise.mdx
@@ -21,3 +21,7 @@ ToDo一覧画面に削除ボタンを追加する方法が簡単です。
 その場合、[確認ダイアログ](alert.mdx)との組み合わせで考えてみてください。
 もちろん、違った形で実装しても問題ありません。
 :::
+
+:::note
+削除APIは[APIクライアントの作成](../networking/generate-api-client.mdx)で生成されています。削除APIを`/src/services/TodoService.ts`で呼びだすように修正します。
+:::

--- a/docs/react-native/learn/todo-app/screens/exercise.mdx
+++ b/docs/react-native/learn/todo-app/screens/exercise.mdx
@@ -23,5 +23,5 @@ ToDo一覧画面に削除ボタンを追加する方法が簡単です。
 :::
 
 :::note
-削除APIは[APIクライアントの作成](../networking/generate-api-client.mdx)で生成されています。削除APIを`/src/services/TodoService.ts`で呼びだすように修正します。
+ToDoの削除API（`TodosApi.deleteTodo `）は[APIクライアントの作成](../networking/generate-api-client.mdx)で生成されています。
 :::

--- a/docs/react-native/learn/todo-app/screens/exercise.mdx
+++ b/docs/react-native/learn/todo-app/screens/exercise.mdx
@@ -23,5 +23,5 @@ ToDo一覧画面に削除ボタンを追加する方法が簡単です。
 :::
 
 :::note
-ToDoの削除API（`TodosApi.deleteTodo `）は[APIクライアントの作成](../networking/generate-api-client.mdx)で生成されています。
+ToDoの削除API（`TodosApi.deleteTodo`）は[APIクライアントの作成](../networking/generate-api-client.mdx)で生成されています。
 :::

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -174,9 +174,9 @@ module.exports = {
             'react-native/learn/todo-app/networking/api-request',
             'react-native/learn/todo-app/networking/activity-indicator',
             'react-native/learn/todo-app/networking/activity-indicator-each-todo',
-            'react-native/learn/todo-app/screens/exercise',
           ],
         },
+        'react-native/learn/todo-app/screens/exercise',
       ],
     },
     {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -163,7 +163,6 @@ module.exports = {
             'react-native/learn/todo-app/screens/use-focus-effect',
             'react-native/learn/todo-app/screens/basic-components',
             'react-native/learn/todo-app/screens/logo',
-            'react-native/learn/todo-app/screens/exercise',
           ],
         },
         {
@@ -175,6 +174,7 @@ module.exports = {
             'react-native/learn/todo-app/networking/api-request',
             'react-native/learn/todo-app/networking/activity-indicator',
             'react-native/learn/todo-app/networking/activity-indicator-each-todo',
+            'react-native/learn/todo-app/screens/exercise',
           ],
         },
       ],


### PR DESCRIPTION
## ✅ What's done

- [x] 「演習課題」を「ToDoアプリの実装」の末尾に移動（「画面の実装」、「REST APIとの接続」と並ぶように移動）
- [x] 影響のある文言、ソースコードブロックの修正（演習課題にて実装する内容が含まれていたので削除）

---

## Tests

- [x] npm run lint
- [x] 「git grep 演習課題」を実行し、他に影響箇所がないか確認
  - 演習課題自体のmdであるexercise.mdx以外にヒットなし
- [x] 「git grep 演習問題」を実行し、他に影響箇所がないか確認
  - docs\react-native\learn\todo-app\networking\api-request.mdxに演習課題でToDoの削除を実装している場合の文言があったため削除

## Other (messages to reviewers, concerns, etc.)

なし
