### PR TITLE
🚑️: DEVビルドの場合のみ開発メニューにデモへのリンクを追加。

### DIFF
--- a/example-app/SantokuApp/src/navigation/RootStackNav.tsx
+++ b/example-app/SantokuApp/src/navigation/RootStackNav.tsx
@@ -17,9 +17,11 @@ export const RootStackNav: React.FC = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
   useEffect(() => {
-    DevSettings.addMenuItem('Go to Demo', () => {
-      navigation.navigate('DemoStackNav', {screen: 'Demo'});
-    });
+    if (__DEV__) {
+      DevSettings.addMenuItem('Go to Demo', () => {
+        navigation.navigate('DemoStackNav', {screen: 'Demo'});
+      });
+    }
   }, [navigation]);
 
   return (


### PR DESCRIPTION
## ✅ What's done

- [x] iOSのIn-Houseビルドでエラーが発生しないように、DEVビルドの場合のみ開発メニューにデモへのリンクを追加。
---

## Tests

- [x] In-Houseビルドでアプリが起動できること

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [x] iOS
  - [x] ~~シミュレータ (iPhone Xs/iOS 14)~~
  - [x] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] ~~エミュレータ (Pixel 3a/Android 11)~~
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

なし