### PR TITLE
👔: 定期更新時も同じFCM登録トークンを利用できるようにAPI仕様を変更

### DIFF
--- a/example-app/SantokuApp/src/generated/api/api.ts
+++ b/example-app/SantokuApp/src/generated/api/api.ts
@@ -183,6 +183,19 @@ export interface AccountRegistration {
     'password'?: string;
 }
 /**
+ * 登録・更新するデバイス登録トークン
+ * @export
+ * @interface AddDeviceToken
+ */
+export interface AddDeviceToken {
+    /**
+     * 登録・更新するデバイス登録トークン
+     * @type {string}
+     * @memberof AddDeviceToken
+     */
+    'deviceToken'?: string;
+}
+/**
  * アバター画像
  * @export
  * @interface AvatarImage
@@ -307,6 +320,19 @@ export interface Profile {
      * @memberof Profile
      */
     'avatarImageUrl'?: string;
+}
+/**
+ * 削除するデバイス登録トークン
+ * @export
+ * @interface RemoveDeviceToken
+ */
+export interface RemoveDeviceToken {
+    /**
+     * 削除するデバイス登録トークン
+     * @type {string}
+     * @memberof RemoveDeviceToken
+     */
+    'deviceToken'?: string;
 }
 /**
  * チーム
@@ -495,25 +521,6 @@ export interface TimetableTemplate {
      * @memberof TimetableTemplate
      */
     'periodTemplateList'?: Array<PeriodTemplate>;
-}
-/**
- * 更新するデバイス登録トークン
- * @export
- * @interface UpdateDeviceToken
- */
-export interface UpdateDeviceToken {
-    /**
-     * 登録するデバイス登録トークン
-     * @type {string}
-     * @memberof UpdateDeviceToken
-     */
-    'newDeviceToken'?: string;
-    /**
-     * 削除するデバイス登録トークン
-     * @type {string}
-     * @memberof UpdateDeviceToken
-     */
-    'oldDeviceToken'?: string;
 }
 
 /**
@@ -727,14 +734,14 @@ export const AccountApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * ログイン済みアカウントのデバイス登録トークンを更新する。 
-         * @summary ログイン済みアカウントのデバイス登録トークンの更新
-         * @param {UpdateDeviceToken} [updateDeviceToken] 
+         * ログイン済みアカウントのデバイス登録トークンを登録・更新する。 
+         * @summary ログイン済みアカウントのデバイス登録トークンの登録・更新
+         * @param {AddDeviceToken} [addDeviceToken] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postAccountsMeDeviceToken: async (updateDeviceToken?: UpdateDeviceToken, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/accounts/me/device-token`;
+        postAccountsMeDeviceTokenAdd: async (addDeviceToken?: AddDeviceToken, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/accounts/me/device-token/add`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -755,7 +762,43 @@ export const AccountApiAxiosParamCreator = function (configuration?: Configurati
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(updateDeviceToken, localVarRequestOptions, configuration)
+            localVarRequestOptions.data = serializeDataIfNeeded(addDeviceToken, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * ログイン済みアカウントのデバイス登録トークンを削除する。 
+         * @summary ログイン済みアカウントのデバイス登録トークンの削除
+         * @param {RemoveDeviceToken} [removeDeviceToken] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postAccountsMeDeviceTokenRemove: async (removeDeviceToken?: RemoveDeviceToken, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/accounts/me/device-token/remove`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Session required
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(removeDeviceToken, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1017,14 +1060,25 @@ export const AccountApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * ログイン済みアカウントのデバイス登録トークンを更新する。 
-         * @summary ログイン済みアカウントのデバイス登録トークンの更新
-         * @param {UpdateDeviceToken} [updateDeviceToken] 
+         * ログイン済みアカウントのデバイス登録トークンを登録・更新する。 
+         * @summary ログイン済みアカウントのデバイス登録トークンの登録・更新
+         * @param {AddDeviceToken} [addDeviceToken] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async postAccountsMeDeviceToken(updateDeviceToken?: UpdateDeviceToken, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.postAccountsMeDeviceToken(updateDeviceToken, options);
+        async postAccountsMeDeviceTokenAdd(addDeviceToken?: AddDeviceToken, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postAccountsMeDeviceTokenAdd(addDeviceToken, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * ログイン済みアカウントのデバイス登録トークンを削除する。 
+         * @summary ログイン済みアカウントのデバイス登録トークンの削除
+         * @param {RemoveDeviceToken} [removeDeviceToken] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postAccountsMeDeviceTokenRemove(removeDeviceToken?: RemoveDeviceToken, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postAccountsMeDeviceTokenRemove(removeDeviceToken, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1149,14 +1203,24 @@ export const AccountApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getAccountsMeTerms(options).then((request) => request(axios, basePath));
         },
         /**
-         * ログイン済みアカウントのデバイス登録トークンを更新する。 
-         * @summary ログイン済みアカウントのデバイス登録トークンの更新
-         * @param {UpdateDeviceToken} [updateDeviceToken] 
+         * ログイン済みアカウントのデバイス登録トークンを登録・更新する。 
+         * @summary ログイン済みアカウントのデバイス登録トークンの登録・更新
+         * @param {AddDeviceToken} [addDeviceToken] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postAccountsMeDeviceToken(updateDeviceToken?: UpdateDeviceToken, options?: any): AxiosPromise<void> {
-            return localVarFp.postAccountsMeDeviceToken(updateDeviceToken, options).then((request) => request(axios, basePath));
+        postAccountsMeDeviceTokenAdd(addDeviceToken?: AddDeviceToken, options?: any): AxiosPromise<void> {
+            return localVarFp.postAccountsMeDeviceTokenAdd(addDeviceToken, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * ログイン済みアカウントのデバイス登録トークンを削除する。 
+         * @summary ログイン済みアカウントのデバイス登録トークンの削除
+         * @param {RemoveDeviceToken} [removeDeviceToken] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postAccountsMeDeviceTokenRemove(removeDeviceToken?: RemoveDeviceToken, options?: any): AxiosPromise<void> {
+            return localVarFp.postAccountsMeDeviceTokenRemove(removeDeviceToken, options).then((request) => request(axios, basePath));
         },
         /**
          * ログイン済みアカウントにおいて、指定された利用規約のバージョンに同意します。 
@@ -1287,15 +1351,27 @@ export class AccountApi extends BaseAPI {
     }
 
     /**
-     * ログイン済みアカウントのデバイス登録トークンを更新する。 
-     * @summary ログイン済みアカウントのデバイス登録トークンの更新
-     * @param {UpdateDeviceToken} [updateDeviceToken] 
+     * ログイン済みアカウントのデバイス登録トークンを登録・更新する。 
+     * @summary ログイン済みアカウントのデバイス登録トークンの登録・更新
+     * @param {AddDeviceToken} [addDeviceToken] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountApi
      */
