### PR TITLE
🎨: 各画面のヘッダタイトルをMessageLoaderから取得するように変更

### DIFF
--- a/example-app/SantokuApp/src/screens/account/TermsOfServiceAgreementScreen.tsx
+++ b/example-app/SantokuApp/src/screens/account/TermsOfServiceAgreementScreen.tsx
@@ -87,9 +87,9 @@ const styles = StyleSheet.create({
 export const TermsOfServiceAgreementScreen = {
   component: Screen,
   name: ScreenName,
-  options: {
+  options: () => ({
     headerShown: true,
-    title: '利用規約',
+    title: m('利用規約'),
     presentation: 'formSheet' as const,
-  },
+  }),
 };

--- a/example-app/SantokuApp/src/screens/home/HomeScreen.tsx
+++ b/example-app/SantokuApp/src/screens/home/HomeScreen.tsx
@@ -1,3 +1,4 @@
+import {m} from 'framework';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {Text} from 'react-native-elements';
@@ -23,7 +24,7 @@ const styles = StyleSheet.create({
 export const HomeScreen = {
   component: Screen,
   name: ScreenName,
-  options: {
-    title: 'ホーム',
-  },
+  options: () => ({
+    title: m('ホーム'),
+  }),
 };

--- a/example-app/SantokuApp/src/screens/team/TeamDetailScreen.tsx
+++ b/example-app/SantokuApp/src/screens/team/TeamDetailScreen.tsx
@@ -1,3 +1,4 @@
+import {m} from 'framework';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {Button, Text} from 'react-native-elements';
@@ -26,7 +27,7 @@ const styles = StyleSheet.create({
 export const TeamDetailScreen = {
   component: Screen,
   name: ScreenName,
-  options: {
-    title: 'チーム詳細',
-  },
+  options: () => ({
+    title: m('チーム詳細'),
+  }),
 };


### PR DESCRIPTION
## ✅ What's done

- [x] 利用規約画面、ホーム画面、チーム詳細画面のヘッダタイトルをMessageLoaderから取得するように変更

## ⏸ What's not done

- デモ画面のヘッダタイトルは固定文字列のまま変更無し。

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] 利用規約画面、ホーム画面、チーム詳細画面のヘッダタイトルが変更前と同様に表示されることを確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
