### PR TITLE
✨: キャッシュディレクトリ内のファイルの表示と一括削除が行えるデモ画面の追加

### DIFF
--- a/example-app/SantokuApp/src/navigation/DemoStackNav.tsx
+++ b/example-app/SantokuApp/src/navigation/DemoStackNav.tsx
@@ -22,6 +22,7 @@ import {
   HttpApiScreen,
   NavigationScreen,
   PushNotificationScreen,
+  CacheScreen,
 } from 'screens';
 
 import {DemoStackParamList, RootStackParamList} from './types';
@@ -60,6 +61,7 @@ export const Screen: React.FC = () => {
       <nav.Screen {...HttpApiScreen} />
       <nav.Screen {...NavigationScreen} />
       <nav.Screen {...PushNotificationScreen} />
+      <nav.Screen {...CacheScreen} />
     </nav.Navigator>
   );
 };

--- a/example-app/SantokuApp/src/navigation/types.ts
+++ b/example-app/SantokuApp/src/navigation/types.ts
@@ -45,6 +45,7 @@ export type DemoStackParamList = {
   HttpApi: undefined;
   Navigation: undefined;
   PushNotification: undefined;
+  Cache: undefined;
 };
 
 export type AppNavigatorOptions = {

--- a/example-app/SantokuApp/src/screens/demo/DemoScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/DemoScreen.tsx
@@ -8,6 +8,7 @@ import {DemoTemplate} from './DemoTemplate';
 import {AppStateScreen} from './app-state';
 import {AuthenticationScreen} from './authentication';
 import {ButtonScreen} from './button';
+import {CacheScreen} from './cache';
 import {ConfigScreen} from './config';
 import {ErrorCaseScreen} from './error';
 import {HttpApiScreen} from './http-api';
@@ -81,6 +82,10 @@ const demoScreenList: ScreenList[] = [
   {
     title: 'PushNotification',
     to: PushNotificationScreen.name,
+  },
+  {
+    title: 'Cache',
+    to: CacheScreen.name,
   },
 ];
 

--- a/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
@@ -1,0 +1,212 @@
+import * as FileSystem from 'expo-file-system';
+import {DemoStackParamList} from 'navigation/types';
+import React, {useCallback, useEffect, useState} from 'react';
+import {StyleSheet, View, SectionList, SectionListData} from 'react-native';
+import {Icon, ListItem, Text} from 'react-native-elements';
+
+import {Button} from '../../../components/button/Button';
+import {useSnackbar} from '../../../components/snackbar';
+
+type FileInfoWithChildItems = FileSystem.FileInfo & {
+  childItems?: FileSystem.FileInfo[];
+};
+
+type Section = {
+  title: string;
+  isDirectory: boolean;
+  data: FileSystem.FileInfo[];
+};
+
+const ScreenName = 'Cache';
+const Screen: React.FC = () => {
+  const [sectionListData, setSectionListData] = useState<SectionListData<FileSystem.FileInfo, Section>[]>([]);
+  const snackbar = useSnackbar();
+
+  const getFileNameFromUri = useCallback((uri: string) => {
+    return uri.split('/').slice(-1)[0];
+  }, []);
+
+  const sortFileInfos = useCallback((fileInfos: FileSystem.FileInfo[]) => {
+    const copiedArray = [...fileInfos];
+    copiedArray.sort((a, b) => {
+      if (a.isDirectory && !b.isDirectory) {
+        return -1;
+      } else if (!a.isDirectory && b.isDirectory) {
+        return 1;
+      } else if (a.uri < b.uri) {
+        return -1;
+      } else if (a.uri > b.uri) {
+        return 1;
+      }
+      return 0;
+    });
+    return copiedArray;
+  }, []);
+
+  const readDirectoryItemsFileInfoAsync = useCallback(
+    async (fileUri: string) => {
+      const info = await FileSystem.getInfoAsync(fileUri);
+      if (info.isDirectory) {
+        const paths = await FileSystem.readDirectoryAsync(fileUri);
+        const infos = await Promise.all(
+          paths.map(path => {
+            const fullPath = fileUri.endsWith('/') ? `${fileUri}${path}` : `${fileUri}/${path}`;
+            return FileSystem.getInfoAsync(fullPath);
+          }),
+        );
+        return sortFileInfos(infos);
+      } else {
+        return [];
+      }
+    },
+    [sortFileInfos],
+  );
+
+  const getFileInfoWithChildItems = useCallback(
+    async (info: FileSystem.FileInfo): Promise<FileInfoWithChildItems> => {
+      const childItems = await readDirectoryItemsFileInfoAsync(info.uri);
+      return {
+        ...info,
+        childItems,
+      };
+    },
+    [readDirectoryItemsFileInfoAsync],
+  );
+
+  const updateCacheDirectoryItemsAsync = useCallback(async () => {
+    if (FileSystem.cacheDirectory) {
+      const topLevelItemInfos = await readDirectoryItemsFileInfoAsync(FileSystem.cacheDirectory);
+      const topLevelItemInfosWithChildItems = await Promise.all(
+        topLevelItemInfos.map(info => {
+          if (info.isDirectory) {
+            return getFileInfoWithChildItems(info);
+          } else {
+            return new Promise<FileInfoWithChildItems>(resolve => resolve(info));
+          }
+        }),
+      );
+      const data = topLevelItemInfosWithChildItems.map(item => {
+        if (item.childItems) {
+          return {
+            title: getFileNameFromUri(item.uri),
+            isDirectory: item.isDirectory,
+            data: item.childItems,
+          };
+        } else {
+          return {
+            title: getFileNameFromUri(item.uri),
+            isDirectory: item.isDirectory,
+            data: [],
+          };
+        }
+      });
+      setSectionListData(data);
+    }
+  }, [readDirectoryItemsFileInfoAsync, getFileInfoWithChildItems, getFileNameFromUri]);
+
+  const deleteChildItemsAsync = useCallback(
+    async (fileInfo: FileSystem.FileInfo) => {
+      if (fileInfo.exists) {
+        if (fileInfo.isDirectory) {
+          const childItemInfos = await readDirectoryItemsFileInfoAsync(fileInfo.uri);
+          await Promise.all(
+            childItemInfos.map(info => {
+              return FileSystem.deleteAsync(info.uri);
+            }),
+          );
+        } else {
+          await FileSystem.deleteAsync(fileInfo.uri);
+        }
+      }
+    },
+    [readDirectoryItemsFileInfoAsync],
+  );
+
+  const clearCacheDir = useCallback(async () => {
+    if (FileSystem.cacheDirectory) {
+      try {
+        const fileInfos = await readDirectoryItemsFileInfoAsync(FileSystem.cacheDirectory);
+        await Promise.all(
+          fileInfos.map(info => {
+            // http-cacheなどのトップレベルのディレクトリは削除できないので、その中のファイルだけを削除対象とする
+            return deleteChildItemsAsync(info);
+          }),
+        );
+        await updateCacheDirectoryItemsAsync();
+        snackbar.showWithCloseButton(`ファイルの削除に成功しました。`);
+      } catch (e) {
+        console.log(e);
+        snackbar.showWithCloseButton(`ファイルの削除に失敗しました。`);
+      }
+    }
+  }, [snackbar, deleteChildItemsAsync, readDirectoryItemsFileInfoAsync, updateCacheDirectoryItemsAsync]);
+
+  useEffect(() => {
+    updateCacheDirectoryItemsAsync().catch(e => console.log(e));
+  }, [updateCacheDirectoryItemsAsync]);
+
+  const renderItem = useCallback(
+    ({item}: {item: FileSystem.FileInfo}) => {
+      return (
+        <ListItem containerStyle={styles.listItem}>
+          <Icon name={item.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
+          <ListItem.Title>{getFileNameFromUri(item.uri)}</ListItem.Title>
+        </ListItem>
+      );
+    },
+    [getFileNameFromUri],
+  );
+
+  const renderSectionHeader = useCallback(({section}: {section: Section}) => {
+    return (
+      <ListItem containerStyle={styles.section}>
+        <Icon name={section.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
+        <ListItem.Title>{section.title}</ListItem.Title>
+        {section.data.length === 0 && <ListItem.Subtitle>(empty)</ListItem.Subtitle>}
+      </ListItem>
+    );
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>キャッシュディレクトリ内(2階層分)</Text>
+      <SectionList
+        contentContainerStyle={styles.sectionListContainer}
+        sections={sectionListData}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={(_item, index) => `${index}`}
+      />
+      <Button size="full" title="キャッシュディレクトリ内のファイルを削除" onPress={clearCacheDir} />
+    </View>
+  );
+};
+
+export const CacheScreen: NativeStackScreenConfig<DemoStackParamList, typeof ScreenName> = {
+  name: ScreenName,
+  component: Screen,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 8,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 4,
+  },
+  sectionListContainer: {
+    flex: 1,
+  },
+  section: {
+    backgroundColor: 'transparent',
+    padding: 4,
+    width: '90%',
+  },
+  listItem: {
+    backgroundColor: 'transparent',
+    padding: 4,
+    paddingLeft: 20,
+  },
+});

--- a/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
@@ -1,182 +1,42 @@
-import * as FileSystem from 'expo-file-system';
 import {DemoStackParamList} from 'navigation/types';
 import React, {useCallback, useEffect, useState} from 'react';
-import {StyleSheet, View, SectionList, SectionListData} from 'react-native';
-import {Icon, ListItem, Text} from 'react-native-elements';
+import {ScrollView, StyleSheet, View, RefreshControl} from 'react-native';
+import {Text} from 'react-native-elements';
 
 import {Button} from '../../../components/button/Button';
-import {useSnackbar} from '../../../components/snackbar';
-
-type FileInfoWithChildItems = FileSystem.FileInfo & {
-  childItems?: FileSystem.FileInfo[];
-};
-
-type Section = {
-  title: string;
-  isDirectory: boolean;
-  data: FileSystem.FileInfo[];
-};
+import {FileInfo} from './FileInfo';
+import {useCacheDirectory} from './useCacheDirectory';
 
 const ScreenName = 'Cache';
 const Screen: React.FC = () => {
-  const [sectionListData, setSectionListData] = useState<SectionListData<FileSystem.FileInfo, Section>[]>([]);
-  const snackbar = useSnackbar();
+  const {topLevelFileInfos, reloadCacheDirectoryItemsAsync, clearCacheDir} = useCacheDirectory();
+  const [refreshing, setRefreshing] = useState<boolean>(false);
 
-  const getFileNameFromUri = useCallback((uri: string) => {
-    return uri.endsWith('/') ? uri.split('/').slice(-2)[0] : uri.split('/').slice(-1)[0];
-  }, []);
-
-  const sortFileInfos = useCallback((fileInfos: FileSystem.FileInfo[]) => {
-    const copiedArray = [...fileInfos];
-    copiedArray.sort((a, b) => {
-      if (a.isDirectory && !b.isDirectory) {
-        return -1;
-      } else if (!a.isDirectory && b.isDirectory) {
-        return 1;
-      } else if (a.uri < b.uri) {
-        return -1;
-      } else if (a.uri > b.uri) {
-        return 1;
-      }
-      return 0;
-    });
-    return copiedArray;
-  }, []);
-
-  const readDirectoryItemsFileInfoAsync = useCallback(
-    async (fileUri: string) => {
-      const info = await FileSystem.getInfoAsync(fileUri);
-      if (info.isDirectory) {
-        const paths = await FileSystem.readDirectoryAsync(fileUri);
-        const infos = await Promise.all(
-          paths.map(path => {
-            const fullPath = fileUri.endsWith('/') ? `${fileUri}${path}` : `${fileUri}/${path}`;
-            return FileSystem.getInfoAsync(fullPath);
-          }),
-        );
-        return sortFileInfos(infos);
-      } else {
-        return [];
-      }
-    },
-    [sortFileInfos],
-  );
-
-  const getFileInfoWithChildItems = useCallback(
-    async (info: FileSystem.FileInfo): Promise<FileInfoWithChildItems> => {
-      const childItems = await readDirectoryItemsFileInfoAsync(info.uri);
-      return {
-        ...info,
-        childItems,
-      };
-    },
-    [readDirectoryItemsFileInfoAsync],
-  );
-
-  const updateCacheDirectoryItemsAsync = useCallback(async () => {
-    if (FileSystem.cacheDirectory) {
-      const topLevelItemInfos = await readDirectoryItemsFileInfoAsync(FileSystem.cacheDirectory);
-      const topLevelItemInfosWithChildItems = await Promise.all(
-        topLevelItemInfos.map(info => {
-          if (info.isDirectory) {
-            return getFileInfoWithChildItems(info);
-          } else {
-            return new Promise<FileInfoWithChildItems>(resolve => resolve(info));
-          }
-        }),
-      );
-      const data = topLevelItemInfosWithChildItems.map(item => {
-        if (item.childItems) {
-          return {
-            title: getFileNameFromUri(item.uri),
-            isDirectory: item.isDirectory,
-            data: item.childItems,
-          };
-        } else {
-          return {
-            title: getFileNameFromUri(item.uri),
-            isDirectory: item.isDirectory,
-            data: [],
-          };
-        }
-      });
-      setSectionListData(data);
-    }
-  }, [readDirectoryItemsFileInfoAsync, getFileInfoWithChildItems, getFileNameFromUri]);
-
-  const deleteChildItemsAsync = useCallback(
-    async (fileInfo: FileSystem.FileInfo) => {
-      if (fileInfo.exists) {
-        if (fileInfo.isDirectory) {
-          const childItemInfos = await readDirectoryItemsFileInfoAsync(fileInfo.uri);
-          await Promise.all(
-            childItemInfos.map(info => {
-              return FileSystem.deleteAsync(info.uri);
-            }),
-          );
-        } else {
-          await FileSystem.deleteAsync(fileInfo.uri);
-        }
-      }
-    },
-    [readDirectoryItemsFileInfoAsync],
-  );
-
-  const clearCacheDir = useCallback(async () => {
-    if (FileSystem.cacheDirectory) {
-      try {
-        const fileInfos = await readDirectoryItemsFileInfoAsync(FileSystem.cacheDirectory);
-        await Promise.all(
-          fileInfos.map(info => {
-            // http-cacheなどのトップレベルのディレクトリは削除できないので、その中のファイルだけを削除対象とする
-            return deleteChildItemsAsync(info);
-          }),
-        );
-        await updateCacheDirectoryItemsAsync();
-        snackbar.showWithCloseButton(`ファイルの削除に成功しました。`);
-      } catch (e) {
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    reloadCacheDirectoryItemsAsync()
+      .catch(e => {
         console.log(e);
-        snackbar.showWithCloseButton(`ファイルの削除に失敗しました。`);
-      }
-    }
-  }, [snackbar, deleteChildItemsAsync, readDirectoryItemsFileInfoAsync, updateCacheDirectoryItemsAsync]);
+      })
+      .finally(() => {
+        setRefreshing(false);
+      });
+  }, [reloadCacheDirectoryItemsAsync]);
 
   useEffect(() => {
-    updateCacheDirectoryItemsAsync().catch(e => console.log(e));
-  }, [updateCacheDirectoryItemsAsync]);
-
-  const renderItem = useCallback(
-    ({item}: {item: FileSystem.FileInfo}) => {
-      return (
-        <ListItem containerStyle={styles.listItem}>
-          <Icon name={item.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
-          <ListItem.Title>{getFileNameFromUri(item.uri)}</ListItem.Title>
-        </ListItem>
-      );
-    },
-    [getFileNameFromUri],
-  );
-
-  const renderSectionHeader = useCallback(({section}: {section: Section}) => {
-    return (
-      <ListItem containerStyle={styles.section}>
-        <Icon name={section.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
-        <ListItem.Title>{section.title}</ListItem.Title>
-        {section.data.length === 0 && <ListItem.Subtitle>(empty)</ListItem.Subtitle>}
-      </ListItem>
-    );
-  }, []);
+    reloadCacheDirectoryItemsAsync().catch(e => console.log(e));
+  }, [reloadCacheDirectoryItemsAsync]);
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>キャッシュディレクトリ内(2階層分)</Text>
-      <SectionList
-        contentContainerStyle={styles.sectionListContainer}
-        sections={sectionListData}
-        renderItem={renderItem}
-        renderSectionHeader={renderSectionHeader}
-        keyExtractor={(_item, index) => `${index}`}
-      />
+      <Text style={styles.title}>キャッシュディレクトリ内</Text>
+      <ScrollView
+        style={styles.directoryView}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
+        {topLevelFileInfos.map((info, index) => {
+          return <FileInfo key={index} fileInfo={info} currentDepth={1} />;
+        })}
+      </ScrollView>
       <Button size="full" title="キャッシュディレクトリ内のファイルを削除" onPress={clearCacheDir} />
     </View>
   );
