### PR TITLE
🔨: テスト用のスクリプト追加

### DIFF
--- a/example-app/SantokuApp/.gitignore
+++ b/example-app/SantokuApp/.gitignore
@@ -56,6 +56,7 @@ web-build/
 
 # Jest
 jest-junit.xml
+/coverage
 
 # Local environmental variables
 ios/PersonalAccount.xcconfig

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -7,6 +7,8 @@
     "web": "expo start --web",
     "start": "react-native start",
     "test": "jest --detectOpenHandles --runInBand",
+    "test:coverage": "jest --detectOpenHandles --runInBand --coverage",
+    "test:report": "jest --detectOpenHandles --runInBand --reporters=default --reporters=jest-junit --coverage",
     "lint": "run-s --print-name --continue-on-error lint:*",
     "lint:es": "eslint --ext .jsx,.js,.tsx,.ts .",
     "lint:tsc": "tsc --noEmit",


### PR DESCRIPTION
## ✅ What's done

- [x] jestを使った単体テスト用のスクリプトを追加
  - [x] カバレッジ表示
  - [x] カバレッジ表示＋レポート出力
- [x] coverageフォルダがgit管理対象外になるよう、`.gitignore`を更新

---

## Tests

- [x] 追加したスクリプトでカバレッジ表示とレポート出力ができていること
- [x] coverageフォルダがgit管理対象外となっていること

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Other (messages to reviewers, concerns, etc.)

なし