### PR TITLE
🚑: 学習コンテンツのToDo一覧画面のhtmlリンク切れ対応

### DIFF
--- a/website/docs/react-native/learn/todo-app/screens/todo-board.mdx
+++ b/website/docs/react-native/learn/todo-app/screens/todo-board.mdx
@@ -6,8 +6,8 @@ ToDo一覧画面を実装します。
 
 ## ToDo機能関連の部品
 
-まずはToDo機能に必要な部品を用意します。  
-ここでは、モバイルアプリだけで動作するように部品を作成します。  
+まずはToDo機能に必要な部品を用意します。
+ここでは、モバイルアプリだけで動作するように部品を作成します。
 バックエンドとの連携は[REST APIとの接続](../networking/setting-up-local-server.mdx)で実施します。
 
 :::note
@@ -259,7 +259,7 @@ export * from './todo';
 共通部品では、React Native Elementsの`ButtonGroup`、`CheckBox`を使用しています。
 それぞれの使い方は公式ドキュメントを確認してください。
 
-- [`ButtonGroup`](https://reactnativeelements.com/docs/button_group)
+- [`ButtonGroup`](https://reactnativeelements.com/docs/buttongroup)
 - [`CheckBox`](https://reactnativeelements.com/docs/checkbox)
 
 ## ToDo一覧画面の作成


### PR DESCRIPTION
## ✅ What's done

- [x] React Native ElementsのButton Groupのリンク切れに対応しました

---

## Other (messages to reviewers, concerns, etc.)

なし
