### PR TITLE
🩹: Use relative paths for pod spec to keep checksum stable

### DIFF
--- a/example-app/SantokuApp/ios/Podfile.lock
+++ b/example-app/SantokuApp/ios/Podfile.lock
@@ -657,7 +657,7 @@ SPEC CHECKSUMS:
   EXSecureStore: 919bf7c28472862020d2cd7b59b69aae160b5d40
   EXSplashScreen: 57f329dbf25c5c12800feed79068a056453dc772
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
-  FBReactNativeSpec: 833169fdb77d25ebb7891d8b30f931ebfc70b6b0
+  FBReactNativeSpec: 289039c27ca26d02a6683c56c6fc7868bc804c43
   Firebase: 44213362f1dcc52555b935dc925ed35ac55f1b20
   FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
   FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18

--- a/example-app/SantokuApp/patches/README.md
+++ b/example-app/SantokuApp/patches/README.md
@@ -15,3 +15,11 @@ Xcode 13から、`xcodebuild`の実行時に常に`destination`が適切に指�
 > --- xcodebuild: WARNING: Using the first of multiple matching destinations:
 
 動作には特に問題はなかったですが、警告を放置するのは問題があるのでパッチを当てて対応しています。
+
+## Podfile.lockにdiffが出ないようにするパッチ
+
+React Native 0.64.3ではReact Nativeに含まれるPodのpodspecファイルが`pod install`した環境によって異なるという問題があります。この問題のため、`Podfile.lock`の内容も環境によって異なるものになってしまいます。
+
+[Diff in Podfile.lock when runs in different machines](https://github.com/facebook/react-native/issues/31121#issuecomment-802182459)
+
+[このコミット](https://github.com/facebook/react-native/commit/bdfe2a51791046c4e6836576e08655431373ed67)で解決されているようなので、内容をパッチとして取り込んでいます。

--- a/example-app/SantokuApp/patches/README.md
+++ b/example-app/SantokuApp/patches/README.md
@@ -18,8 +18,8 @@ Xcode 13から、`xcodebuild`の実行時に常に`destination`が適切に指�
 
 ## Podfile.lockにdiffが出ないようにするパッチ
 
-React Native 0.64.3ではReact Nativeに含まれるPodのpodspecファイルが`pod install`した環境によって異なるという問題があります。この問題のため、`Podfile.lock`の内容も環境によって異なるものになってしまいます。
+React Native 0.64.3ではReact Nativeに含まれるPodのpodspecの内容が`pod install`した環境によって異なるという問題があります。この問題のため、`Podfile.lock`の内容も環境によって異なるものになってしまいます。
 
 [Diff in Podfile.lock when runs in different machines](https://github.com/facebook/react-native/issues/31121#issuecomment-802182459)
 
-[このコミット](https://github.com/facebook/react-native/commit/bdfe2a51791046c4e6836576e08655431373ed67)で解決されているようなので、内容をパッチとして取り込んでいます。
+[このコミット](https://github.com/facebook/react-native/commit/bdfe2a51791046c4e6836576e08655431373ed67)で解決されているので、内容をパッチとして取り込んでいます。

--- a/example-app/SantokuApp/patches/react-native+0.64.3.patch
+++ b/example-app/SantokuApp/patches/react-native+0.64.3.patch
@@ -1,0 +1,142 @@
+diff --git a/node_modules/react-native/scripts/generate-specs.sh b/node_modules/react-native/scripts/generate-specs.sh
+index aed955e..b7096de 100755
+--- a/node_modules/react-native/scripts/generate-specs.sh
++++ b/node_modules/react-native/scripts/generate-specs.sh
+@@ -10,14 +10,14 @@
+ #
+ # Optionally, set these envvars to override defaults:
+ # - SRCS_DIR: Path to JavaScript sources
+-# - CODEGEN_MODULES_LIBRARY_NAME: Defaults to FBReactNativeSpec
+-# - CODEGEN_MODULES_OUTPUT_DIR: Defaults to React/$CODEGEN_MODULES_LIBRARY_NAME/$CODEGEN_MODULES_LIBRARY_NAME
+-# - CODEGEN_COMPONENTS_LIBRARY_NAME: Defaults to rncore
+-# - CODEGEN_COMPONENTS_OUTPUT_DIR: Defaults to ReactCommon/react/renderer/components/$CODEGEN_COMPONENTS_LIBRARY_NAME
++# - MODULES_LIBRARY_NAME: Defaults to FBReactNativeSpec
++# - MODULES_OUTPUT_DIR: Defaults to React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME
++# - COMPONENTS_LIBRARY_NAME: Defaults to rncore
++# - COMPONENTS_OUTPUT_DIR: Defaults to ReactCommon/react/renderer/components/$COMPONENTS_LIBRARY_NAME
+ #
+ # Usage:
+ #   ./scripts/generate-specs.sh
+-#   SRCS_DIR=myapp/js CODEGEN_MODULES_LIBRARY_NAME=MySpecs CODEGEN_MODULES_OUTPUT_DIR=myapp/MySpecs ./scripts/generate-specs.sh
++#   SRCS_DIR=myapp/js MODULES_LIBRARY_NAME=MySpecs MODULES_OUTPUT_DIR=myapp/MySpecs ./scripts/generate-specs.sh
+ #
+ 
+ # shellcheck disable=SC2038
+@@ -46,13 +46,13 @@ describe () {
+ 
+ main() {
+   SRCS_DIR=${SRCS_DIR:-$(cd "$RN_DIR/Libraries" && pwd)}
+-  CODEGEN_MODULES_LIBRARY_NAME=${CODEGEN_MODULES_LIBRARY_NAME:-FBReactNativeSpec}
++  MODULES_LIBRARY_NAME=${MODULES_LIBRARY_NAME:-FBReactNativeSpec}
+ 
+-  CODEGEN_COMPONENTS_LIBRARY_NAME=${CODEGEN_COMPONENTS_LIBRARY_NAME:-rncore}
+-  CODEGEN_MODULES_OUTPUT_DIR=${CODEGEN_MODULES_OUTPUT_DIR:-"$RN_DIR/React/$CODEGEN_MODULES_LIBRARY_NAME/$CODEGEN_MODULES_LIBRARY_NAME"}
+-  # TODO: $CODEGEN_COMPONENTS_PATH should be programmatically specified, and may change with use_frameworks! support.
+-  CODEGEN_COMPONENTS_PATH="ReactCommon/react/renderer/components"
+-  CODEGEN_COMPONENTS_OUTPUT_DIR=${CODEGEN_COMPONENTS_OUTPUT_DIR:-"$RN_DIR/$CODEGEN_COMPONENTS_PATH/$CODEGEN_COMPONENTS_LIBRARY_NAME"}
++  COMPONENTS_LIBRARY_NAME=${COMPONENTS_LIBRARY_NAME:-rncore}
++  MODULES_OUTPUT_DIR=${MODULES_OUTPUT_DIR:-"$RN_DIR/React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME"}
++  # TODO: $COMPONENTS_PATH should be programmatically specified, and may change with use_frameworks! support.
++  COMPONENTS_PATH="ReactCommon/react/renderer/components"
++  COMPONENTS_OUTPUT_DIR=${COMPONENTS_OUTPUT_DIR:-"$RN_DIR/$COMPONENTS_PATH/$COMPONENTS_LIBRARY_NAME"}
+ 
+   TEMP_OUTPUT_DIR="$TEMP_DIR/out"
+   SCHEMA_FILE="$TEMP_DIR/schema.json"
+@@ -75,14 +75,14 @@ main() {
+ 
+   describe "Generating native code from schema (iOS)"
+   pushd "$RN_DIR" >/dev/null || exit 1
+-    "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$CODEGEN_MODULES_LIBRARY_NAME"
++    "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$MODULES_LIBRARY_NAME"
+   popd >/dev/null || exit 1
+ 
+   describe "Copying output to final directory"
+-  mkdir -p "$CODEGEN_COMPONENTS_OUTPUT_DIR" "$CODEGEN_MODULES_OUTPUT_DIR"
+-  cp -R "$TEMP_OUTPUT_DIR/$CODEGEN_MODULES_LIBRARY_NAME.h" "$TEMP_OUTPUT_DIR/$CODEGEN_MODULES_LIBRARY_NAME-generated.mm" "$CODEGEN_MODULES_OUTPUT_DIR" || exit 1
+-  find "$TEMP_OUTPUT_DIR" -type f | xargs sed -i.bak "s/$CODEGEN_MODULES_LIBRARY_NAME/$CODEGEN_COMPONENTS_LIBRARY_NAME/g" || exit 1
+-  find "$TEMP_OUTPUT_DIR" -type f -not -iname "$CODEGEN_MODULES_LIBRARY_NAME*" -exec cp '{}' "$CODEGEN_COMPONENTS_OUTPUT_DIR/" ';' || exit 1
++  mkdir -p "$COMPONENTS_OUTPUT_DIR" "$MODULES_OUTPUT_DIR"
++  cp -R "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME.h" "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME-generated.mm" "$MODULES_OUTPUT_DIR" || exit 1
++  find "$TEMP_OUTPUT_DIR" -type f | xargs sed -i.bak "s/$MODULES_LIBRARY_NAME/$COMPONENTS_LIBRARY_NAME/g" || exit 1
++  find "$TEMP_OUTPUT_DIR" -type f -not -iname "$MODULES_LIBRARY_NAME*" -exec cp '{}' "$COMPONENTS_OUTPUT_DIR/" ';' || exit 1
+ 
+   echo >&2 'Done.'
+ }
+diff --git a/node_modules/react-native/scripts/react_native_pods.rb b/node_modules/react-native/scripts/react_native_pods.rb
+index db9a34a..a391f39 100644
+--- a/node_modules/react-native/scripts/react_native_pods.rb
++++ b/node_modules/react-native/scripts/react_native_pods.rb
+@@ -164,33 +164,31 @@ end
+ def use_react_native_codegen!(spec, options={})
+   return if ENV['DISABLE_CODEGEN'] == '1'
+ 
+-  # The path to react-native (e.g. react_native_path)
+-  prefix = options[:path] ||= File.join(__dir__, "..")
++  # The path to react-native
++  prefix = options[:path] ||= "${PODS_TARGET_SRCROOT}/../.."
+ 
+   # The path to JavaScript files
+-  srcs_dir = options[:srcs_dir] ||= File.join(prefix, "Libraries")
++  js_srcs = options[:js_srcs_dir] ||= "#{prefix}/Libraries"
+ 
+   # Library name (e.g. FBReactNativeSpec)
+-  codegen_modules_library_name = spec.name
+-  codegen_modules_output_dir = options[:codegen_modules_output_dir] ||= File.join(prefix, "React/#{codegen_modules_library_name}/#{codegen_modules_library_name}")
++  modules_library_name = spec.name
++  modules_output_dir = "React/#{modules_library_name}/#{modules_library_name}"
+ 
+   # Run the codegen as part of the Xcode build pipeline.
+-  env_vars = "SRCS_DIR=#{srcs_dir}"
+-  env_vars += " CODEGEN_MODULES_OUTPUT_DIR=#{codegen_modules_output_dir}"
++  env_vars = "SRCS_DIR=#{js_srcs}"
++  env_vars += " MODULES_OUTPUT_DIR=#{prefix}/#{modules_output_dir}"
++  env_vars += " MODULES_LIBRARY_NAME=#{modules_library_name}"
+ 
+-  # Since the generated files are not guaranteed to exist when CocoaPods is run, we need to create
+-  # empty files to ensure the references are included in the resulting Pods Xcode project.
+-  mkdir_command = "mkdir -p #{codegen_modules_output_dir}"
+-  generated_filenames = [ "#{codegen_modules_library_name}.h", "#{codegen_modules_library_name}-generated.mm" ]
+-  generated_files = generated_filenames.map { |filename| File.join(codegen_modules_output_dir, filename) }
++  generated_dirs = [modules_output_dir]
++  generated_filenames = ["#{modules_library_name}.h", "#{modules_library_name}-generated.mm"]
++  generated_files = generated_filenames.map { |filename| "#{modules_output_dir}/#{filename}" }
+ 
+   if ENV['USE_FABRIC'] == '1'
+     # We use a different library name for components, as well as an additional set of files.
+-    # Eventually, we want these to be part of the same library as #{codegen_modules_library_name} above.
+-    codegen_components_library_name = "rncore"
+-    codegen_components_output_dir = File.join(prefix, "ReactCommon/react/renderer/components/#{codegen_components_library_name}")
+-    env_vars += " CODEGEN_COMPONENTS_OUTPUT_DIR=#{codegen_components_output_dir}"
+-    mkdir_command += " #{codegen_components_output_dir}"
++    # Eventually, we want these to be part of the same library as #{modules_library_name} above.
++    components_output_dir = "ReactCommon/react/renderer/components/rncore/"
++    generated_dirs.push components_output_dir
++    env_vars += " COMPONENTS_OUTPUT_DIR=#{prefix}/#{components_output_dir}"
+     components_generated_filenames = [
+       "ComponentDescriptors.h",
+       "EventEmitters.cpp",
+@@ -201,19 +199,19 @@ def use_react_native_codegen!(spec, options={})
+       "ShadowNodes.cpp",
+       "ShadowNodes.h"
+     ]
+-    generated_files = generated_files.concat(components_generated_filenames.map { |filename| File.join(codegen_components_output_dir, filename) })
++    generated_files = generated_files.concat(components_generated_filenames.map { |filename| "#{components_output_dir}/#{filename}" })
+   end
+ 
+   spec.script_phase = {
+     :name => 'Generate Specs',
+-    :input_files => [srcs_dir],
+-    :output_files => ["$(DERIVED_FILE_DIR)/codegen-#{codegen_modules_library_name}.log"].concat(generated_files),
+-    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} #{File.join(__dir__, "generate-specs.sh")}' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
++    :input_files => [js_srcs],
++    :output_files => ["${DERIVED_FILE_DIR}/codegen-#{modules_library_name}.log"].concat(generated_files.map { |filename| "#{prefix}/#{filename}" }),
++    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} ${PODS_TARGET_SRCROOT}/../../scripts/generate-specs.sh' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
+     :execution_position => :before_compile,
+     :show_env_vars_in_log => true
+   }
+ 
+-  spec.prepare_command = "#{mkdir_command} && touch #{generated_files.reduce() { |str, file| str + " " + file }}"
++  spec.prepare_command = "mkdir -p #{generated_dirs.reduce("") { |str, dir| "#{str} ../../#{dir}" }} && touch #{generated_files.reduce("") { |str, filename| "#{str} ../../#{filename}" }}"
+ end
+ 
+ # Local method for the Xcode 12.5 fix


### PR DESCRIPTION
## ✅ What's done

- [x] Apply patch for scripts creating podspec of React Native pods
---

## Other (messages to reviewers, concerns, etc.)

最低限、`npm ci`してから`npm run pod-install`して、`Podfile.lock`にdiffがでなくなることを確認してもらいたいです。