### PR TITLE
✨: React Native Firebase関連のパッケージをまとめて更新する設定に変更

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,11 @@
       matchPackagePrefixes: ['@react-navigation/'],
     },
     {
+      // React Native Firebaseの関連パッケージはまとめて更新するようにします
+      groupName: 'React Native Firebase',
+      matchPackagePrefixes: ['@react-native-firebase/'],
+    },
+    {
       // Docusaurusの関連パッケージはまとめて更新するようにします
       groupName: 'Docusaurus',
       matchPackagePrefixes: ['@docusaurus'],


### PR DESCRIPTION
## ✅ What's done

- [x] RenovateのpackageRulesにReact Native Firebase関連の設定を追加
  - #427 と #428 で個々に更新しようとしてエラーが発生しているので、まとめて更新するように

