### PR TITLE
💚: htmltestのタイムアウト対応

### DIFF
--- a/website/.htmltest.yaml
+++ b/website/.htmltest.yaml
@@ -54,5 +54,10 @@ IgnoreURLs:
   - https://marketplace.visualstudio.com/items\?itemName=yzhang.markdown-all-in-one
   # 403になってしまうので無視
   - https://blog.expo.dev/
-# タイムアウトでビルドが失敗すると困るので、余裕を持って長めに設定しておく。
-ExternalTimeout: 60
+# タイムアウトでビルドが失敗して困るので、次の値をデフォルトから変更して余裕を持っておく。
+# DocumentConcurrencyLimit: 128 -> 64
+# HTTPConcurrencyLimit: 16 -> 8
+# ExternalTimeout: 15 -> 120
+DocumentConcurrencyLimit: 64
+HTTPConcurrencyLimit: 8
+ExternalTimeout: 120

--- a/website/.htmltest.yaml
+++ b/website/.htmltest.yaml
@@ -54,10 +54,7 @@ IgnoreURLs:
   - https://marketplace.visualstudio.com/items\?itemName=yzhang.markdown-all-in-one
   # 403になってしまうので無視
   - https://blog.expo.dev/
-# タイムアウトでビルドが失敗して困るので、次の値をデフォルトから変更して余裕を持っておく。
-# DocumentConcurrencyLimit: 128 -> 64
-# HTTPConcurrencyLimit: 16 -> 8
-# ExternalTimeout: 15 -> 120
-DocumentConcurrencyLimit: 64
-HTTPConcurrencyLimit: 8
-ExternalTimeout: 120
+# タイムアウトでビルドが失敗するので、失敗時は手動確認とする。
+IgnoreExternalBrokenLinks: true
+# タイムアウトでビルドが失敗すると困るので、余裕を持って長めに設定しておく。
+ExternalTimeout: 60

--- a/website/.htmltest.yaml
+++ b/website/.htmltest.yaml
@@ -54,7 +54,7 @@ IgnoreURLs:
   - https://marketplace.visualstudio.com/items\?itemName=yzhang.markdown-all-in-one
   # 403になってしまうので無視
   - https://blog.expo.dev/
-# タイムアウトでビルドが失敗するので、失敗時は手動確認とする。
+# タイムアウトでビルドが失敗するので、外部リンクのエラーは警告とし手動で問題ないかを確認とする。
 IgnoreExternalBrokenLinks: true
 # タイムアウトでビルドが失敗すると困るので、余裕を持って長めに設定しておく。
 ExternalTimeout: 60


### PR DESCRIPTION
## ✅ What's done

- [x] タイムアウトでビルドが失敗するので、外部リンクのエラーは警告とし手動で問題ないかを確認とする。
  - [x] IgnoreExternalBrokenLinks: false(default) -> true

## Tests

- [x] ローカルのDocker環境でテスト。ローカルでもタイムアウトエラーが出ていたが、上記設定で3回連続htmltestが成功した

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Other (messages to reviewers, concerns, etc.)

なし