### PR TITLE
🩹: Debugの場合にATSが完全に無効になっていたのを、localhostのみ無効にするように修正

### DIFF
--- a/example-app/SantokuApp/ios/SantokuApp/Debug.plist
+++ b/example-app/SantokuApp/ios/SantokuApp/Debug.plist
@@ -26,8 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>

--- a/website/docs/react-native/santoku/development/build-configuration/build-type-configurations.mdx
+++ b/website/docs/react-native/santoku/development/build-configuration/build-type-configurations.mdx
@@ -327,8 +327,6 @@ EA57F9FD253824C7003D7604 /* DebugAdvanced */ = {
 <dict>
   <key>NSAppTransportSecurity</key>
   <dict>
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
     <key>NSExceptionDomains</key>
     <dict>
       <key>localhost</key>


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- Debug/DebugAdvancedでビルドして開発しているときも、`localhost`以外のホストにはHTTPS接続が必須になります。

## ✅ What's done

- [x] Debugの場合にATSが完全に無効になっていたのを、localhostのみ無効にするように修正
---

## Tests

- [x] `npm run ios -- --device <Registered Device>` で、実機でアプリが起動し、JavaScriptが読み込めること
- [x] `NSExceptionDomains`の設定を削除すると、JavaScriptを読み込めなくなること

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 14)

## Other (messages to reviewers, concerns, etc.)

[App Transport Security - ビルドタイプ](https://ws-4020.github.io/mobile-app-crib-notes/react-native/santoku/development/build-configuration/build-type-configurations#app-transport-security)で、「有効（`localhost`を除外）」と設計していたのですが、そのとおりに実装されていなかったので修正しました。
