### PR TITLE
🧑‍💻: デバッグメニューからデモ画面へ遷移

### DIFF
--- a/example-app/SantokuApp/src/App.test.tsx
+++ b/example-app/SantokuApp/src/App.test.tsx
@@ -1,9 +1,11 @@
 import '@testing-library/jest-native/extend-expect';
-import 'react-native';
 import {render, waitFor} from '@testing-library/react-native';
 import React from 'react';
+import {DevSettings} from 'react-native';
 
 import {App} from './App';
+
+jest.spyOn(DevSettings, 'addMenuItem').mockImplementation(() => {});
 
 beforeEach(() => {
   // 画面遷移時のアニメーションが、コンポーネントのアンマウント後にステートを更新してしまうようで、

--- a/example-app/SantokuApp/src/navigation/RootStackNav.tsx
+++ b/example-app/SantokuApp/src/navigation/RootStackNav.tsx
@@ -1,6 +1,8 @@
+import {useNavigation} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {useInitializeContext} from 'components/initialize';
-import React from 'react';
+import React, {useEffect} from 'react';
+import {DevSettings} from 'react-native';
 import {TermsOfServiceAgreementScreen} from 'screens';
 
 import {AuthenticatedStackNav} from './AuthenticatedStackNav';
@@ -10,6 +12,14 @@ const nav = createNativeStackNavigator();
 const name = 'RootStackNav';
 export const RootStackNav: React.FC = () => {
   const {navigatorOptions} = useInitializeContext();
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    DevSettings.addMenuItem('Go to Demo', () => {
+      navigation.navigate(DemoStackNav.name);
+    });
+  }, [navigation]);
+
   return (
     <nav.Navigator
       screenOptions={{


### PR DESCRIPTION
## ✅ What's done

- [x] [Ctrl+M]やシェイクで表示されるデバッグメニューから、デモ画面へ遷移する

## ⏸ What's not done

- 他の画面への遷移（最終的にはやった方が便利）

---

## Tests

- [x] エミュレータと実機で、デバッグメニューからデモ画面へ遷移できること
- [x] npm run lintでエラーが出ないこと
- [x] npm run textでエラーが出ないこと

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

最終的には遷移先の画面を選択できるようにしたい