@@ -196,17 +56,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 4,
   },
-  sectionListContainer: {
+  directoryView: {
     flex: 1,
-  },
-  section: {
-    backgroundColor: 'transparent',
-    padding: 4,
-    width: '90%',
-  },
-  listItem: {
-    backgroundColor: 'transparent',
-    padding: 4,
-    paddingLeft: 20,
   },
 });

--- a/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
@@ -24,8 +24,8 @@ const Screen: React.FC = () => {
   }, [reloadCacheDirectoryItemsAsync]);
 
   useEffect(() => {
-    reloadCacheDirectoryItemsAsync().catch(e => console.log(e));
-  }, [reloadCacheDirectoryItemsAsync]);
+    onRefresh();
+  }, [onRefresh]);
 
   return (
     <View style={styles.container}>

--- a/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/CacheScreen.tsx
@@ -23,7 +23,7 @@ const Screen: React.FC = () => {
   const snackbar = useSnackbar();
 
   const getFileNameFromUri = useCallback((uri: string) => {
-    return uri.split('/').slice(-1)[0];
+    return uri.endsWith('/') ? uri.split('/').slice(-2)[0] : uri.split('/').slice(-1)[0];
   }, []);
 
   const sortFileInfos = useCallback((fileInfos: FileSystem.FileInfo[]) => {

--- a/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
@@ -1,9 +1,9 @@
 import * as FileSystem from 'expo-file-system';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {Icon, Text} from 'react-native-elements';
 
-import {useCacheDirectory} from './useCacheDirectory';
+import {readDirectoryItemsFileInfoAsync} from './useCacheDirectory';
 
 type FileInfoProps = {
   fileInfo: FileSystem.FileInfo;
@@ -18,10 +18,11 @@ const getFileNameFromUri = (uri: string) => {
 
 const FileInfo: React.FC<FileInfoProps> = props => {
   const {fileInfo, currentDepth} = props;
-  const {readDirectoryItemsFileInfoAsync} = useCacheDirectory();
   const [childFileInfos, setChildFileInfos] = useState<FileSystem.FileInfo[]>([]);
+  const isViewChildren = useMemo(() => {
+    return fileInfo.isDirectory && currentDepth <= maxDepth;
+  }, [fileInfo, currentDepth]);
 
-  const isViewChildren = fileInfo.isDirectory && currentDepth <= maxDepth;
   useEffect(() => {
     if (isViewChildren) {
       readDirectoryItemsFileInfoAsync(fileInfo.uri)
@@ -32,7 +33,7 @@ const FileInfo: React.FC<FileInfoProps> = props => {
           console.log(e);
         });
     }
-  }, [isViewChildren, fileInfo, readDirectoryItemsFileInfoAsync]);
+  }, [isViewChildren, fileInfo]);
 
   return (
     <View style={styles.container}>

--- a/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
@@ -12,14 +12,14 @@ type FileInfoProps = {
 
 const maxDepth = 10;
 
+const getFileNameFromUri = (uri: string) => {
+  return uri.endsWith('/') ? uri.split('/').slice(-2)[0] : uri.split('/').slice(-1)[0];
+};
+
 const FileInfo: React.FC<FileInfoProps> = props => {
   const {fileInfo, currentDepth} = props;
   const {readDirectoryItemsFileInfoAsync} = useCacheDirectory();
   const [childFileInfos, setChildFileInfos] = useState<FileSystem.FileInfo[]>([]);
-
-  const getFileNameFromUri = useCallback((uri: string) => {
-    return uri.endsWith('/') ? uri.split('/').slice(-2)[0] : uri.split('/').slice(-1)[0];
-  }, []);
 
   const isViewChildren = fileInfo.isDirectory && currentDepth <= maxDepth;
   useEffect(() => {

--- a/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
@@ -21,8 +21,9 @@ const FileInfo: React.FC<FileInfoProps> = props => {
     return uri.endsWith('/') ? uri.split('/').slice(-2)[0] : uri.split('/').slice(-1)[0];
   }, []);
 
+  const isViewChildren = fileInfo.isDirectory && currentDepth <= maxDepth;
   useEffect(() => {
-    if (fileInfo.isDirectory && currentDepth <= maxDepth) {
+    if (isViewChildren) {
       readDirectoryItemsFileInfoAsync(fileInfo.uri)
         .then(fileInfos => {
           setChildFileInfos(fileInfos);
@@ -31,7 +32,7 @@ const FileInfo: React.FC<FileInfoProps> = props => {
           console.log(e);
         });
     }
-  }, [currentDepth, fileInfo, readDirectoryItemsFileInfoAsync]);
+  }, [isViewChildren, fileInfo, readDirectoryItemsFileInfoAsync]);
 
   if (fileInfo.isDirectory && currentDepth <= maxDepth) {
     return (

--- a/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
@@ -1,0 +1,87 @@
+import * as FileSystem from 'expo-file-system';
+import React, {useCallback, useEffect, useState} from 'react';
+import {StyleSheet, View} from 'react-native';
+import {Icon, Text} from 'react-native-elements';
+
+import {useCacheDirectory} from './useCacheDirectory';
+
+type FileInfoProps = {
+  fileInfo: FileSystem.FileInfo;
+  currentDepth: number;
+};
+
+const maxDepth = 10;
+
+const FileInfo: React.FC<FileInfoProps> = props => {
+  const {fileInfo, currentDepth} = props;
+  const {readDirectoryItemsFileInfoAsync} = useCacheDirectory();
+  const [childFileInfos, setChildFileInfos] = useState<FileSystem.FileInfo[]>([]);
+
+  const getFileNameFromUri = useCallback((uri: string) => {
+    return uri.endsWith('/') ? uri.split('/').slice(-2)[0] : uri.split('/').slice(-1)[0];
+  }, []);
+
+  useEffect(() => {
+    if (fileInfo.isDirectory && currentDepth <= maxDepth) {
+      readDirectoryItemsFileInfoAsync(fileInfo.uri)
+        .then(fileInfos => {
+          setChildFileInfos(fileInfos);
+        })
+        .catch(e => {
+          console.log(e);
+        });
+    }
+  }, [currentDepth, fileInfo, readDirectoryItemsFileInfoAsync]);
+
+  if (fileInfo.isDirectory && currentDepth <= maxDepth) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.item}>
+          <Icon name="file-directory" type="octicon" size={18} />
+          <Text style={styles.title}>{getFileNameFromUri(fileInfo.uri)}</Text>
+        </View>
+        <View style={styles.childContainer}>
+          {childFileInfos.map((info, index) => {
+            return <FileInfo key={index} fileInfo={info} currentDepth={currentDepth + 1} />;
+          })}
+        </View>
+      </View>
+    );
+  } else {
+    return (
+      <View style={styles.container}>
+        <View style={styles.item}>
+          <Icon name={fileInfo.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
+          <Text style={styles.title}>{getFileNameFromUri(fileInfo.uri)}</Text>
+        </View>
+      </View>
+    );
+  }
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+  item: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    flex: 1,
+    fontSize: 18,
+    marginLeft: 8,
+    marginBottom: 4,
+  },
+  childContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginLeft: 20,
+  },
+});
+
+export {FileInfo};

--- a/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
+++ b/example-app/SantokuApp/src/screens/demo/cache/FileInfo.tsx
@@ -34,30 +34,21 @@ const FileInfo: React.FC<FileInfoProps> = props => {
     }
   }, [isViewChildren, fileInfo, readDirectoryItemsFileInfoAsync]);
 
-  if (fileInfo.isDirectory && currentDepth <= maxDepth) {
-    return (
-      <View style={styles.container}>
-        <View style={styles.item}>
-          <Icon name="file-directory" type="octicon" size={18} />
-          <Text style={styles.title}>{getFileNameFromUri(fileInfo.uri)}</Text>
-        </View>
+  return (
+    <View style={styles.container}>
+      <View style={styles.item}>
+        <Icon name={fileInfo.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
+        <Text style={styles.title}>{getFileNameFromUri(fileInfo.uri)}</Text>
+      </View>
+      {isViewChildren && (
         <View style={styles.childContainer}>
           {childFileInfos.map((info, index) => {
             return <FileInfo key={index} fileInfo={info} currentDepth={currentDepth + 1} />;
           })}
         </View>
-      </View>
-    );
-  } else {
-    return (
-      <View style={styles.container}>
-        <View style={styles.item}>
-          <Icon name={fileInfo.isDirectory ? 'file-directory' : 'file'} type="octicon" size={18} />
-          <Text style={styles.title}>{getFileNameFromUri(fileInfo.uri)}</Text>
-        </View>
-      </View>
-    );
-  }
+      )}
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({

--- a/example-app/SantokuApp/src/screens/demo/cache/index.ts
+++ b/example-app/SantokuApp/src/screens/demo/cache/index.ts
@@ -1,0 +1,1 @@
+export * from './CacheScreen';

--- a/example-app/SantokuApp/src/screens/demo/cache/useCacheDirectory.ts
+++ b/example-app/SantokuApp/src/screens/demo/cache/useCacheDirectory.ts
@@ -1,0 +1,97 @@
+import {useSnackbar} from 'components/snackbar';
+import * as FileSystem from 'expo-file-system';
+import {useCallback, useState} from 'react';
+
+const useCacheDirectory = () => {
+  const [topLevelFileInfos, setTopLevelFileInfos] = useState<FileSystem.FileInfo[]>([]);
+  const snackbar = useSnackbar();
+
+  const sortFileInfos = useCallback((fileInfos: FileSystem.FileInfo[]) => {
+    const copiedArray = [...fileInfos];
+    copiedArray.sort((a, b) => {
+      if (a.isDirectory && !b.isDirectory) {
+        return -1;
+      } else if (!a.isDirectory && b.isDirectory) {
+        return 1;
+      } else if (a.uri < b.uri) {
+        return -1;
+      } else if (a.uri > b.uri) {
+        return 1;
+      }
+      return 0;
+    });
+    return copiedArray;
+  }, []);
+
+  const readDirectoryItemsFileInfoAsync = useCallback(
+    async (fileUri: string) => {
+      const info = await FileSystem.getInfoAsync(fileUri);
+      if (info.isDirectory) {
+        const paths = await FileSystem.readDirectoryAsync(fileUri);
+        const infos = await Promise.all(
+          paths.map(path => {
+            const fullPath = fileUri.endsWith('/') ? `${fileUri}${path}` : `${fileUri}/${path}`;
+            return FileSystem.getInfoAsync(fullPath);
+          }),
+        );
+        return sortFileInfos(infos);
+      } else {
+        return [];
+      }
+    },
+    [sortFileInfos],
+  );
+
+  const reloadCacheDirectoryItemsAsync = useCallback(async () => {
+    if (FileSystem.cacheDirectory) {
+      const fileInfos = await readDirectoryItemsFileInfoAsync(FileSystem.cacheDirectory);
+      setTopLevelFileInfos(fileInfos);
+    }
+  }, [readDirectoryItemsFileInfoAsync]);
+
+  const deleteChildItemsAsync = useCallback(
+    async (fileInfo: FileSystem.FileInfo) => {
+      if (fileInfo.exists) {
+        if (fileInfo.isDirectory) {
+          const childItemInfos = await readDirectoryItemsFileInfoAsync(fileInfo.uri);
+          await Promise.all(
+            childItemInfos.map(info => {
+              return FileSystem.deleteAsync(info.uri);
+            }),
+          );
+        } else {
+          await FileSystem.deleteAsync(fileInfo.uri);
+        }
+      }
+    },
+    [readDirectoryItemsFileInfoAsync],
+  );
+
+  const clearCacheDir = useCallback(async () => {
+    if (FileSystem.cacheDirectory) {
+      try {
+        const fileInfos = await readDirectoryItemsFileInfoAsync(FileSystem.cacheDirectory);
+        await Promise.all(
+          fileInfos.map(info => {
+            // http-cacheなどのトップレベルのディレクトリは削除できないので、その中のファイルだけを削除対象とする
+            return deleteChildItemsAsync(info);
+          }),
+        );
+        await reloadCacheDirectoryItemsAsync();
+        snackbar.showWithCloseButton(`ファイルの削除に成功しました。`);
+      } catch (e) {
+        console.log(e);
+        snackbar.showWithCloseButton(`ファイルの削除に失敗しました。`);
+      }
+    }
+  }, [snackbar, readDirectoryItemsFileInfoAsync, reloadCacheDirectoryItemsAsync, deleteChildItemsAsync]);
+
+  return {
+    topLevelFileInfos,
+    readDirectoryItemsFileInfoAsync,
+    reloadCacheDirectoryItemsAsync,
+    clearCacheDir,
+  };
+};
+
+export {useCacheDirectory};

--- a/example-app/SantokuApp/src/screens/demo/index.ts
+++ b/example-app/SantokuApp/src/screens/demo/index.ts
@@ -13,3 +13,4 @@ export * from './button';
 export * from './authentication';
 export * from './navigation';
 export * from './push-notification';
+export * from './cache';


### PR DESCRIPTION
## ✅ What's done

- [x] キャッシュディレクトリ内のファイルの表示と一括削除が行えるデモ画面の追加

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] Android Emulatorでの動作確認
- [x] iOS Simulatorでの動作確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [x] iOS
  - [x] シミュレータ (iPhone 13/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 4/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
