### PR TITLE
🌱: Firebaseの設定をしなくてもアプリをビルドできるようにダミーの設定ファイルを準備

### DIFF
--- a/example-app/SantokuApp/.gitignore
+++ b/example-app/SantokuApp/.gitignore
@@ -65,8 +65,10 @@ ios/PersonalAccount.xcconfig
 ios/tmp.xcconfig
 
 # Firebase
-GoogleService-Info.plist
+GoogleService-Info*.plist
+!ios/SantokuApp/Supporting/GoogleService-Info-Dummy.plist
 google-services.json
+!android/app/google-services.json
 
 # generated
 /generated

--- a/example-app/SantokuApp/android/app/google-services.json
+++ b/example-app/SantokuApp/android/app/google-services.json
@@ -1,0 +1,298 @@
+{
+  "project_info": {
+    "project_number": "01234567890",
+    "project_id": "santoku-app-dummy",
+    "storage_bucket": "jp.fintan.mobile.SantokuApp.dummy"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.dev"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.dev"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.house"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.house"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.dev.house"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.dev.house"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.debugAdvanced"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.debugAdvanced"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.dev.debugAdvanced"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.dev.debugAdvanced"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.debug"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678901:android:64jfpbhnqqgk7dongdrfmb",
+        "android_client_info": {
+          "package_name": "jp.fintan.mobile.SantokuApp.dev.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "dummy-api-key-J9qb7dBt2Q0l58IqPa8i-BJXn"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "012345678901-nuc7czo2nz7n2l1ob0guvy32xewi2316.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "jp.fintan.mobile.SantokuApp.dev.debug"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
+++ b/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		2CBE99D8413DC464B14E20E6 /* Pods-SantokuApp.debugadvanced.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SantokuApp.debugadvanced.xcconfig"; path = "Target Support Files/Pods-SantokuApp/Pods-SantokuApp.debugadvanced.xcconfig"; sourceTree = "<group>"; };
 		3280BADF6F7E2E51C7BC7D30 /* Pods-SantokuApp.releaseinhouse.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SantokuApp.releaseinhouse.xcconfig"; path = "Target Support Files/Pods-SantokuApp/Pods-SantokuApp.releaseinhouse.xcconfig"; sourceTree = "<group>"; };
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-SantokuApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SantokuApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6909A3A526E1EC0000F9111D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		6909A3A526E1EC0000F9111D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		699A764226E6E45C00D48F9D /* RCTThrowErrorModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTThrowErrorModule.h; sourceTree = "<group>"; };
 		699A764326E6E48500D48F9D /* RCTThrowErrorModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTThrowErrorModule.m; sourceTree = "<group>"; };
 		6C2E3173556A471DD304B334 /* Pods-SantokuApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SantokuApp.debug.xcconfig"; path = "Target Support Files/Pods-SantokuApp/Pods-SantokuApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -59,7 +59,6 @@
 			isa = PBXGroup;
 			children = (
 				69C8ACE526E7062F00816784 /* Demo */,
-				6909A3A526E1EC0000F9111D /* GoogleService-Info.plist */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
@@ -126,6 +125,7 @@
 		BB2F792B24A3F905000567C9 /* Supporting */ = {
 			isa = PBXGroup;
 			children = (
+				6909A3A526E1EC0000F9111D /* GoogleService-Info.plist */,
 				BB2F792C24A3F905000567C9 /* Expo.plist */,
 			);
 			name = Supporting;
@@ -179,9 +179,7 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = S246SVH826;
 						LastSwiftMigration = 1120;
-						ProvisioningStyle = Automatic;
 					};
 				};
 			};

--- a/example-app/SantokuApp/ios/SantokuApp/Supporting/GoogleService-Info.plist
+++ b/example-app/SantokuApp/ios/SantokuApp/Supporting/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.012345678901-sidw5laqvzk01kzyoudm1ng80cqceo1m</string>
+	<key>API_KEY</key>
+	<string>dummy-api-key-PdQdaLEG3fDRST6hgjc9TNP0K</string>
+	<key>GCM_SENDER_ID</key>
+	<string>012345678901</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>jp.fintan.mobile.SantokuApp.dev.debug</string>
+	<key>PROJECT_ID</key>
+	<string>santoku-app-dummy</string>
+	<key>STORAGE_BUCKET</key>
+	<string>jp.fintan.mobile.SantokuApp.dummy</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<false></false>
+	<key>IS_GCM_ENABLED</key>
+	<false></false>
+	<key>IS_SIGNIN_ENABLED</key>
+	<false></false>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:012345678901:ios:1z378xb072v3jz5lum72ds</string>
+</dict>
+</plist>


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- iOS用のFirebase設定ファイル（`GoogleService-Info.plist`）の配置ディレクトリを以下のように変更
  - `ios/GoogleService-Info.plist` -> `ios/SantokuApp/Supporting/GoogleService-Info.plist`

## ✅ What's done

- [x] ダミーのFirebase設定ファイルを配置（Android, iOS）
- [x] iOS用のFirebase設定ファイルの格納ディレクトリを変更

## ⏸ What's not done

- iOSのSchemeごとのPre Buildアクションの実装
---

## Tests

- [ ] すべてのビルドバリアントでSantokuAppをビルドできること、起動できること

    ```fish
    bundle install && npm ci && npm run reset-cache:all \
    && for configuration in Release ReleaseInHouse DebugAdvanced Debug
            for scheme in DevSantokuApp SantokuApp
                npm run ios -- --configuration $configuration --scheme $scheme >/dev/null; or echo 'error '$configuration' '$scheme
            end
        end \
    && for type in Release ReleaseInHouse DebugAdvanced Debug
            for flavor in devSantokuApp santokuApp
                npm run android -- --variant $flavor$type >/dev/null; or echo 'error '$flavor$type
            end
        end
    ```

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 13.5)
- [x] Android
  - [x] エミュレータ (Pixel 4a/Android 11)

## Other (messages to reviewers, concerns, etc.)

* Schemeごとの設定ファイルコピー処理を実装したら、`GoogleService-Info.plist`の削除をよろしくです
* ダミー設定ファイルはそれぞれ以下のディレクトリに配置する想定で`.gitignore`を修正してます
  * iOS: `ios/SantokuApp/Supporting/GoogleService-Info-Dummy.plist`
    * スクリプトの都合で変えたほうが良ければ変えてください
  * Android: `android/app/google-services.json`