### PR TITLE
✨: ApplicationErrorはグローバルエラーハンドリングしないよう修正

### DIFF
--- a/example-app/SantokuApp/src/components/reactQuery/useDefaultGlobalErrorHandler.ts
+++ b/example-app/SantokuApp/src/components/reactQuery/useDefaultGlobalErrorHandler.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import {useSnackbar} from 'components/overlay';
 import {m, log} from 'framework';
+import {isApplicationError} from 'framework/error/ApplicationError';
 import {RequestTimeoutError} from 'framework/error/RequestTimeoutError';
 import {ErrorResponse} from 'generated/backend/model';
 import {useCallback} from 'react';
@@ -69,6 +70,10 @@ const useBaseErrorHandler = () => {
 
   return useCallback(
     (error: unknown) => {
+      if (isApplicationError(error)) {
+        // ApplicationErrorは呼出し元で処理する
+        return;
+      }
       if (axios.isCancel(error)) {
         // Timeout以外の理由でcancelされた場合 (cancelQueries呼び出し時など)
         // デフォルトの動作としては特に処理を実施しない

--- a/example-app/SantokuApp/src/framework/error/ApplicationError.ts
+++ b/example-app/SantokuApp/src/framework/error/ApplicationError.ts
@@ -83,3 +83,7 @@ export class ApplicationError extends Error {
     this.stack = mergeStackTrace(this.stack, stackTraceSoFar);
   }
 }
+
+export function isApplicationError(error: any): error is ApplicationError {
+  return error !== null && typeof error === 'object' && error instanceof ApplicationError;
+}

--- a/example-app/SantokuApp/src/framework/error/RequestTimeoutError.ts
+++ b/example-app/SantokuApp/src/framework/error/RequestTimeoutError.ts
@@ -1,3 +1,1 @@
-import {ApplicationError} from './ApplicationError';
-
-export class RequestTimeoutError extends ApplicationError {}
+export class RequestTimeoutError extends Error {}

--- a/example-app/SantokuApp/src/screens/demo/authentication/useAuthentication.tsx
+++ b/example-app/SantokuApp/src/screens/demo/authentication/useAuthentication.tsx
@@ -1,43 +1,31 @@
-import axios from 'axios';
-import {AuthenticationService, generatePassword, PasswordNotFoundError} from 'framework';
-import {ApplicationError} from 'framework/error/ApplicationError';
-import {ErrorResponse} from 'generated/backend/model';
-import {useCallback, useState} from 'react';
+import {useLoadingOverlay} from 'components/overlay';
+import {ActiveAccountIdNotFoundError, AuthenticationService, generatePassword, PasswordNotFoundError} from 'framework';
+import {isApplicationError} from 'framework/error/ApplicationError';
+import {useCallback, useEffect, useState} from 'react';
 
 export const useAuthentication = () => {
   const [accountId, setAccountId] = useState<string>();
   const [accountIdInput, setAccountIdInput] = useState('');
+  const loadingOverlay = useLoadingOverlay();
   const mutationSignup = AuthenticationService.useSignup();
   const mutationChangeAccount = AuthenticationService.useChangeAccount();
   const mutationAutoLogin = AuthenticationService.useAutoLogin();
   const mutationLogout = AuthenticationService.useLogout();
 
-  const signup = useCallback(async () => {
-    try {
-      const password = await generatePassword();
-      const account = await mutationSignup.mutateAsync({nickname: 'demoNickname', password});
-      setAccountId(account.accountId);
-      alert(`アカウントIDは${account.accountId}です`);
-    } catch (e) {
-      if (axios.isAxiosError(e) && e.response) {
-        const data = e.response.data as ErrorResponse | undefined;
-        const message = data?.message ?? '予期せぬ通信エラー';
-        alert(message);
-        return;
-      }
-      alert(e);
-    }
-  }, [mutationSignup]);
+  const isProcessing =
+    mutationSignup.isLoading ||
+    mutationChangeAccount.isLoading ||
+    mutationAutoLogin.isLoading ||
+    mutationLogout.isLoading;
 
-  const changeAccount = useCallback(async () => {
-    try {
-      const accountLoginResponse = await mutationChangeAccount.mutateAsync({accountId: accountIdInput});
-      alert(`ログイン成功しました state=${accountLoginResponse.status}`);
-    } catch (e) {
-      if (axios.isAxiosError(e) && e.response) {
-        const data = e.response.data as ErrorResponse | undefined;
-        const message = data?.message ?? '予期せぬ通信エラー';
-        alert(message);
+  useEffect(() => {
+    loadingOverlay.setVisible(isProcessing);
+  }, [isProcessing, loadingOverlay]);
+
+  const handleError = useCallback((e: unknown) => {
+    if (isApplicationError(e)) {
+      if (e instanceof ActiveAccountIdNotFoundError) {
+        alert('自動ログイン可能なアカウントIDが見つかりません');
         return;
       }
       if (e instanceof PasswordNotFoundError) {
@@ -46,50 +34,54 @@ export const useAuthentication = () => {
       }
       alert(e);
     }
-  }, [mutationChangeAccount, accountIdInput]);
+  }, []);
+
+  const signup = useCallback(async () => {
+    try {
+      const password = await generatePassword();
+      const account = await mutationSignup.mutateAsync({nickname: 'demoNickname', password});
+      setAccountId(account.accountId);
+      alert(`アカウントIDは${account.accountId}です`);
+    } catch (e) {
+      handleError(e);
+    }
+  }, [mutationSignup, handleError]);
+
+  const changeAccount = useCallback(async () => {
+    try {
+      const accountLoginResponse = await mutationChangeAccount.mutateAsync({accountId: accountIdInput});
+      alert(`ログイン成功しました state=${accountLoginResponse.status}`);
+    } catch (e) {
+      handleError(e);
+    }
+  }, [mutationChangeAccount, accountIdInput, handleError]);
 
   const canAutoLogin = useCallback(async () => {
     try {
       const res = await AuthenticationService.canAutoLogin();
       alert(res ? '自動ログイン可能です' : '自動ログインできません');
     } catch (e) {
-      alert(e);
+      handleError(e);
     }
-  }, []);
+  }, [handleError]);
 
   const autoLogin = useCallback(async () => {
     try {
       const accountLoginResponse = await mutationAutoLogin.mutateAsync();
       alert(`自動ログイン成功しました state=${accountLoginResponse.status}`);
     } catch (e) {
-      if (axios.isAxiosError(e) && e.response) {
-        const data = e.response.data as ErrorResponse | undefined;
-        const message = data?.message ?? '予期せぬ通信エラー';
-        alert(message);
-        return;
-      }
-      if (e instanceof ApplicationError) {
-        alert(e.message);
-        return;
-      }
-      alert(e);
+      handleError(e);
     }
-  }, [mutationAutoLogin]);
+  }, [mutationAutoLogin, handleError]);
 
   const logout = useCallback(async () => {
     try {
       await mutationLogout.mutateAsync();
       alert(`ログアウト成功しました`);
     } catch (e) {
-      if (axios.isAxiosError(e) && e.response) {
-        const data = e.response.data as ErrorResponse | undefined;
-        const message = data?.message ?? '予期せぬ通信エラー';
-        alert(message);
-        return;
-      }
-      alert(e);
+      handleError(e);
     }
-  }, [mutationLogout]);
+  }, [mutationLogout, handleError]);
 
   const copyAccountIdInput = useCallback(() => {
     if (accountId) {


### PR DESCRIPTION
## ✅ What's done

- [x] ApplicationErrorはグローバルエラーハンドリングしないよう改修
  - [x] ApplicationErrorを判別する型ガードを追加
  - [x] RequestTimeoutErrorはApplicationErrorの派生クラスではなくErrorの派生クラスに変更
    - グローバルエラーハンドリングで処理してもcatch句は呼ばれるので、画面側をシンプルにするために変更しました
  - [x] 認証デモ画面のエラーハンドリング周りを修正
- [x] その他
  - [x] 認証デモ画面で処理中はローディングオーバレイを表示するよう修正

---

## Tests

- [x] 実機での正常系動作確認

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [x] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Fire HD8)

## Other (messages to reviewers, concerns, etc.)

なし
