### PR TITLE
🩹: Lintなどの実行自体が失敗したときにも、ビルド失敗として扱われるように修正

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -77,23 +77,22 @@ jobs:
           reviewdog_version: latest
 
       - name: Lint (ESLint)
-        continue-on-error: true
         run: |
           cd example-app/SantokuApp && npm run -s lint:es -- -f eslint-formatter-rdjson | reviewdog -tee -fail-on-error -reporter=github-check -f=rdjson -name="ESLint (SantokuApp)"
 
       - name: Lint (TypeScript)
-        continue-on-error: true
+        if: always()
         run: |
           cd example-app/SantokuApp && npm run -s lint:tsc | reviewdog -tee -fail-on-error -reporter=github-check -f=tsc -name="TypeScript (SantokuApp)"
 
       - name: Test
-        continue-on-error: true
+        if: always()
         run: |
           npm run -s test --prefix example-app/SantokuApp -- --ci --reporters=default --reporters=jest-junit --coverage
 
       - name: Archive workflow results
         uses: actions/upload-artifact@v2
-        continue-on-error: true
+        if: always()
         with:
           name: workflow-results
           path: |

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -67,27 +67,26 @@ jobs:
       # In the case of reviewdog, the result of the lint error is determined based on the current directory.
       # So, use cd instead of --prefix to move the current directory.
       - name: Lint (textlint)
-        continue-on-error: true
         run: |
           cd website && npm run -s lint:text -- -f checkstyle | reviewdog -tee -fail-on-error -reporter=github-check -f=checkstyle -name="textlint (GitHub Pages)"
 
       - name: Lint (markdownlint)
-        continue-on-error: true
+        if: always()
         run: |
           cd website && npm run -s lint:md 2>&1 | sed -e 's/^/e:/' | reviewdog -tee -fail-on-error -reporter=github-check -efm="%t:%f:%l:%c %m" -efm="%t:%f:%l %m" -name="markdownlint (GitHub Pages)"
 
       - name: Lint (ESLint)
-        continue-on-error: true
+        if: always()
         run: |
           cd website && npm run -s lint:es -- -f eslint-formatter-rdjson | reviewdog -tee -fail-on-error -reporter=github-check -f=rdjson -name="ESLint (GitHub Pages)"
 
       - name: Lint (TypeScript)
-        continue-on-error: true
+        if: always()
         run: |
           cd website && npm run -s lint:tsc | reviewdog -tee -fail-on-error -reporter=github-check -f=tsc -name="TypeScript (GitHub Pages)"
 
       - name: Lint (stylelint)
-        continue-on-error: true
+        if: always()
         run: |
           cd website && npm run -s lint:css | reviewdog -tee -fail-on-error -reporter=github-check -f=stylelint -name="stylelint (GitHub Pages)"
 


### PR DESCRIPTION
## ✅ What's done

- [x] `continue-on-error`はコマンドの実行が失敗してもステップは成功として扱うので、代わりに`always`を使うように修正 
---

## Tests

- [ ] GitHub Actionsで正常に実行できること
- [ ] 途中でLintコマンドの実行に失敗しても、後続のLintは実行されること

## Other (messages to reviewers, concerns, etc.)

なし