### PR TITLE
🚑: azure pipelineで使用しているRubyのバージョンを3.0.xを使用するように変更

### DIFF
--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -54,7 +54,7 @@ stages:
       steps:
       - task: UseRubyVersion@0
         inputs:
-          versionSpec: '>= 3.0.x'
+          versionSpec: '3.0.x'
           addToPath: true
       - task: NodeTool@0
         displayName: 'Use Node.js 16.13.0'
@@ -144,7 +144,7 @@ stages:
       steps:
       - task: UseRubyVersion@0
         inputs:
-          versionSpec: '>= 3.0.x'
+          versionSpec: '3.0.x'
           addToPath: true
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{buildVariant.name}}'

--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -142,11 +142,15 @@ stages:
       pool:
         vmImage: macOS-11
       steps:
+      - task: UseRubyVersion@0
+        inputs:
+          versionSpec: '>= 3.0'
+          addToPath: true
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{buildVariant.name}}'
         inputs:
           certSecureFile: $(apple_DevelopmentCertificateSecureFileName)
-        certPwd: $(apple_DevelopmentCertificatePassword)
+          certPwd: $(apple_DevelopmentCertificatePassword)
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{buildVariant.name}}'
         inputs:

--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -52,6 +52,10 @@ stages:
       pool:
         vmImage: macOS-11
       steps:
+      - task: UseRubyVersion@0
+        inputs:
+          versionSpec: '>= 3.0'
+          addToPath: true
       - task: NodeTool@0
         displayName: 'Use Node.js 16.13.0'
         inputs:
@@ -142,7 +146,7 @@ stages:
         displayName: 'Install an Apple certificate for ${{buildVariant.name}}'
         inputs:
           certSecureFile: $(apple_DevelopmentCertificateSecureFileName)
-          certPwd: $(apple_DevelopmentCertificatePassword)
+        certPwd: $(apple_DevelopmentCertificatePassword)
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{buildVariant.name}}'
         inputs:

--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -54,7 +54,7 @@ stages:
       steps:
       - task: UseRubyVersion@0
         inputs:
-          versionSpec: '>= 3.0'
+          versionSpec: '>= 3.0.x'
           addToPath: true
       - task: NodeTool@0
         displayName: 'Use Node.js 16.13.0'
@@ -144,7 +144,7 @@ stages:
       steps:
       - task: UseRubyVersion@0
         inputs:
-          versionSpec: '>= 3.0'
+          versionSpec: '>= 3.0.x'
           addToPath: true
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{buildVariant.name}}'


### PR DESCRIPTION
## ✅ What's done

- [x] azure pipelineで使用しているRubyのバージョンを3.0.xを使用するように変更

---

## Tests

- [x] 実際にdeployする

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse


## Other (messages to reviewers, concerns, etc.)

↓を参考にしました。
https://docs.microsoft.com/ja-jp/azure/devops/pipelines/ecosystems/ruby?view=azure-devops#use-a-specific-ruby-version
