### PR TITLE
✨: Releaseモードのシミュレータ起動ではCPUアーキテクチャからarm64を除外するように変更

### DIFF
--- a/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
+++ b/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = SantokuApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -549,6 +550,7 @@
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = SantokuApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
## ✅ What's done

- [x]  iOSのシミュレータではRelease、ReleaseInHouseで起動しなかったため、project.pbprojに"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;を追加

---

## Tests

- [x] シミュレータで起動することを確認

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 14)
- [x] ~~Android~~

## Other (messages to reviewers, concerns, etc.)

なし
