### PR TITLE
✏️: Google Playの商標を追記

### DIFF
--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -12,7 +12,7 @@ title: 商標について
 - 「Apple」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「Xcode」「App Store」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->  
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
-- 「Google Chrome」「Android」「Flutter」「Firebase」は、 Google LLCの登録商標です。
+- 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」は、 Google LLCの登録商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->
 - 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->


### PR DESCRIPTION
## ✅ What's done

- [x] `Google Play`が商標になかったので追加

---

## Tests

- [x] `lint`を実行して、文言の確認
- [x] `npm start`を実行して、ブラウザで確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [x] Windows 10
  - [x] Chrome

## Other (messages to reviewers, concerns, etc.)

なし
