### PR TITLE
🚑: スナックバーがアンマウントされない事象の対応

### DIFF
--- a/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
+++ b/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
@@ -42,7 +42,7 @@ describe('Snackbar', () => {
     expect(renderResult).toMatchSnapshot('フェードイン後');
 
     jest.advanceTimersByTime(AUTO_HIDE_DURATION + FADE_OUT_DURATION);
-    expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(0);
+    expect(queryByTestId('snackbarAnimatedView')).toBeNull();
     expect(renderResult).toMatchSnapshot('フェードアウト後');
   });
 

--- a/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
+++ b/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
@@ -22,7 +22,7 @@ const FORCE_FADE_OUT_DURATION = 300;
 const HIDE_FADE_OUT_DURATION = 300;
 
 describe('Snackbar', () => {
-  it('Snackbarが正常にrenderできることを確認', () => {
+  it('Snackbarが正常にrenderできることを確認', async () => {
     const renderResult = render(
       <Snackbar message="テストメッセージ">
         <ChildComponent />
@@ -41,9 +41,11 @@ describe('Snackbar', () => {
     expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(1);
     expect(renderResult).toMatchSnapshot('フェードイン後');
 
-    jest.advanceTimersByTime(AUTO_HIDE_DURATION + FADE_OUT_DURATION);
-    expect(queryByTestId('snackbarAnimatedView')).toBeNull();
-    expect(renderResult).toMatchSnapshot('フェードアウト後');
+    await waitFor(() => {
+      jest.advanceTimersByTime(AUTO_HIDE_DURATION + FADE_OUT_DURATION);
+      expect(queryByTestId('snackbarAnimatedView')).toBeNull();
+      expect(renderResult).toMatchSnapshot('フェードアウト後');
+    });
   });
 
   it('Snackbar表示中にpropsが更新された場合、フェードアウト後に更新後のpropsでSnackbarが表示されることを確認', async () => {

--- a/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
+++ b/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
@@ -1,3 +1,4 @@
+import {act} from '@testing-library/react-hooks';
 import {render, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import {Text, TextStyle, ViewStyle} from 'react-native';
@@ -22,7 +23,7 @@ const FORCE_FADE_OUT_DURATION = 300;
 const HIDE_FADE_OUT_DURATION = 300;
 
 describe('Snackbar', () => {
-  it('Snackbarが正常にrenderできることを確認', async () => {
+  it('Snackbarが正常にrenderできることを確認', () => {
     const renderResult = render(
       <Snackbar message="テストメッセージ">
         <ChildComponent />
@@ -37,15 +38,17 @@ describe('Snackbar', () => {
     expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(0);
     expect(renderResult).toMatchSnapshot('render直後');
 
-    await waitFor(() => {
+    act(() => {
       jest.advanceTimersByTime(FADE_IN_DURATION);
-      expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(1);
-      expect(renderResult).toMatchSnapshot('フェードイン後');
-
-      jest.advanceTimersByTime(AUTO_HIDE_DURATION + FADE_OUT_DURATION);
-      expect(queryByTestId('snackbarAnimatedView')).toBeNull();
-      expect(renderResult).toMatchSnapshot('フェードアウト後');
     });
+    expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(1);
+    expect(renderResult).toMatchSnapshot('フェードイン後');
+
+    act(() => {
+      jest.advanceTimersByTime(AUTO_HIDE_DURATION + FADE_OUT_DURATION);
+    });
+    expect(queryByTestId('snackbarAnimatedView')).toBeNull();
+    expect(renderResult).toMatchSnapshot('フェードアウト後');
   });
 
   it('Snackbar表示中にpropsが更新された場合、フェードアウト後に更新後のpropsでSnackbarが表示されることを確認', async () => {

--- a/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
+++ b/example-app/SantokuApp/src/components/snackbar/Snackbar.test.tsx
@@ -37,11 +37,11 @@ describe('Snackbar', () => {
     expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(0);
     expect(renderResult).toMatchSnapshot('render直後');
 
-    jest.advanceTimersByTime(FADE_IN_DURATION);
-    expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(1);
-    expect(renderResult).toMatchSnapshot('フェードイン後');
-
     await waitFor(() => {
+      jest.advanceTimersByTime(FADE_IN_DURATION);
+      expect(getStyle<ViewStyle>(getByTestId('snackbarAnimatedView')).opacity).toBe(1);
+      expect(renderResult).toMatchSnapshot('フェードイン後');
+
       jest.advanceTimersByTime(AUTO_HIDE_DURATION + FADE_OUT_DURATION);
       expect(queryByTestId('snackbarAnimatedView')).toBeNull();
       expect(renderResult).toMatchSnapshot('フェードアウト後');

--- a/example-app/SantokuApp/src/components/snackbar/Snackbar.tsx
+++ b/example-app/SantokuApp/src/components/snackbar/Snackbar.tsx
@@ -130,8 +130,6 @@ export const Snackbar: React.FC<SnackbarProps> = props => {
       };
 
       barrierFadeOutAnimationRef.current?.stop();
-      fadeInAnimationRef.current?.stop();
-      fadeOutAnimationRef.current?.stop();
 
       animationStart(barrierFadeOutAnimationRef, barrierFadeOutAnimationConfig, ({finished}) => {
         if (finished) {
@@ -139,6 +137,8 @@ export const Snackbar: React.FC<SnackbarProps> = props => {
           callback?.();
         }
       });
+      fadeInAnimationRef.current?.stop();
+      fadeOutAnimationRef.current?.stop();
     },
     [animationStart],
   );

--- a/example-app/SantokuApp/src/components/snackbar/Snackbar.tsx
+++ b/example-app/SantokuApp/src/components/snackbar/Snackbar.tsx
@@ -109,12 +109,12 @@ export const Snackbar: React.FC<SnackbarProps> = props => {
           useNativeDriver: true,
         };
         animationStart(fadeOutAnimationRef, fadeOutAnimationConfig, () => {
-          if (!barrierFadeOutAnimationRef) {
+          if (!barrierFadeOutAnimationRef.current) {
             setVisibleSnackbarProps(undefined);
           }
         });
       } else {
-        if (!barrierFadeOutAnimationRef) {
+        if (!barrierFadeOutAnimationRef.current) {
           setVisibleSnackbarProps(undefined);
         }
       }

--- a/example-app/SantokuApp/src/components/snackbar/__snapshots__/Snackbar.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/snackbar/__snapshots__/Snackbar.test.tsx.snap
@@ -64,66 +64,11 @@ Array [
 `;
 
 exports[`Snackbar Snackbarが正常にrenderできることを確認: フェードアウト後 1`] = `
-Array [
-  <Text
-    testID="text"
-  >
-    test
-  </Text>,
-  <View
-    testID="FullWindowOverlay"
-  >
-    <View
-      style={
-        Object {
-          "bottom": 20,
-          "flex": 1,
-          "minHeight": 48,
-          "opacity": 0,
-          "paddingHorizontal": 10,
-          "position": "absolute",
-          "width": "100%",
-        }
-      }
-      testID="snackbarAnimatedView"
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#393939",
-            "borderRadius": 5,
-            "flex": 1,
-            "flexDirection": "row",
-            "justifyContent": "center",
-          }
-        }
-        testID="snackbarStyleView"
-      >
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "paddingLeft": 20,
-              "paddingRight": 10,
-              "paddingVertical": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "white",
-              }
-            }
-          >
-            テストメッセージ
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>,
-]
+<Text
+  testID="text"
+>
+  test
+</Text>
 `;
 
 exports[`Snackbar Snackbarが正常にrenderできることを確認: フェードイン後 1`] = `


### PR DESCRIPTION
## ✅ What's done

- [x] スナックバーがフェードアウトした後も、アンマウントされずに残っている（Opacityは0のため消えているように見える）事象の対応

---

## Tests

- [x] スナックバーを表示 -> 非表示後、スナックバーが表示されていた領域のボタンなどがタップされることを確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 4a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
