### PR TITLE
✨: セキュアストレージに保存する際のオプションをWHEN_UNLOCKEDに変更

### DIFF
--- a/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.test.ts
+++ b/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.test.ts
@@ -9,7 +9,7 @@ describe('SecureStorageAdapter saveActiveAccountId', () => {
     await SecureStorageAdapter.saveActiveAccountId('1234567890');
 
     expect(spy).toHaveBeenCalledWith('activeAccountId', '1234567890', {
-      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      keychainAccessible: SecureStore.WHEN_UNLOCKED,
     });
   });
 });
@@ -21,7 +21,7 @@ describe('SecureStorageAdapter savePassword', () => {
     await SecureStorageAdapter.savePassword('1234567890', 'password');
 
     expect(spySecureStore).toHaveBeenCalledWith('abcdef_password', 'password', {
-      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      keychainAccessible: SecureStore.WHEN_UNLOCKED,
     });
     expect(spyCrypto).toHaveBeenCalledWith('1234567890');
   });

--- a/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
+++ b/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
@@ -7,6 +7,9 @@ const STORED_ITEM_KEYS = {
   PASSWORD: 'password',
 } as const;
 
+// https://github.com/ws-4020/mobile-app-crib-notes/pull/640#issuecomment-984500781
+const KEY_CHAIN_ACCESSIBILITY = SecureStore.WHEN_UNLOCKED;
+
 /**
  * 指定されたアカウントIDを、アクティブなアカウントとしてセキュアストレージに格納します。
  * セキュアストレージに格納する際のオプションとして、以下を指定します。

--- a/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
+++ b/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
@@ -20,7 +20,7 @@ const KEY_CHAIN_ACCESSIBILITY = SecureStore.WHEN_UNLOCKED;
  */
 function saveActiveAccountId(accountId: string): Promise<void> {
   return SecureStore.setItemAsync(STORED_ITEM_KEYS.ACTIVE_ACCOUNT_ID, accountId, {
-    keychainAccessible: SecureStore.WHEN_UNLOCKED,
+    keychainAccessible: KEY_CHAIN_ACCESSIBILITY,
   });
 }
 

--- a/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
+++ b/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
@@ -10,14 +10,14 @@ const STORED_ITEM_KEYS = {
 /**
  * 指定されたアカウントIDを、アクティブなアカウントとしてセキュアストレージに格納します。
  * セキュアストレージに格納する際のオプションとして、以下を指定します。
- * ・keychainAccessible: {@link SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY}
+ * ・keychainAccessible: {@link SecureStore.WHEN_UNLOCKED}
  *
  * @param accountId アカウントID
  * @see {@link https://docs.expo.dev/versions/latest/sdk/securestore/#constants}
  */
 function saveActiveAccountId(accountId: string): Promise<void> {
   return SecureStore.setItemAsync(STORED_ITEM_KEYS.ACTIVE_ACCOUNT_ID, accountId, {
-    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    keychainAccessible: SecureStore.WHEN_UNLOCKED,
   });
 }
 
@@ -26,7 +26,7 @@ function saveActiveAccountId(accountId: string): Promise<void> {
  * 指定されたアカウントIDをSHA256でハッシュ化して、その値をキーとしてセキュアストレージに格納します。
  *
  * セキュアストレージに格納する際のオプションとして、以下を指定します。
- * ・keychainAccessible: {@link SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY}
+ * ・keychainAccessible: {@link SecureStore.WHEN_UNLOCKED}
  *
  * @param accountId アカウントID
  * @param password パスワード
@@ -36,7 +36,7 @@ async function savePassword(accountId: string, password: string): Promise<void> 
   // ログインに利用するような項目は平文で保存しないでハッシュ化します。
   const hash = await sha256(accountId);
   return SecureStore.setItemAsync(`${hash}_${STORED_ITEM_KEYS.PASSWORD}`, password, {
-    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    keychainAccessible: SecureStore.WHEN_UNLOCKED,
   });
 }
 

--- a/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
+++ b/example-app/SantokuApp/src/framework/authentication/SecureStorageAdapter.ts
@@ -39,7 +39,7 @@ async function savePassword(accountId: string, password: string): Promise<void> 
   // ログインに利用するような項目は平文で保存しないでハッシュ化します。
   const hash = await sha256(accountId);
   return SecureStore.setItemAsync(`${hash}_${STORED_ITEM_KEYS.PASSWORD}`, password, {
-    keychainAccessible: SecureStore.WHEN_UNLOCKED,
+    keychainAccessible: KEY_CHAIN_ACCESSIBILITY,
   });
 }
 


### PR DESCRIPTION
## ✅ What's done

- [x] `SecureStoreOptions.keychainAccessible`に設定する値を、WHEN_UNLOCKED_THIS_DEVICE_ONLY -> WHEN_UNLOCKEDに変更

---

## Tests

- [x] 自動テスト

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

変更した理由は以下を参照ください。
https://github.com/ws-4020/mobile-app-crib-notes/pull/640#issuecomment-984500781