-    public postAccountsMeDeviceToken(updateDeviceToken?: UpdateDeviceToken, options?: AxiosRequestConfig) {
-        return AccountApiFp(this.configuration).postAccountsMeDeviceToken(updateDeviceToken, options).then((request) => request(this.axios, this.basePath));
+    public postAccountsMeDeviceTokenAdd(addDeviceToken?: AddDeviceToken, options?: AxiosRequestConfig) {
+        return AccountApiFp(this.configuration).postAccountsMeDeviceTokenAdd(addDeviceToken, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * ログイン済みアカウントのデバイス登録トークンを削除する。 
+     * @summary ログイン済みアカウントのデバイス登録トークンの削除
+     * @param {RemoveDeviceToken} [removeDeviceToken] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AccountApi
+     */
+    public postAccountsMeDeviceTokenRemove(removeDeviceToken?: RemoveDeviceToken, options?: AxiosRequestConfig) {
+        return AccountApiFp(this.configuration).postAccountsMeDeviceTokenRemove(removeDeviceToken, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/example-app/SantokuApp/src/screens/demo/push-notification/usePushNotification.tsx
+++ b/example-app/SantokuApp/src/screens/demo/push-notification/usePushNotification.tsx
@@ -37,8 +37,8 @@ export const usePushNotification = () => {
 
   const registerFcmToken = useCallback(async () => {
     try {
-      await accountApi.postAccountsMeDeviceToken({newDeviceToken: token});
-      alert('FCM登録トークンをバックエンドに登録しました');
+      await accountApi.postAccountsMeDeviceTokenAdd({deviceToken: token});
+      alert('FCM登録トークンをバックエンドに新規登録または更新しました');
     } catch (e) {
       if (e instanceof ApiResponseError) {
         alert(e.response.data.message);
@@ -50,7 +50,7 @@ export const usePushNotification = () => {
 
   const removeFcmToken = useCallback(async () => {
     try {
-      await accountApi.postAccountsMeDeviceToken({oldDeviceToken: token});
+      await accountApi.postAccountsMeDeviceTokenRemove({deviceToken: token});
       alert('FCM登録トークンをバックエンドから削除しました');
     } catch (e) {
       if (e instanceof ApiResponseError) {

--- a/example-app/api-document/openapi.yaml
+++ b/example-app/api-document/openapi.yaml
@@ -19,7 +19,7 @@ security:
   - Session: []
 paths:
   /csrf_token:
-    get: 
+    get:
       summary: CSRFトークンの取得
       tags:
         - System
@@ -36,7 +36,7 @@ paths:
     post:
       summary: アカウントの登録
       tags:
-        - Account 
+        - Account
       description: |
         アカウントを登録します。アカウントの登録には、ニックネームとパスワードが必要です。
       operationId: post-signup
@@ -66,7 +66,7 @@ paths:
       description: |
         アカウントIDとパスワードを指定してログインします。
       tags:
-        - Account 
+        - Account
       operationId: post-login
       requestBody:
         content:
@@ -98,7 +98,7 @@ paths:
       summary: ログアウトする
       description: ''
       tags:
-        - Account 
+        - Account
       operationId: post-logout
       responses:
         '204':
@@ -120,7 +120,7 @@ paths:
       description: |
         アカウントIDをキーとして登録されているアカウントを取得する。
       tags:
-        - Account 
+        - Account
       operationId: get-accounts-accountId
       responses:
         '200':
@@ -142,7 +142,7 @@ paths:
       description: |
         アバターを取得する。
       tags:
-        - Account 
+        - Account
       operationId: get-accounts-accountId-avatar
       responses:
         '200':
@@ -157,7 +157,7 @@ paths:
       description: |
         ログイン済みのアカウントを取得する。
       tags:
-        - Account 
+        - Account
       operationId: get-accounts-me
       responses:
         '200':
@@ -174,7 +174,7 @@ paths:
       description: |
         ログイン済みアカウントのアバターを取得する。
       tags:
-        - Account 
+        - Account
       operationId: get-accounts-me-avatar
       responses:
         '200':
@@ -188,7 +188,7 @@ paths:
       description: |
         ログイン済みアカウントのアバターを登録する。
       tags:
-        - Account 
+        - Account
       operationId: put-accounts-me-avatar
       requestBody:
         content:
@@ -207,19 +207,35 @@ paths:
                 type: string
                 format: uri-reference
               description: アカウントのアバター画像のURL
-  /accounts/me/device-token:
+  /accounts/me/device-token/add:
     post:
-      summary: ログイン済みアカウントのデバイス登録トークンの更新
+      summary: ログイン済みアカウントのデバイス登録トークンの登録・更新
       description: |
-        ログイン済みアカウントのデバイス登録トークンを更新する。
+        ログイン済みアカウントのデバイス登録トークンを登録・更新する。
       tags:
-        - Account 
-      operationId: post-accounts-me-device-token
+        - Account
+      operationId: post-accounts-me-device-token-add
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateDeviceToken'
+              $ref: '#/components/schemas/AddDeviceToken'
+      responses:
+        '204':
+          description: No Content
+  /accounts/me/device-token/remove:
+    post:
+      summary: ログイン済みアカウントのデバイス登録トークンの削除
+      description: |
+        ログイン済みアカウントのデバイス登録トークンを削除する。
+      tags:
+        - Account
+      operationId: post-accounts-me-device-token-remove
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoveDeviceToken'
       responses:
         '204':
           description: No Content
@@ -229,7 +245,7 @@ paths:
       description: |
         ログイン済みアカウントの有効な利用規約に同意しているかの状態を取得します。
       tags:
-        - Account 
+        - Account
       operationId: get-accounts-me-terms
       responses:
         '200':
@@ -243,7 +259,7 @@ paths:
       description: |
         ログイン済みアカウントにおいて、指定された利用規約のバージョンに同意します。
       tags:
-        - Account 
+        - Account
       operationId: post-accounts-me-terms
       requestBody:
         content:
@@ -273,7 +289,7 @@ paths:
         > sending a payload body on a DELETE request might cause some existing
         > implementations to reject the request.
       tags:
-        - Account 
+        - Account
       operationId: delete-accounts-me-delete
       requestBody:
         content:
@@ -295,7 +311,7 @@ paths:
       description: |
         有効な利用規約を取得します。このAPIの呼び出しには認証情報は不要です。
       tags:
-        - Terms 
+        - Terms
       security: []
       operationId: get-terms
       responses:
@@ -623,11 +639,11 @@ components:
           description: トークンのヘッダー名
         csrfTokenParameterName:
           type: string
-          description: トークンのパラメータ名        
+          description: トークンのパラメータ名
       required:
-        - csrfTokenValue 
-        - csrfTokenHeaderName 
-        - csrfTokenParameterName 
+        - csrfTokenValue
+        - csrfTokenHeaderName
+        - csrfTokenParameterName
     Profile:
       title: Profile
       type: object
@@ -735,16 +751,21 @@ components:
           type: string
           format: binary
           description: アバター画像
-    UpdateDeviceToken:
-      title: UpdateDeviceToken
+    AddDeviceToken:
+      title: AddDeviceToken
       type: object
-      description: 更新するデバイス登録トークン
+      description: 登録・更新するデバイス登録トークン
       properties:
-        newDeviceToken:
+        deviceToken:
           type: string
-          description: 登録するデバイス登録トークン
-        oldDeviceToken:
-          type: string 
+          description: 登録・更新するデバイス登録トークン
+    RemoveDeviceToken:
+      title: RemoveDeviceToken
+      type: object
+      description: 削除するデバイス登録トークン
+      properties:
+        deviceToken:
+          type: string
           description: 削除するデバイス登録トークン
     TermsOfService:
       title: TermsOfService

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/presentation/restapi/account/MyAccountDeviceTokenAction.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/presentation/restapi/account/MyAccountDeviceTokenAction.java
@@ -1,11 +1,8 @@
 package jp.fintan.mobile.santokuapp.presentation.restapi.account;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import jp.fintan.mobile.santokuapp.application.service.LoginAccountIdSupplier;
 import jp.fintan.mobile.santokuapp.application.service.account.AccountDeviceTokenService;

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/presentation/restapi/account/MyAccountDeviceTokenAction.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/presentation/restapi/account/MyAccountDeviceTokenAction.java
@@ -1,8 +1,11 @@
 package jp.fintan.mobile.santokuapp.presentation.restapi.account;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import jp.fintan.mobile.santokuapp.application.service.LoginAccountIdSupplier;
 import jp.fintan.mobile.santokuapp.application.service.account.AccountDeviceTokenService;
@@ -40,10 +43,41 @@ public class MyAccountDeviceTokenAction {
     }
   }
 
+  @POST
+  @Path("/add")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public void add(ExecutionContext context, UpdateDeviceTokenRequest requestBody) {
+    AccountId accountId = loginAccountIdSupplier.supply();
+
+    if (requestBody.deviceToken != null) {
+      accountDeviceTokenService.deleteDevice(accountId, new DeviceToken(requestBody.deviceToken));
+      accountDeviceTokenService.registerDevice(accountId, new DeviceToken(requestBody.deviceToken));
+    }
+  }
+
+  @POST
+  @Path("/remove")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public void remove(ExecutionContext context, DeleteDeviceTokenRequest requestBody) {
+    AccountId accountId = loginAccountIdSupplier.supply();
+
+    if (requestBody.deviceToken != null) {
+      accountDeviceTokenService.deleteDevice(accountId, new DeviceToken(requestBody.deviceToken));
+    }
+  }
+
   public static class DeviceTokenRequest {
 
     public String newDeviceToken;
 
     public String oldDeviceToken;
+  }
+
+  public static class UpdateDeviceTokenRequest {
+    public String deviceToken;
+  }
+
+  public static class DeleteDeviceTokenRequest {
+    public String deviceToken;
   }
 }


### PR DESCRIPTION
## ✅ What's done

- [x] バックエンドAPIに登録トークンの登録のみ、削除のみを行うAPIを追加
- [x] 上記に合わせてOpenAPI定義を修正
- [x] 上記に合わせてクライアント側コードを修正

<!-- 該当するものがなければ、このセクション（この行から「---」の前の行まで）を削除してください。 -->
## ⏸ What's not done

- クライアント側での登録トークン定期更新処理の実装
  - 現時点ではデモ画面から手動で登録トークンの登録・削除を行う機能のみ

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] Android Emulatorでの動作確認
  - [x] プッシュ通知のデモ画面から登録トークンの取得とバックエンドサーバへの登録・削除ができることの確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 4/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
