### PR TITLE
💄: React Native Elementsのドキュメントへのリンク切れを修正

### DIFF
--- a/website/docs/react-native/santoku/design/context/theme.mdx
+++ b/website/docs/react-native/santoku/design/context/theme.mdx
@@ -81,7 +81,7 @@ colors内の各属性で定義するカラーコードは、以下の用途に�
 React Navigationには[Theme機能](https://reactnavigation.org/docs/themes/)が存在します。
 このTheme機能を用いると、React Navigationで提供されているコンポーネントの色を切り替えることができます。
 
-React Native Elementsにも[Theme機能](https://reactnativeelements.com/docs/customization/#theming)が存在します。
+React Native Elementsにも[Theme機能](https://reactnativeelements.com/docs/customization#theming)が存在します。
 こちらも同様にReact Native Elementsで提供されているコンポーネントの色を切り替えることができます。
 また、コンポーネントのデフォルトのpropsも設定できます。
 

--- a/website/docs/react-native/santoku/design/screen-specs/basic-policy.mdx
+++ b/website/docs/react-native/santoku/design/screen-specs/basic-policy.mdx
@@ -7,7 +7,7 @@ sidebar_label: 基本方針
 
 ## 全体
 
-- このアプリでは、[React Native Elements](https://reactnativeelements.com/docs/)を使用します。
+- このアプリでは、[React Native Elements](https://reactnativeelements.com/docs)を使用します。
 - 非機能要件の[ユーザビリティおよびアクセシビリティに関する事項の「利用において配慮すべき事項」](/react-native/santoku/requirements/non-functional/usability.mdx#利用において配慮すべき事項)に従います。
 
 ## インジケータ

--- a/website/docs/react-native/santoku/design/screen-specs/common-parts/button/overview.mdx
+++ b/website/docs/react-native/santoku/design/screen-specs/common-parts/button/overview.mdx
@@ -29,7 +29,7 @@ sidebar_label: ボタン
 | 番号 | 名称          | 項目種別    | 取得元               | 表示/活性条件                                 |
 |:----|:--------------|:-----------|:--------------------|:--------------------------------------------|
 | O1  | ボタンテキスト   | ラベル     | -（※1）               | インジケータ表示中の場合は非表示                |
-（※1）[React Native ElementsのButtonのプロパティ](https://reactnativeelements.com/docs/button/#title)で任意の文字列を指定します。
+（※1）[React Native ElementsのButtonのプロパティ](https://reactnativeelements.com/docs/button#title)で任意の文字列を指定します。
 
 - インジケータは、[React Native ElementsのButton][]の機能を使用するため割愛します。
 
@@ -49,7 +49,7 @@ sidebar_label: ボタン
 
 | イベント | 処理概要 |
 |:------|:------|
-| ボタンをタップ | [プロパティ](https://reactnativeelements.com/docs/button/#onpress)で指定された処理を実行します。|
+| ボタンをタップ | プロパティで指定された処理を実行します。|
 
 ## プロパティ
 
@@ -57,7 +57,7 @@ sidebar_label: ボタン
 |:--------------|:-----|:-------|:------------------------------------------------------|
 | size          | -    | Union | ボタンの横幅サイズを`small`、`middle`、`large`、`full`から指定します。デフォルトは`small`。<br />`small`、`middle`、`large`は固定のピクセルサイズですが、`full`のみ親要素の横幅いっぱいに広がります。 |
 
-※ React Native Elementsには存在しないプロパティのみ記載しています。上記以外は[React Native ElementsのButtonのプロパティ](https://reactnativeelements.com/docs/button/#props)をご参照ください。
+※ React Native Elementsには存在しないプロパティのみ記載しています。上記以外は[React Native ElementsのButtonのプロパティ](https://reactnativeelements.com/docs/button#props)をご参照ください。
 
 <!-- link定義を使う場合は以下に記載する -->
-[React Native ElementsのButton]: https://reactnativeelements.com/docs/button/
+[React Native ElementsのButton]: https://reactnativeelements.com/docs/button


### PR DESCRIPTION
## ✅ What's done

- [x] React Native ElementsのドキュメントURLの末尾にスラッシュがつかなくなったことによるリンク切れを修正
- [x] React Native Elementsのv4系のButtonのドキュメントからonPressの項目が無くなったため、該当リンクを一旦削除

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] 修正後のリンクURLにアクセスできることの確認 
- [x] htmltestが通ることの確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
