### PR TITLE
✨: react-test-rendererをRenovate対象外にする

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,7 @@
       enabled: false,
       matchPackageNames: [
         '@types/jest', // jest-expo -> jest
-        '@types/react-test-renderer', // jest-expo -> react-test-renderer
+        'react-test-renderer', // jest-expo -> react-test-renderer
         'jest',
         'gradle', // expo-template-bare-typescript
       ],


### PR DESCRIPTION
## ✅ What's done

- [x] react-test-rendererをRenovate対象外グループに追加
  - （もともと@types/react-test-rendererが対象外とされていたので修正）

