### PR TITLE
✨: ADRのタイトルを「エラーのハンドリング方法」から「エラーハンドリング」に変更

### DIFF
--- a/website/docs/react-native/santoku/decisions.mdx
+++ b/website/docs/react-native/santoku/decisions.mdx
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 import {PageList} from '../../../src/components';
 const overviews = [
   {
-    title: 'エラーのハンドリング方法',
+    title: 'エラーハンドリング',
     to: '/react-native/santoku/decisions/adr-001-error-handling',
   }
 ]

--- a/website/docs/react-native/santoku/decisions/adr-001-error-handling.mdx
+++ b/website/docs/react-native/santoku/decisions/adr-001-error-handling.mdx
@@ -1,5 +1,5 @@
 ---
-title: エラーのハンドリング方法
+title: エラーハンドリング
 ---
 
 Status: Accepted


### PR DESCRIPTION
## ✅ What's done

- [x] エラーハンドリングのADRのタイトルを、「エラーのハンドリング方法」から「エラーハンドリング」に変更

---
## Other (messages to reviewers, concerns, etc.)

方式設計に合わせて、「エラーハンドリング」に変更しました
