### PR TITLE
🔨: react-native-samplesの中はRenovateの対象外にする

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
     enabled: true,
     schedule: ['before 20:00 on sunday'],
   },
-  ignorePaths: ['react-native-samples'],
+  ignorePaths: ['react-native-samples/**'],
   packageRules: [
     {
       // expo upgradeで更新されるパッケージはRenovateの対象外とします


### PR DESCRIPTION
## ✅ What's done

- [x] `react-native-samples`の中を全て無視するようにRenovateの設定を修正。
---

## Other (messages to reviewers, concerns, etc.)

Globを使わないと、直下のやつだけ無視されてしまうらしい。