### PR TITLE
🐛: Androidでウィンドウを分割してリサイズすると、Home画面に戻ってしまう問題に対応

### DIFF
--- a/example-app/SantokuApp/android/app/src/main/AndroidManifest.xml
+++ b/example-app/SantokuApp/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <activity
       android:name=".MainActivity"
       android:label="@string/APP_NAME_HOME"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode|screenLayout|smallestScreenSize"
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize"
       android:theme="@style/Theme.App.SplashScreen"


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- Androidで分割表示したときに、アクティビティが再起動されなくなりました

## ✅ What's done

- [x] `AndroidManifest.xml`の`android:configChanges`に、画面サイズ変更関連のイベントを追加
---

## Tests

- [x] SantokuAppを分割表示してリサイズしても、Home画面に戻らないこと

## Devices

- [x] ~~iOS~~
- [x] Android
  - [x] ~~エミュレータ (Pixel 3a/Android 11)~~
  - [x] 実機 (Pixel 4a/Android 11)

## Other (messages to reviewers, concerns, etc.)

参考にしたドキュメント

- [マルチウィンドウのサポート - Android デベロッパー](https://developer.android.com/guide/topics/ui/multi-window)
- [構成の変更を処理する - Android デベロッパー](https://developer.android.com/guide/topics/resources/runtime-changes)
- [\<activity\> - Android デベロッパー](https://developer.android.com/guide/topics/manifest/activity-element#config)