### PR TITLE
🌱: メッセージ管理の部品を追加

### DIFF
--- a/example-app/SantokuApp/src/App.tsx
+++ b/example-app/SantokuApp/src/App.tsx
@@ -20,7 +20,7 @@ export const App = () => {
   // アプリ内で使用するメッセージのロード
   loadMessages(new BundledMessagesLoader()).catch(() => {
     // アプリにバンドルしているメッセージのロードは失敗しない想定
-    log.error('Failed to load message.', 'MessageLoadingFailure');
+    log.error('Failed to load message.', 'BundledMessagesLoadingFailure');
   });
 
   return (

--- a/example-app/SantokuApp/src/App.tsx
+++ b/example-app/SantokuApp/src/App.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import {BundledMessagesLoader, loadMessages} from './framework';
 import {firebaseConfig} from './framework/firebase';
+import {log} from './framework/logging';
 
 export const App = () => {
   // 開発中は画面がスリープしないようにしておきます。
@@ -19,6 +20,7 @@ export const App = () => {
   // アプリ内で使用するメッセージのロード
   loadMessages(new BundledMessagesLoader()).catch(() => {
     // アプリにバンドルしているメッセージのロードは失敗しない想定
+    log.error('Failed to load message.', 'MessageLoadingFailure');
   });
 
   return (

--- a/example-app/SantokuApp/src/App.tsx
+++ b/example-app/SantokuApp/src/App.tsx
@@ -3,6 +3,7 @@ import {activateKeepAwake} from 'expo-keep-awake';
 import {RootStackNav} from 'navigation';
 import React from 'react';
 
+import {BundledMessagesLoader, loadMessages} from './framework';
 import {firebaseConfig} from './framework/firebase';
 
 export const App = () => {
@@ -15,6 +16,10 @@ export const App = () => {
     // Firebase Crashlyticsの初期化
     require('@react-native-firebase/crashlytics');
   }
+  // アプリ内で使用するメッセージのロード
+  loadMessages(new BundledMessagesLoader()).catch(() => {
+    // アプリにバンドルしているメッセージのロードは失敗しない想定
+  });
 
   return (
     <NavigationContainer>

--- a/example-app/SantokuApp/src/framework/index.ts
+++ b/example-app/SantokuApp/src/framework/index.ts
@@ -1,1 +1,2 @@
 export {AppConfig} from './config';
+export {m, loadMessages, BundledMessagesLoader} from './message';

--- a/example-app/SantokuApp/src/framework/message/BundledMessageLoader.ts
+++ b/example-app/SantokuApp/src/framework/message/BundledMessageLoader.ts
@@ -1,0 +1,13 @@
+import {BundledMessages, BundledMessagesType} from '../../generated/BundledMessages';
+import {MessagesLoader} from './Message';
+
+/**
+ * アプリ内にバンドルされたメッセージをロードするクラスです。
+ */
+class BundledMessagesLoader implements MessagesLoader {
+  load() {
+    return new Promise<BundledMessagesType>((resolve) => resolve(BundledMessages));
+  }
+}
+
+export {BundledMessagesLoader};

--- a/example-app/SantokuApp/src/framework/message/BundledMessageLoader.ts
+++ b/example-app/SantokuApp/src/framework/message/BundledMessageLoader.ts
@@ -1,4 +1,4 @@
-import {BundledMessages, BundledMessagesType} from '../../generated/BundledMessages';
+import {bundledMessages, BundledMessagesType} from '../../generated/BundledMessages';
 import {MessagesLoader} from './Message';
 
 /**
@@ -6,7 +6,7 @@ import {MessagesLoader} from './Message';
  */
 class BundledMessagesLoader implements MessagesLoader {
   load() {
-    return new Promise<BundledMessagesType>((resolve) => resolve(BundledMessages));
+    return new Promise<BundledMessagesType>((resolve) => resolve(bundledMessages));
   }
 }
 

--- a/example-app/SantokuApp/src/framework/message/Message.test.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.test.ts
@@ -1,29 +1,49 @@
-import {BundledMessages} from '../../generated/BundledMessages';
+import {log} from '../logging';
 import {loadMessages, m} from './Message';
 
 describe('Message message', () => {
   test('メッセージがロードされていない場合の検証', () => {
-    expect(() => m('validation.required')).toThrowError(new Error('Messages was not cached.'));
+    // @ts-ignore
+    expect(() => m('msg.error.network')).toThrowError(new Error('Messages was not cached.'));
   });
   test('オプションが存在しないメッセージの取得を検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise((resolve) => {
-          resolve({...BundledMessages, 'msg.error.ネットワーク': 'network error.'});
+          // @ts-ignore
+          resolve({'msg.error.network': 'network error.'});
         });
       },
     });
-    expect(m('msg.error.ネットワーク')).toEqual('network error.');
+    // @ts-ignore
+    expect(m('msg.error.network')).toEqual('network error.');
   });
   test('オプションが存在するメッセージの取得を検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise((resolve) => {
-          resolve({...BundledMessages, 'validation.required': '{0}を入力してください。'});
+          // @ts-ignore
+          resolve({'validation.required': '{0}を入力してください。'});
         });
       },
     });
