### PR TITLE
📌: expo-randomをrenovateの管理対象から除外

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,7 @@
         'expo-keep-awake',
         'expo-splash-screen',
         'expo-updates',
+        'expo-random',
         'react',
         'react-dom',
         'react-native',


### PR DESCRIPTION
## ✅ What's done

- [x] Expoのアップデート時にバージョンアップするため、expo-randomはrenovateの管理対象から除外

---

## Other (messages to reviewers, concerns, etc.)

なし
