### PR TITLE
🩹: iOSでアプリ起動時に警告メッセージが表示される事象の対応

### DIFF
--- a/example-app/SantokuApp/ios/SantokuApp/AppDelegate.m
+++ b/example-app/SantokuApp/ios/SantokuApp/AppDelegate.m
@@ -1,5 +1,12 @@
 #import "AppDelegate.h"
 
+// アプリ起動時に、以下の警告メッセージが表示されるため、RCTDevLoadingViewをimportします
+// 「RCTBridge required dispatch_sync to load RCTDevLoadingView. This may lead to deadlocks」
+// https://github.com/facebook/react-native/issues/16376
+#if RCT_DEV
+#import <React/RCTDevLoadingView.h>
+#endif
+
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
@@ -39,6 +46,14 @@ static void InitializeFlipper(UIApplication *application) {
 #endif
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+
+  // アプリ起動時に、以下の警告メッセージが表示されるため、RCTDevLoadingViewをロードします
+  // 「RCTBridge required dispatch_sync to load RCTDevLoadingView. This may lead to deadlocks」
+  // https://github.com/facebook/react-native/issues/16376
+  #if RCT_DEV
+    [bridge moduleForClass:[RCTDevLoadingView class]];
+  #endif
+
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
   if (rootViewBackgroundColor != nil) {


### PR DESCRIPTION
## ✅ What's done

- [x] iOSでアプリ起動時に「「RCTBridge required dispatch_sync to load RCTDevLoadingView. This may lead to deadlocks」という警告メッセージが表示される事象の対応

---

## Tests

- [x] iOSでアプリ起動

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

【関連issue】
https://github.com/facebook/react-native/issues/16376

【参考ドキュメント】
https://amanhimself.dev/blog/rctbridge-required-dispatch-sync-to-load-warning/