+    // @ts-ignore
     expect(m('validation.required', 'name')).toEqual('nameを入力してください。');
+    // @ts-ignore
     expect(m('validation.required')).toEqual('{0}を入力してください。');
+  });
+  test('指定されたメッセージキーに該当するメッセージが存在しない場合の検証', async () => {
+    await loadMessages({
+      load: async () => {
+        return new Promise((resolve) => {
+          // @ts-ignore
+          resolve({'msg.error.network': 'network error.'});
+        });
+      },
+    });
+    const spy = jest.spyOn(log, 'error');
+    // @ts-ignore
+    expect(m('dummyKey')).toEqual('dummyKey');
+    expect(spy).toHaveBeenCalledWith('Message was not found. messageKey=[dummyKey]', 'MessageNotFound');
   });
 });

--- a/example-app/SantokuApp/src/framework/message/Message.test.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.test.ts
@@ -3,46 +3,46 @@ import {loadMessages, m} from './Message';
 
 describe('Message message', () => {
   test('メッセージがロードされていない場合の検証', () => {
-    // @ts-ignore
+    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(() => m('msg.error.network')).toThrowError(new Error('Messages was not cached.'));
   });
   test('オプションが存在しないメッセージの取得を検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise((resolve) => {
-          // @ts-ignore
+          // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'msg.error.network': 'network error.'});
         });
       },
     });
-    // @ts-ignore
+    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('msg.error.network')).toEqual('network error.');
   });
   test('オプションが存在するメッセージの取得を検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise((resolve) => {
-          // @ts-ignore
+          // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'validation.required': '{0}を入力してください。'});
         });
       },
     });
-    // @ts-ignore
+    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required', 'name')).toEqual('nameを入力してください。');
-    // @ts-ignore
+    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required')).toEqual('{0}を入力してください。');
   });
   test('指定されたメッセージキーに該当するメッセージが存在しない場合の検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise((resolve) => {
-          // @ts-ignore
+          // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'msg.error.network': 'network error.'});
         });
       },
     });
     const spy = jest.spyOn(log, 'error');
-    // @ts-ignore
+    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('dummyKey')).toEqual('dummyKey');
     expect(spy).toHaveBeenCalledWith('Message was not found. messageKey=[dummyKey]', 'MessageNotFound');
   });

--- a/example-app/SantokuApp/src/framework/message/Message.test.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.test.ts
@@ -1,0 +1,29 @@
+import {BundledMessages} from '../../generated/BundledMessages';
+import {loadMessages, m} from './Message';
+
+describe('Message message', () => {
+  test('メッセージがロードされていない場合の検証', () => {
+    expect(() => m('validation.required')).toThrowError(new Error('Messages was not cached.'));
+  });
+  test('オプションが存在しないメッセージの取得を検証', async () => {
+    await loadMessages({
+      load: async () => {
+        return new Promise((resolve) => {
+          resolve({...BundledMessages, 'msg.error.ネットワーク': 'network error.'});
+        });
+      },
+    });
+    expect(m('msg.error.ネットワーク')).toEqual('network error.');
+  });
+  test('オプションが存在するメッセージの取得を検証', async () => {
+    await loadMessages({
+      load: async () => {
+        return new Promise((resolve) => {
+          resolve({...BundledMessages, 'validation.required': '{0}を入力してください。'});
+        });
+      },
+    });
+    expect(m('validation.required', 'name')).toEqual('nameを入力してください。');
+    expect(m('validation.required')).toEqual('{0}を入力してください。');
+  });
+});

--- a/example-app/SantokuApp/src/framework/message/Message.test.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.test.ts
@@ -4,7 +4,7 @@ import {loadMessages, m} from './Message';
 describe('Message message', () => {
   test('メッセージがロードされていない場合の検証', () => {
     // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
-    expect(() => m('msg.error.network')).toThrowError(new Error('Messages was not cached.'));
+    expect(() => m('msg.error.network')).toThrowError(new Error('Messages are not loaded.'));
   });
   test('オプションが存在しないメッセージの取得を検証', async () => {
     await loadMessages({
@@ -44,6 +44,6 @@ describe('Message message', () => {
     const spy = jest.spyOn(log, 'error');
     // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('dummyKey')).toEqual('dummyKey');
-    expect(spy).toHaveBeenCalledWith('Message was not found. messageKey=[dummyKey]', 'MessageNotFound');
+    expect(spy).toHaveBeenCalledWith('Could not find the message. messageKey=[dummyKey]', 'MessageNotFound');
   });
 });

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -1,4 +1,5 @@
 import {MessageKey} from '../../generated/BundledMessages';
+import {log} from '../logging';
 
 /**
  * メッセージをロードします。
@@ -43,6 +44,10 @@ async function loadMessages(loader: MessagesLoader) {
 function message(key: MessageKey, ...options: string[]): string {
   if (!cache) {
     throw new Error('Messages was not cached.');
+  }
+  if (cache[key] === undefined) {
+    log.error(`Message was not found. messageKey=[${key}]`, 'MessageNotFound');
+    return key;
   }
   return !options.length ? cache[key] : format(cache[key], options);
 }

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -44,10 +44,10 @@ async function loadMessages(loader: MessagesLoader) {
  */
 function message(key: MessageKey, ...options: string[]): string {
   if (!cache) {
-    throw new Error('Messages was not cached.');
+    throw new Error('Messages are not loaded.');
   }
   if (cache[key] === undefined) {
-    log.error(`Message was not found. messageKey=[${key}]`, 'MessageNotFound');
+    log.error(`Could not find the message. messageKey=[${key}]`, 'MessageNotFound');
     return key;
   }
   return !options.length ? cache[key] : format(cache[key], options);

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -23,6 +23,7 @@ async function loadMessages(loader: MessagesLoader) {
  * {@link loadMessages}を呼び出してして、メッセージをロード後に使用してください。
  * @param key メッセージのキー
  * @param options メッセージのオプション
+ * @returns 指定されたメッセージキーに該当するメッセージ。指定されたメッセージキーに該当するメッセージが存在しない場合はメッセージキーを返却
  *
  * @example
  * 定義されているメッセージの例

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -1,0 +1,63 @@
+import {MessageKey} from '../../generated/BundledMessages';
+
+/**
+ * メッセージをロードします。
+ */
+interface MessagesLoader {
+  load(): Promise<Record<MessageKey, string>>;
+}
+
+let cache: Record<MessageKey, string> | undefined;
+
+/**
+ * メッセージをロードします。
+ * @param loader メッセージをロードするクラス
+ */
+async function loadMessages(loader: MessagesLoader) {
+  cache = await loader.load();
+}
+
+/**
+ * メッセージを取得します。
+ * {@link loadMessages}を呼び出してして、メッセージをロード後に使用してください。
+ * @param key メッセージのキー
+ * @param options メッセージのオプション
+ *
+ * @example
+ * 定義されているメッセージの例
+ * ```
+ * export const BundledMessages = {
+ *  'validation.email': 'メールアドレスの形式が正しくありません。',
+ *  'validation.required': '{0}を入力してください。',
+ *  'validation.min': '{0}は{1}文字以上の値を入力してください。',
+ * } as const;
+ * ```
+ * @example
+ * メッセージを取得する例
+ * ```
+ * m('validation.email') // メールアドレスの形式が正しくありません。
+ * m('validation.required', 'パスワード') // パスワードを入力してください。
+ * m('validation.min', 'パスワード', '8') // パスワードは8文字以上の値を入力してください。
+ * ```
+ */
+function message(key: MessageKey, ...options: string[]): string {
+  if (!cache) {
+    throw new Error('Messages was not cached.');
+  }
+  return !options.length ? cache[key] : format(cache[key], options);
+}
+
+/**
+ * メッセージをフォーマットします。
+ * @param message メッセージ
+ * @param options メッセージのオプション
+ * @returns フォーマット後のメッセージ
+ */
+function format(message: string, options: string[]): string {
+  return options.reduce((message, option, index) => {
+    return message.replace(`{${index}}`, option);
+  }, message);
+}
+
+export type {MessagesLoader};
+export {message as m, loadMessages};

--- a/example-app/SantokuApp/src/framework/message/index.ts
+++ b/example-app/SantokuApp/src/framework/message/index.ts
@@ -1,0 +1,2 @@
+export * from './Message';
+export * from './BundledMessageLoader';

--- a/example-app/SantokuApp/src/generated/BundledMessages.ts
+++ b/example-app/SantokuApp/src/generated/BundledMessages.ts
@@ -1,0 +1,9 @@
+export const BundledMessages = {
+  ホーム: 'ホーム',
+  チーム名: 'チーム名',
+  'validation.required': '{0}を入力してください。',
+  'msg.error.ネットワーク': 'ページの表示中にエラーが発生しました。ネットワーク環境を確認してください。',
+} as const;
+
+export type BundledMessagesType = typeof BundledMessages;
+export type MessageKey = keyof typeof BundledMessages;

--- a/example-app/SantokuApp/src/generated/BundledMessages.ts
+++ b/example-app/SantokuApp/src/generated/BundledMessages.ts
@@ -1,9 +1,9 @@
-export const BundledMessages = {
+export const bundledMessages = {
   ホーム: 'ホーム',
   チーム名: 'チーム名',
   'validation.required': '{0}を入力してください。',
   'msg.error.ネットワーク': 'ページの表示中にエラーが発生しました。ネットワーク環境を確認してください。',
 } as const;
 
-export type BundledMessagesType = typeof BundledMessages;
-export type MessageKey = keyof typeof BundledMessages;
+export type BundledMessagesType = typeof bundledMessages;
+export type MessageKey = keyof typeof bundledMessages;

--- a/example-app/SantokuApp/src/navigation/DemoStackNav.tsx
+++ b/example-app/SantokuApp/src/navigation/DemoStackNav.tsx
@@ -13,6 +13,7 @@ import {
   ErrorInNativeModuleScreen,
   InstructionsScreen,
   AppInfoScreen,
+  MessageScreen,
 } from 'screens';
 
 import {useCloseThisNavigatorButton} from './useCloseThisNavigatorButton';
@@ -45,6 +46,7 @@ export const Screen: React.FC = () => {
       <nav.Screen {...ErrorInUseEffectScreen} />
       <nav.Screen {...ErrorInUseEffectSyncProcessScreen} />
       <nav.Screen {...InstructionsScreen} />
+      <nav.Screen {...MessageScreen} />
     </nav.Navigator>
   );
 };

--- a/example-app/SantokuApp/src/screens/demo/DemoScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/DemoScreen.tsx
@@ -8,6 +8,7 @@ import {ConfigScreen} from './config';
 import {ErrorCaseScreen} from './error';
 import {AppInfoScreen} from './info';
 import {InstructionsScreen} from './instructions';
+import {MessageScreen} from './message';
 
 const demoScreenList = [
   {
@@ -29,6 +30,10 @@ const demoScreenList = [
   {
     title: 'Configuration',
     to: ConfigScreen.name,
+  },
+  {
+    title: 'Message',
+    to: MessageScreen.name,
   },
 ];
 

--- a/example-app/SantokuApp/src/screens/demo/index.ts
+++ b/example-app/SantokuApp/src/screens/demo/index.ts
@@ -3,4 +3,5 @@ export * from './config';
 export * from './error';
 export * from './info';
 export * from './instructions';
+export * from './message';
 export * from './DemoScreen';

--- a/example-app/SantokuApp/src/screens/demo/message/MessageListItem.tsx
+++ b/example-app/SantokuApp/src/screens/demo/message/MessageListItem.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {Text, View} from 'react-native';
+import {ListItem} from 'react-native-elements';
+
+export type MessageItemData = {
+  name?: string;
+  value: string | null;
+};
+
+type MessageListItemProps = {
+  item: MessageItemData;
+};
+
+export const MessageListItem: React.FC<MessageListItemProps> = ({item}) => {
+  return !item.name ? null : (
+    <ListItem bottomDivider>
+      <ListItem.Content>
+        <ListItem.Title>
+          <Text>{item.name}</Text>
+        </ListItem.Title>
+        <View style={{marginTop: 10, marginLeft: 10}}>
+          <Text>{item.value}</Text>
+        </View>
+      </ListItem.Content>
+    </ListItem>
+  );
+};

--- a/example-app/SantokuApp/src/screens/demo/message/MessageScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/message/MessageScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import {MessageTemplate} from './MessageTemplate';
+import {useMessage} from './useMessage';
+
+const ScreenName = 'Message';
+const Screen: React.FC = () => {
+  const {info, infoKeyExtractor} = useMessage();
+  return <MessageTemplate testID="MessageScreen" items={info} keyExtractor={infoKeyExtractor} />;
+};
+
+export const MessageScreen = {
+  name: ScreenName,
+  component: Screen,
+  options: {
+    title: 'Message',
+  },
+};

--- a/example-app/SantokuApp/src/screens/demo/message/MessageTemplate.tsx
+++ b/example-app/SantokuApp/src/screens/demo/message/MessageTemplate.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import {FlatList} from 'react-native';
+
+import {MessageItemData, MessageListItem} from './MessageListItem';
+
+type MessageTemplateProps = {
+  items: MessageItemData[];
+  keyExtractor: (item: MessageItemData, index: number) => string;
+  testID?: string;
+};
+
+export const MessageTemplate: React.FC<MessageTemplateProps> = ({items, keyExtractor, testID}) => {
+  return <FlatList data={items} renderItem={MessageListItem} keyExtractor={keyExtractor} testID={testID} />;
+};

--- a/example-app/SantokuApp/src/screens/demo/message/index.ts
+++ b/example-app/SantokuApp/src/screens/demo/message/index.ts
@@ -1,0 +1,1 @@
+export * from './MessageScreen';

--- a/example-app/SantokuApp/src/screens/demo/message/useMessage.tsx
+++ b/example-app/SantokuApp/src/screens/demo/message/useMessage.tsx
@@ -1,0 +1,23 @@
+import {m} from 'framework';
+
+const infoKeyExtractor = (_: unknown, index: number) => index.toString();
+
+export const useMessage = () => {
+  return {
+    info: [
+      {
+        name: 'ホーム',
+        value: m('ホーム'),
+      },
+      {
+        name: 'validation.required',
+        value: m('validation.required', m('チーム名')),
+      },
+      {
+        name: 'msg.error.ネットワーク',
+        value: m('msg.error.ネットワーク'),
+      },
+    ],
+    infoKeyExtractor,
+  };
+};


### PR DESCRIPTION
## ✅ What's done

- [x] メッセージをロード、取得する部品の追加
- [x] 作成した部品を使用するデモ画面の追加

---

## Tests

- [x] 自動テスト
- [x] メッセージを取得するデモ画面を打鍵

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone 11/iOS 15)
- [x] Android
  - [x] エミュレータ (Pixel 4a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし