### PR TITLE
🔨: Debugの時は、Androidの難読化ファイルをCrashlyticsにアップロードしないようにする

### DIFF
--- a/example-app/SantokuApp/android/app/build.gradle
+++ b/example-app/SantokuApp/android/app/build.gradle
@@ -186,6 +186,9 @@ android {
             signingConfig signingConfigs.debug
             debuggable true
             applicationIdSuffix ".debug"
+            firebaseCrashlytics {
+                mappingFileUploadEnabled false
+            }
         }
         debugAdvanced {
             initWith debug


### PR DESCRIPTION
## ✅ What's done

- [x] DebugはFirebaseに基本的に接続しない想定なので、マッピングファイルをアップロードしないように設定しておきます。
---

## Tests

- [x] `npm run android` でSantokuAppをビルド、起動できること
- [x] `npm run android -- --variant "devSantokuAppRelease" --appIdSuffix "dev"` でSantokuAppをビルド、起動できること

## Other (messages to reviewers, concerns, etc.)

以下のドキュメントに従って設定しました。

[難読化されたビルド バリアントを保持する - Firebase Crashlytics](https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?hl=ja&platform=android#keep_obfuscated_build_variants)