### PR TITLE
♻️: 認証部品のリファクタ

### DIFF
--- a/example-app/SantokuApp/src/framework/authentication/AuthenticationService.test.ts
+++ b/example-app/SantokuApp/src/framework/authentication/AuthenticationService.test.ts
@@ -1,10 +1,10 @@
-import {AuthnService} from '.';
+import {AuthenticationService} from '.';
 import {AccountLoginResponseStatusEnum} from '../../generated/api';
 import {accountApi} from '../backend';
 import {ActiveAccountIdNotFoundError, PasswordNotFoundError} from './AuthenticationService';
 import {SecureStorageAdapter} from './SecureStorageAdapter';
 
-describe('AuthnService signup', () => {
+describe('AuthenticationService signup', () => {
   test('サインアップAPIを呼び出して、クレデシャルをセキュアストレージに格納しているかの検証', async () => {
     const spySignupApi = jest.spyOn(accountApi, 'postSignup').mockResolvedValue({
       data: {accountId: '123456789', profile: {nickname: 'testNickName'}},
@@ -14,14 +14,14 @@ describe('AuthnService signup', () => {
       config: {},
     });
     const spySecureStorageAdapterSavePassword = jest.spyOn(SecureStorageAdapter, 'savePassword');
-    const res = await AuthnService.signup('testNickName', 'password123');
+    const res = await AuthenticationService.signup('testNickName', 'password123');
     expect(res).toEqual({accountId: '123456789', profile: {nickname: 'testNickName'}});
     expect(spySignupApi).toHaveBeenCalledWith({nickname: 'testNickName', password: 'password123'});
     expect(spySecureStorageAdapterSavePassword).toHaveBeenCalledWith('123456789', 'password123');
   });
 });
 
-describe('AuthnService changeAccount', () => {
+describe('AuthenticationService changeAccount', () => {
   const spyLoginApi = jest.spyOn(accountApi, 'postLogin').mockResolvedValue({
     data: {status: AccountLoginResponseStatusEnum.Complete},
     status: 200,
@@ -36,7 +36,7 @@ describe('AuthnService changeAccount', () => {
 
   test('セキュアストレージからパスワードを取得してログインAPIを呼び出しているかの検証', async () => {
     const spySecureStorageAdapter = jest.spyOn(SecureStorageAdapter, 'loadPassword').mockResolvedValue('password123');
-    const res = await AuthnService.changeAccount('123456789');
+    const res = await AuthenticationService.changeAccount('123456789');
     expect(res).toEqual({status: AccountLoginResponseStatusEnum.Complete});
     expect(spyLoginApi).toHaveBeenCalledWith({accountId: '123456789', password: 'password123'});
     expect(spySecureStorageAdapter).toHaveBeenCalledWith('123456789');
@@ -44,12 +44,12 @@ describe('AuthnService changeAccount', () => {
 
   test('セキュアストレージからパスワードを取得できなかった場合の検証', async () => {
     jest.spyOn(SecureStorageAdapter, 'loadPassword').mockResolvedValue(null);
-    const changeAccount = AuthnService.changeAccount('123456789');
+    const changeAccount = AuthenticationService.changeAccount('123456789');
     await expect(changeAccount).rejects.toThrowError(PasswordNotFoundError);
   });
 });
 
-describe('AuthnService autoLogin', () => {
+describe('AuthenticationService autoLogin', () => {
   const spyLoginApi = jest.spyOn(accountApi, 'postLogin').mockResolvedValue({
     data: {status: AccountLoginResponseStatusEnum.Complete},
     status: 200,
@@ -69,7 +69,7 @@ describe('AuthnService autoLogin', () => {
   test('セキュアストレージからクレデンシャルを取得してログインAPIを呼び出しているかの検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue('password123');
-    const res = await AuthnService.autoLogin();
+    const res = await AuthenticationService.autoLogin();
     expect(res).toEqual({status: AccountLoginResponseStatusEnum.Complete});
     expect(spyLoginApi).toHaveBeenCalledWith({accountId: '123456789', password: 'password123'});
     expect(spySecureStorageAdapterLoadActiveAccountId).toHaveBeenCalled();
@@ -78,19 +78,19 @@ describe('AuthnService autoLogin', () => {
 
   test('セキュアストレージからアクティブなアカウントIDを取得できなかった場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue(null);
-    const autoLogin = AuthnService.autoLogin();
+    const autoLogin = AuthenticationService.autoLogin();
     await expect(autoLogin).rejects.toThrowError(ActiveAccountIdNotFoundError);
   });
 
   test('セキュアストレージかパスワードを取得できなかった場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue(null);
-    const autoLogin = AuthnService.autoLogin();
+    const autoLogin = AuthenticationService.autoLogin();
     await expect(autoLogin).rejects.toThrowError(PasswordNotFoundError);
   });
 });
 
-describe('AuthnService canAutoLogin', () => {
+describe('AuthenticationService canAutoLogin', () => {
   const spySecureStorageAdapterLoadActiveAccountId = jest.spyOn(SecureStorageAdapter, 'loadActiveAccountId');
   const spySecureStorageAdapterLoadPassword = jest.spyOn(SecureStorageAdapter, 'loadPassword');
 
@@ -102,7 +102,7 @@ describe('AuthnService canAutoLogin', () => {
   test('セキュアストレージからクレデンシャルを取得できる場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue('password123');
-    const res = await AuthnService.canAutoLogin();
+    const res = await AuthenticationService.canAutoLogin();
     expect(res).toBeTruthy();
     expect(spySecureStorageAdapterLoadActiveAccountId).toHaveBeenCalled();
     expect(spySecureStorageAdapterLoadPassword).toHaveBeenCalledWith('123456789');
@@ -111,7 +111,7 @@ describe('AuthnService canAutoLogin', () => {
   test('セキュアストレージからアクティブなアカウントIDを取得できない場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue(null);
     spySecureStorageAdapterLoadPassword.mockResolvedValue(null);
-    const res = await AuthnService.canAutoLogin();
+    const res = await AuthenticationService.canAutoLogin();
     expect(res).toBeFalsy();
     expect(spySecureStorageAdapterLoadActiveAccountId).toHaveBeenCalled();
     expect(spySecureStorageAdapterLoadPassword).not.toHaveBeenCalled();
@@ -120,14 +120,14 @@ describe('AuthnService canAutoLogin', () => {
   test('セキュアストレージからパスワードを取得できない場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue(null);
-    const res = await AuthnService.canAutoLogin();
+    const res = await AuthenticationService.canAutoLogin();
     expect(res).toBeFalsy();
     expect(spySecureStorageAdapterLoadActiveAccountId).toHaveBeenCalled();
     expect(spySecureStorageAdapterLoadPassword).toHaveBeenCalledWith('123456789');
   });
 });
 
-describe('AuthnService refresh', () => {
+describe('AuthenticationService refresh', () => {
   const spyLoginApi = jest.spyOn(accountApi, 'postLogin').mockResolvedValue({
     data: {status: AccountLoginResponseStatusEnum.Complete},
     status: 200,
@@ -147,7 +147,7 @@ describe('AuthnService refresh', () => {
   test('セキュアストレージからクレデンシャルを取得してログインAPIを呼び出しているかの検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue('password123');
-    const res = await AuthnService.refresh();
+    const res = await AuthenticationService.refresh();
     expect(res).toEqual({status: AccountLoginResponseStatusEnum.Complete});
     expect(spyLoginApi).toHaveBeenCalledWith({accountId: '123456789', password: 'password123'});
     expect(spySecureStorageAdapterLoadActiveAccountId).toHaveBeenCalled();
@@ -156,19 +156,19 @@ describe('AuthnService refresh', () => {
 
   test('セキュアストレージからアクティブなアカウントIDを取得できなかった場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue(null);
-    const refresh = AuthnService.refresh();
+    const refresh = AuthenticationService.refresh();
     await expect(refresh).rejects.toThrowError(ActiveAccountIdNotFoundError);
   });
 
   test('セキュアストレージかパスワードを取得できなかった場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue(null);
-    const refresh = AuthnService.refresh();
+    const refresh = AuthenticationService.refresh();
     await expect(refresh).rejects.toThrowError(PasswordNotFoundError);
   });
 });
 
-describe('AuthnService logout', () => {
+describe('AuthenticationService logout', () => {
   const spyLogoutApi = jest.spyOn(accountApi, 'postLogout').mockResolvedValue({
     data: undefined,
     status: 200,
@@ -183,7 +183,7 @@ describe('AuthnService logout', () => {
     spySecureStorageAdapterDeleteActiveAccountId.mockClear();
   });
   test('ログアウトAPIを呼び出して、セキュアストレージからアクティブアカウントを削除しているかの検証', async () => {
-    await AuthnService.logout();
+    await AuthenticationService.logout();
     expect(spyLogoutApi).toHaveBeenCalled();
     expect(spySecureStorageAdapterDeleteActiveAccountId).toHaveBeenCalled();
   });

--- a/example-app/SantokuApp/src/framework/authentication/AuthenticationService.ts
+++ b/example-app/SantokuApp/src/framework/authentication/AuthenticationService.ts
@@ -87,7 +87,7 @@ async function logout(): Promise<void> {
   return SecureStorageAdapter.deleteActiveAccountId();
 }
 
-export const AuthnService = {
+export const AuthenticationService = {
   signup,
   changeAccount,
   canAutoLogin,

--- a/example-app/SantokuApp/src/framework/authentication/index.ts
+++ b/example-app/SantokuApp/src/framework/authentication/index.ts
@@ -1,1 +1,1 @@
-export {AuthnService, ActiveAccountIdNotFoundError, PasswordNotFoundError} from './AuthenticationService';
+export {AuthenticationService, ActiveAccountIdNotFoundError, PasswordNotFoundError} from './AuthenticationService';

--- a/example-app/SantokuApp/src/framework/index.ts
+++ b/example-app/SantokuApp/src/framework/index.ts
@@ -1,4 +1,4 @@
-export {AuthnService, ActiveAccountIdNotFoundError, PasswordNotFoundError} from './authentication';
+export {AuthenticationService, ActiveAccountIdNotFoundError, PasswordNotFoundError} from './authentication';
 export {systemApi, accountApi, termsApi, teamApi, csrfToken} from './backend';
 export {AppConfig} from './config';
 export {firebaseConfig, FirebaseConfig} from './firebase';

--- a/example-app/SantokuApp/src/screens/demo/authentication/AuthenticationScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/authentication/AuthenticationScreen.tsx
@@ -4,7 +4,7 @@ import {Button, Input, Text} from 'react-native-elements';
 
 import {useAuthentication} from './useAuthentication';
 
-const ScreenName = 'Authn';
+const ScreenName = 'Authentication';
 const Screen = () => {
   const {accountId, accountIdInput, setAccountIdInput, signup, changeAccount, canAutoLogin, autoLogin, logout} =
     useAuthentication();

--- a/example-app/SantokuApp/src/screens/demo/authentication/useAuthentication.tsx
+++ b/example-app/SantokuApp/src/screens/demo/authentication/useAuthentication.tsx
@@ -1,6 +1,6 @@
 import {
   ActiveAccountIdNotFoundError,
-  AuthnService,
+  AuthenticationService,
   csrfToken,
   generatePassword,
   PasswordNotFoundError,
@@ -17,9 +17,8 @@ export const useAuthentication = () => {
     try {
       await csrfToken();
       const password = await generatePassword();
-      const res = await AuthnService.signup('demoNickname', password);
+      const res = await AuthenticationService.signup('demoNickname', password);
       setAccountId(res.accountId);
-      await csrfToken();
       alert(`アカウントIDは${res.accountId}です`);
     } catch (e) {
       if (e instanceof ApiResponseError) {
@@ -33,7 +32,7 @@ export const useAuthentication = () => {
   const changeAccount = useCallback(async () => {
     try {
       await csrfToken();
-      const res = await AuthnService.changeAccount(accountIdInput);
+      const res = await AuthenticationService.changeAccount(accountIdInput);
       await csrfToken();
       alert(`ログイン成功しました state=${res.status}`);
     } catch (e) {
@@ -51,7 +50,7 @@ export const useAuthentication = () => {
 
   const canAutoLogin = useCallback(async () => {
     try {
-      const res = await AuthnService.canAutoLogin();
+      const res = await AuthenticationService.canAutoLogin();
       alert(res ? '自動ログイン可能です' : '自動ログインできません');
     } catch (e) {
       alert(e);
@@ -61,7 +60,7 @@ export const useAuthentication = () => {
   const autoLogin = useCallback(async () => {
     try {
       await csrfToken();
-      const res = await AuthnService.autoLogin();
+      const res = await AuthenticationService.autoLogin();
       await csrfToken();
       alert(`自動ログイン成功しました state=${res.status}`);
     } catch (e) {
@@ -83,7 +82,7 @@ export const useAuthentication = () => {
 
   const logout = useCallback(async () => {
     try {
-      await AuthnService.logout();
+      await AuthenticationService.logout();
       alert(`ログアウト成功しました`);
     } catch (e) {
       if (e instanceof ApiResponseError) {


### PR DESCRIPTION
## ✅ What's done

- [x] export名の変更。AuthnService -> AuthenticationService
- [x] 認証のデモ画面で、サインアップ成功後もCSRFトークンを取得していたので、削除

---

## Tests

- [x] デモ画面の打鍵

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 4a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし