### PR TITLE
🐛: santoku-appのgoogle-services.dummy.jsonをそのまま使えるように修正

### DIFF
--- a/santoku-app/android/app/google-services.dummy.json
+++ b/santoku-app/android/app/google-services.dummy.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:111111111111:android:0000000000111111111122",
         "android_client_info": {
-          "package_name": "dummy"
+          "package_name": "jp.fintan.mobile.santokuapp"
         }
       },
       "oauth_client": [
@@ -45,7 +45,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:111111111111:android:0000000000111111111122",
         "android_client_info": {
-          "package_name": "dummy"
+          "package_name": "jp.fintan.mobile.santokuapp.debug"
         }
       },
       "oauth_client": [


### PR DESCRIPTION
## ✅ What's done

- [x] santoku-appのandroid/app/google-sevices.dummy.jsonのpackage_nameを`dummy`から`jp.fintan.mobile.santokuapp`と`jp.fintan.mobile.santokuapp.debug`に修正

---

## Tests

- [x] `android/app/google-sevices.dummy.json`を`android/app/google-sevices.json`にコピーし、ファイル修正することなくアプリが起動すること

## Devices

- [x] 動作確認に利用したデバイスにチェックをつけてください
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
