### PR TITLE
✏️: 表記が必要な商標を追加

### DIFF
--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -13,12 +13,14 @@ title: 商標について
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
 - 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」「Pixel」は、 Google LLCの登録商標です。
-- 「Android ロボット」は、Google が作成および提供している作品から複製または変更したものであり、クリエイティブ・コモンズ表示 3.0 ライセンスに記載された条件に従って使用しています。
+- Androidロボットは、Googleが作成および提供している作品から複製または変更したものであり、[クリエイティブ・コモンズ表示][cclink] 3.0ライセンスに記載された条件に従って使用しています。
+[cclink]:<https://creativecommons.org/licenses/by/3.0/>
 <!-- textlint-disable ja-technical-writing/sentence-length-->
 - 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->
 - 「Java」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
-- 「Postgres」「PostgreSQL」「Slonikロゴ」は、PostgreSQL Community Association of Canadaの商標または登録商標であり、その許可を得て使用しています。
+<!-- textlint-disable ja-technical-writing/sentence-length-->
+- Postgres,PostgreSQL,Slonikロゴは、PostgreSQL Community Association of Canadaの商標または登録商標であり、その許可を得て使用しています。
 - 「Open Web Application Security Project」「OWASP」は、 OWASP Foundation, Inc. の登録商標です。
 - 「DeployGate」は、株式会社デプロイゲートの登録商標です。
 - 「moto」は、Motorola Trademark Holdings, LLCの商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -17,7 +17,6 @@ title: 商標について
 - 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->
 - 「Java」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
-- 「Kotlin」は、Kotlin Foundationの登録商標です。
 - 「Open Web Application Security Project」「OWASP」は、 OWASP Foundation, Inc. の登録商標です。
 - 「DeployGate」は、株式会社デプロイゲートの登録商標です。
 - 「moto」は、Motorola Trademark Holdings, LLCの商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -9,7 +9,7 @@ title: 商標について
 ### 各社の商標または登録商標
 
 <!-- textlint-disable -->
-- 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
+- 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->  
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
 - 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」「Pixel」は、 Google LLCの登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -9,14 +9,16 @@ title: 商標について
 ### 各社の商標または登録商標
 
 <!-- textlint-disable -->
-- 「Apple」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
+- 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
 - 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」「Pixel」は、 Google LLCの登録商標です。
+- 「Android ロボット」は、Google が作成および提供している作品から複製または変更したものであり、クリエイティブ・コモンズ表示 3.0 ライセンスに記載された条件に従って使用しています。
 <!-- textlint-disable ja-technical-writing/sentence-length-->
 - 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->
 - 「Java」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
+- 「Postgres」「PostgreSQL」「Slonikロゴ」は、PostgreSQL Community Association of Canadaの商標または登録商標であり、その許可を得て使用しています。
 - 「Open Web Application Security Project」「OWASP」は、 OWASP Foundation, Inc. の登録商標です。
 - 「DeployGate」は、株式会社デプロイゲートの登録商標です。
 - 「moto」は、Motorola Trademark Holdings, LLCの商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -9,15 +9,21 @@ title: 商標について
 ### 各社の商標または登録商標
 
 <!-- textlint-disable -->
-- 「Apple」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「Xcode」「App Store」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->  
+- 「Apple」「iCloud」「Safari」「Keychain」「iOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
-- 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」は、 Google LLCの登録商標です。
+- 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」「Pixel」は、 Google LLCの登録商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->
 - 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->
 - 「Java」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
+- 「Kotlin」は、Kotlin Foundationの登録商標です。
 - 「Open Web Application Security Project」「OWASP」は、 OWASP Foundation, Inc. の登録商標です。
 - 「DeployGate」は、株式会社デプロイゲートの登録商標です。
+- 「moto」は、Motorola Trademark Holdings, LLCの商標または登録商標です。
+- 「Xperia」は、ソニー株式会社の商標または登録商標です。
+- 「Galaxy」は、Samsung Electronics Co., Ltd. の商標または登録商標です。
+- 「ZenFone」は、ASUSTeK Computer Inc. の登録商標です。
+- 「QRコード」は、株式会社デンソーウェーブの商標または登録商標です。
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。


### PR DESCRIPTION
## ✅ What's done

- [x] 以下の製品・サービスに関わる商標を追加
 Apple：「Appleのロゴ」「watchOS」「tvOS」「Instruments」「Objective-C」「Swift」
 Google：「Pixel」「Androidロボット」
 ~~Kotlin Foundation：「Kotlin」~~
 PostgreSQL Community Association of Canada：「Postgres」「PostgreSQL」「Slonikロゴ」
 Motorola Trademark Holdings, LLC：「moto」
 ソニー株式会社：「Xperia」
 Samsung Electronics Co., Ltd.：「Galaxy」
 ASUSTeK Computer Inc.：「ZenFone」
 株式会社デンソーウェーブ：「QRコード」

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x]  npm run lintを実行してエラーが出ないこと確認
- [x]  npm startを実行してブラウザ表示内容を確認

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [x] Mac
  - [x] ブラウザチェック

## Other (messages to reviewers, concerns, etc.)

Kotlinはガイドライン上記載を必須とする旨が見当たらなかったので「その他、本サイトに〜」に包括する。
端末商品名はガイドラインそのものが見当たらなかったが商品名ということで記載した方が良いと考えられるので記載する。
Azureロゴはガイドライン上記載を必須とする旨が見当たらなかったので「その他、本サイトに〜」に包括する。
Firebaseロゴはガイドライン上記載を必須とする旨が見当たらなかったので「その他、本サイトに〜」に包括する。