### PR TITLE
🐛: サインアップ後はアクティブアカウントIDをセキュアストレージに保存しないように修正

### DIFF
--- a/example-app/SantokuApp/ios/Podfile.lock
+++ b/example-app/SantokuApp/ios/Podfile.lock
@@ -657,7 +657,7 @@ SPEC CHECKSUMS:
   EXSecureStore: 919bf7c28472862020d2cd7b59b69aae160b5d40
   EXSplashScreen: 57f329dbf25c5c12800feed79068a056453dc772
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
-  FBReactNativeSpec: 6024a4ecd701cff27d7a779e62a2cda5bd331b52
+  FBReactNativeSpec: 833169fdb77d25ebb7891d8b30f931ebfc70b6b0
   Firebase: 629510f1a9ddb235f3a7c5c8ceb23ba887f0f814
   FirebaseCore: 98b29e3828f0a53651c363937a7f7d92a19f1ba2
   FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34

--- a/example-app/SantokuApp/src/framework/authentication/AuthenticationService.test.ts
+++ b/example-app/SantokuApp/src/framework/authentication/AuthenticationService.test.ts
@@ -13,12 +13,10 @@ describe('AuthnService signup', () => {
       headers: {},
       config: {},
     });
-    const spySecureStorageAdapterSaveActiveAccountId = jest.spyOn(SecureStorageAdapter, 'saveActiveAccountId');
     const spySecureStorageAdapterSavePassword = jest.spyOn(SecureStorageAdapter, 'savePassword');
     const res = await AuthnService.signup('testNickName', 'password123');
     expect(res).toEqual({accountId: '123456789', profile: {nickname: 'testNickName'}});
     expect(spySignupApi).toHaveBeenCalledWith({nickname: 'testNickName', password: 'password123'});
-    expect(spySecureStorageAdapterSaveActiveAccountId).toHaveBeenCalledWith('123456789');
     expect(spySecureStorageAdapterSavePassword).toHaveBeenCalledWith('123456789', 'password123');
   });
 });

--- a/example-app/SantokuApp/src/framework/authentication/AuthenticationService.ts
+++ b/example-app/SantokuApp/src/framework/authentication/AuthenticationService.ts
@@ -17,10 +17,7 @@ export class PasswordNotFoundError extends ApplicationError {}
 async function signup(nickname: string, password: string): Promise<Account> {
   const res = await accountApi.postSignup({nickname, password});
   const accountId = res.data.accountId;
-  await Promise.all([
-    SecureStorageAdapter.saveActiveAccountId(accountId),
-    SecureStorageAdapter.savePassword(accountId, password),
-  ]);
+  await SecureStorageAdapter.savePassword(accountId, password);
   return res.data;
 }
 


### PR DESCRIPTION


## ✅ What's done

- [x] サインアップ後はアクティブアカウントIDをセキュアストレージに保存しないように修正
- [x] Podfile.lockを最新化

---

## Tests

- [x] 自動テスト
- [x] デモ画面の打鍵

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 4a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

サインアップしてもsantoku-app-backendからセッションが払い出されてるわけではない（ログインしてない）のでアクティブアカウントIDをセキュアストレージに保存しないように変更しました

