### PR TITLE
🩹: Fix Apple OS names

### DIFF
--- a/website/docs/react-native/santoku/requirements/non-functional/usability.mdx
+++ b/website/docs/react-native/santoku/requirements/non-functional/usability.mdx
@@ -51,7 +51,7 @@ React Nativeを用いたモバイルアプリケーション開発を初めて�
 - iPadOS
 
 Google系OSについてはAndroidのみを対象とし、スマートウォッチ向けのWear OSやTV向けのAndroid TVは対象外とします。
-Apple系OSについてはiOSおよびiPadOSを対象とし、Mac OSとApple Watch OSおよびTv OSは対象外とします。
+Apple系OSについてはiOSおよびiPadOSを対象とし、macOSとwatchOSおよびtvOSは対象外とします。
 
 #### 配信対象OSバージョン
 


### PR DESCRIPTION
## ✅ What's done

- [x] Apple系のOS名を修正
---

## Tests

- [x] `tv`, `watch`, `mac`で検索し、同様の誤記がないことを確認

## Other (messages to reviewers, concerns, etc.)

なし