### PR TITLE
🚩: リリースモードでもデモ画面を表示できるように変更

### DIFF
--- a/example-app/SantokuApp/src/navigation/RootStackNav.tsx
+++ b/example-app/SantokuApp/src/navigation/RootStackNav.tsx
@@ -18,7 +18,7 @@ export const RootStackNav: React.FC = () => {
       {...navigatorOptions[name]}>
       <nav.Screen {...TermsOfServiceAgreementScreen} />
       <nav.Screen {...AuthenticatedStackNav} />
-      {__DEV__ && <nav.Screen {...DemoStackNav} />}
+      <nav.Screen {...DemoStackNav} />
     </nav.Navigator>
   );
 };

--- a/example-app/SantokuApp/src/screens/team/TeamDetailScreen.tsx
+++ b/example-app/SantokuApp/src/screens/team/TeamDetailScreen.tsx
@@ -11,7 +11,7 @@ const Screen: React.FC = () => {
   return (
     <View style={styles.container} testID="TeamDetailScreen">
       <Text h2>開発中</Text>
-      {__DEV__ && <Button title="Go to Demo" onPress={onGoToDemoScreen} />}
+      <Button title="Go to Demo" onPress={onGoToDemoScreen} />
     </View>
   );
 };


### PR DESCRIPTION
## ✅ What's done

- [x] ビルドタイプがReleaseInHouse / Releaseでもデモ画面を表示するように変更

---


## Tests

- [x] デモ画面が表示されるかを打鍵で確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

新しい方式の検証とかで、リリースモードでもデモ画面を使用したいため、このPRを上げました。
