### PR TITLE
✨: メッセージ取得時に、同じプレースホルダが複数存在した場合は、全て置換するように変更

### DIFF
--- a/example-app/SantokuApp/src/framework/message/Message.test.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.test.ts
@@ -22,13 +22,19 @@ describe('Message message', () => {
     await loadMessages({
       load: async () => {
         return new Promise((resolve) => {
-          // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
-          resolve({'validation.required': '{0}を入力してください。'});
+          resolve({
+            // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+            'validation.required': '{0}を入力してください。',
+            // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+            'validation.max': '{0}が長すぎます。{0}は{1}桁以内で入力してください。',
+          });
         });
       },
     });
     // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required', 'name')).toEqual('nameを入力してください。');
+    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    expect(m('validation.max', 'name', 10)).toEqual('nameが長すぎます。nameは10桁以内で入力してください。');
     // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required')).toEqual('{0}を入力してください。');
   });

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -61,7 +61,7 @@ function message(key: MessageKey, ...options: string[]): string {
  */
 function format(message: string, options: string[]): string {
   return options.reduce((message, option, index) => {
-    return message.replaceAll(`{${index}}`, option);
+    return message.replace(new RegExp(`\\{${index}\\}`, 'g'), option);
   }, message);
 }
 

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -61,7 +61,7 @@ function message(key: MessageKey, ...options: string[]): string {
  */
 function format(message: string, options: string[]): string {
   return options.reduce((message, option, index) => {
-    return message.replace(`{${index}}`, option);
+    return message.replace(new RegExp(`\\{${index}\\}`, 'g'), option);
   }, message);
 }
 

--- a/example-app/SantokuApp/src/framework/message/Message.ts
+++ b/example-app/SantokuApp/src/framework/message/Message.ts
@@ -61,7 +61,7 @@ function message(key: MessageKey, ...options: string[]): string {
  */
 function format(message: string, options: string[]): string {
   return options.reduce((message, option, index) => {
-    return message.replace(new RegExp(`\\{${index}\\}`, 'g'), option);
+    return message.replaceAll(`{${index}}`, option);
   }, message);
 }
 


### PR DESCRIPTION
## ✅ What's done

- [x] メッセージ取得時に、同じプレースホルダが複数存在した場合は、指定されたオプション値で全て置換するように変更

---

## Tests

- [x] 自動テスト
  - [x] 同じプレースホルダが複数存在するケースを追加
- [x] デモ画面を打鍵

## Devices

- [ ] iOS
  - [x] シミュレータ (iPhone 11/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 4a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

https://github.com/ws-4020/mobile-app-crib-notes/discussions/573 の対応
