### PR TITLE
⬆: Migrate React Navigation from v5 to v6 in the learning content

### DIFF
--- a/website/docs/react-native/learn/advance/react-navigation-param.mdx
+++ b/website/docs/react-native/learn/advance/react-navigation-param.mdx
@@ -135,7 +135,7 @@ const MainStack = createStackNavigator();
 export const App = () => {
   return (
     <NavigationContainer>
-      <RootStack.Navigator mode="modal" screenOptions={{headerShown: false}}>
+      <RootStack.Navigator screenOptions={{headerShown: false, presentation: 'modal'}}>
         <RootStack.Screen name="MainStack" component={Main} />
         <RootStack.Screen name="Modal1" component={Modal1} />
       </RootStack.Navigator>

--- a/website/docs/react-native/learn/basic-concepts/react-navigation-basics/modal.mdx
+++ b/website/docs/react-native/learn/basic-concepts/react-navigation-basics/modal.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 モーダルは、メインコンテンツを一時的にブロックして別のコンテンツを表示します。ポップアップと似たような性質を持ち、通常の画面遷移とは異なる方法でコンテンツを表示します。
 
 モーダル画面のナビゲータ定義にも`StackNavigator`を用います。
-`StackNavigator`の`mode`プロパティに`'modal'`を指定すると、モーダル表示の画面アニメーションが実現できます。
+`StackNavigator`の`screenOptions.presentation`プロパティに`'modal'`を指定すると、モーダル表示の画面アニメーションが実現できます。
 
 ## ネストされたナビゲータ
 
@@ -28,7 +28,7 @@ const MainStack = createStackNavigator();
 export const App = () => {
   return (
     <NavigationContainer>
-      <RootStack.Navigator mode="modal" screenOptions={{headerShown: false}}>
+      <RootStack.Navigator screenOptions={{headerShown: false, presentation: 'modal'}}>
         <RootStack.Screen name="MainStack" component={Main} />
         <RootStack.Screen name="Modal1" component={Modal1} />
       </RootStack.Navigator>
@@ -46,7 +46,7 @@ const Main = () => {
 };
 ```
 
-`RootStack.Navigator`タグの中で`mode`プロパティに`'modal'`を指定しています。
+`RootStack.Navigator`タグの中で`screenOptions.presentation`プロパティに`'modal'`を指定しています。
 これにより、`Modal1`への画面遷移はモーダル表示のアニメーションとなります。
 
 :::note
@@ -54,7 +54,7 @@ React Navigation公式ドキュメントの[Opening a full-screen modal](https:/
 > The modal prop has no effect on Android because full-screen modals don't have any different transition behavior on the platform.
 
 画面遷移アニメーションは、各プラットフォームのネイティブ動作に従います。
-上記のとおり、Androidのフルスクリーンモーダルには異なるトランジションが用意されていないため、`mode`属性の変更によるアニメーションの変更はありません。
+上記のとおり、Androidのフルスクリーンモーダルには異なるトランジションが用意されていないため、`presentation`属性の変更によるアニメーションの変更はありません。
 :::
 
 ネストされたナビゲータは次のように動作します。
@@ -99,7 +99,7 @@ const MainStack = createStackNavigator();
 export const App = () => {
   return (
     <NavigationContainer>
-      <RootStack.Navigator mode="modal" screenOptions={{headerShown: false}}>
+      <RootStack.Navigator screenOptions={{headerShown: false, presentation: 'modal'}}>
         <RootStack.Screen name="MainStack" component={Main} />
         <RootStack.Screen name="Modal1" component={Modal1} />
       </RootStack.Navigator>
@@ -186,3 +186,9 @@ const styles = StyleSheet.create({
 
 </TabItem>
 </Tabs>
+
+:::info
+React Navigation v5では、画面単位ではモーダル表示を設定できず、モーダル表示のために専用のナビゲータが必要でした。v6で導入された[`Group`](https://reactnavigation.org/docs/group/)を使うことで、モーダル表示の画面と非モーダル表示の画面を、両方とも同じナビゲータの中に配置できるようになっています。
+
+`Group`を使ったモーダル表示の方法については、[Opening a full-screen modal \| React Navigation](https://reactnavigation.org/docs/modal/)を参照してください。
+:::

--- a/website/docs/react-native/learn/todo-app/screens/modal.mdx
+++ b/website/docs/react-native/learn/todo-app/screens/modal.mdx
@@ -6,7 +6,7 @@ title: Modalスクリーン
 
 ![ModalScreen](../app-hands-on/screen-transition-modal.png)
 
-モーダルはStackナビゲータの`mode`属性（デフォルトは`card`）を`modal`に変更することで実現できます。
+モーダルはStackナビゲータの`screenOptions.presentation`属性（デフォルトは`card`）を`modal`に変更することで実現できます。
 画面遷移時のアニメーションの振る舞いが変わります。
 
 ## 画面を追加
@@ -123,11 +123,11 @@ ToDo一覧からToDo登録画面に遷移できるようにナビゲーション
 では`TodoForm`がモーダルになるように実装しましょう。
 `AuthedStackNav`ナビゲータに次の修正を加えます。
 
-1. Stackナビゲータの`mode`属性を`modal`に変更
+1. Stackナビゲータの`screenOptions.presentation`属性を`modal`に変更
 1. ヘッダの右にクローズボタンを追加
 1. ヘッダの背景を非表示（`headerTransparent`を`true`に設定）
 
-まずは、`AuthedStackNav`ナビゲータの`mode`属性を`modal`に変更します。
+まずは、`AuthedStackNav`ナビゲータの`screenOptions.presentation`属性を`modal`に変更します。
 
 ```diff title="/src/navigation/AuthedStackNav.tsx"
   import {createStackNavigator} from '@react-navigation/stack';
@@ -139,7 +139,7 @@ ToDo一覧からToDo登録画面に遷移できるようにナビゲーション
   export const AuthedStackNav: React.FC = () => {
     return (
 -     <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main">
-+     <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
++     <nav.Navigator screenOptions={{headerShown: false, presentation: 'modal'}} initialRouteName="Main">
         <nav.Screen name="Main" component={MainTabNav} />
         <nav.Screen
           name="TodoForm"
@@ -182,7 +182,7 @@ ToDo一覧からToDo登録画面に遷移できるようにナビゲーション
   const nav = createStackNavigator();
   export const AuthedStackNav: React.FC = () => {
     return (
-      <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
+      <nav.Navigator screenOptions={{headerShown: false, presentation: 'modal'}} initialRouteName="Main">
         <nav.Screen name="Main" component={MainTabNav} />
         <nav.Screen
           name="TodoForm"
@@ -205,7 +205,7 @@ ToDo一覧からToDo登録画面に遷移できるようにナビゲーション
   
   export const AuthedStackNav: React.FC = () => {
     return (
-      <nav.Navigator screenOptions={{headerShown: false}} initialRouteName="Main" mode="modal">
+      <nav.Navigator screenOptions={{headerShown: false, presentation: 'modal'}} initialRouteName="Main">
         <nav.Screen name="Main" component={MainTabNav} />
         <nav.Screen
           name="TodoForm"


### PR DESCRIPTION
## ✅ What's done

- [x] Change to use `screenOptions.presentation='modal'` instead of `mode='modal'` to enable modal animation.
---

## Tests

- [ ] 該当ページのコンテンツを実際に動作させて正しくモーダル表示になることを確認

## Devices

- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

RN Spoiler側の修正は別途PRを作成します。