### PR TITLE
🐛: Snackbarが意図せず再表示されてしまう事象の対応

### DIFF
--- a/example-app/SantokuApp/src/components/overlay/snackbar/Snackbar.test.tsx
+++ b/example-app/SantokuApp/src/components/overlay/snackbar/Snackbar.test.tsx
@@ -104,6 +104,77 @@ describe('Snackbar', () => {
     });
   });
 
+  it('Snackbarの表示後に同一のpropsを指定した場合、Snackbarが表示されないことを確認', () => {
+    const props = {
+      message: 'テストメッセージ',
+      messageTextStyle: {color: 'white'},
+      style: {backgroundColor: 'aqua'},
+      positionStyle: {minHeight: 60},
+      actionText: 'close',
+      actionHandler: jest.fn(),
+      actionTextStyle: {color: 'red'},
+      autoHideDuration: 100,
+      fadeInDuration: 200,
+      fadeOutDuration: 300,
+      forceFadeOutDuration: 400,
+      timestamp: Date.now(),
+    };
+    const renderResult = render(
+      <Snackbar {...props}>
+        <ChildComponent />
+      </Snackbar>,
+    );
+
+    expect(renderResult.queryByText('テストメッセージ')).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(FADE_IN_DURATION + AUTO_HIDE_DURATION + FADE_OUT_DURATION);
+    });
+
+    renderResult.update(
+      <Snackbar {...props}>
+        <ChildComponent />
+      </Snackbar>,
+    );
+
+    expect(renderResult.queryByText('テストメッセージ')).toBeNull();
+  });
+
+  it('Snackbarの表示後にTimestamp以外同一のpropsを指定した場合、Snackbarが表示されることを確認', () => {
+    const props = {
+      message: 'テストメッセージ',
+      messageTextStyle: {color: 'white'},
+      style: {backgroundColor: 'aqua'},
+      positionStyle: {minHeight: 60},
+      actionText: 'close',
+      actionHandler: jest.fn(),
+      actionTextStyle: {color: 'red'},
+      autoHideDuration: 100,
+      fadeInDuration: 200,
+      fadeOutDuration: 300,
+      forceFadeOutDuration: 400,
+    };
+    const renderResult = render(
+      <Snackbar {...props} timestamp={Date.now()}>
+        <ChildComponent />
+      </Snackbar>,
+    );
+
+    expect(renderResult.queryByText('テストメッセージ')).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(FADE_IN_DURATION + AUTO_HIDE_DURATION + FADE_OUT_DURATION);
+    });
+
+    renderResult.update(
+      <Snackbar {...props} timestamp={Date.now()}>
+        <ChildComponent />
+      </Snackbar>,
+    );
+
+    expect(renderResult.queryByText('テストメッセージ')).not.toBeNull();
+  });
+
   it('Snackbar表示中にpropsでhideを指定した場合、Snackbarが消えることを確認', async () => {
     const renderResult = render(
       <Snackbar message="テストメッセージ">

--- a/example-app/SantokuApp/src/components/overlay/snackbar/Snackbar.tsx
+++ b/example-app/SantokuApp/src/components/overlay/snackbar/Snackbar.tsx
@@ -52,6 +52,10 @@ export type SnackbarShowProps = {
    * This is applied when you try to display another snackbar while a snackbar is being displayed.
    */
   forceFadeOutDuration?: number;
+  /**
+   * Timestamp
+   */
+  timestamp?: number;
 };
 
 export type SnackbarHideProps = {
@@ -93,7 +97,20 @@ export const Snackbar: React.FC<SnackbarProps> = props => {
   );
 
   const show = useCallback(() => {
-    setVisibleSnackbarProps(props);
+    setVisibleSnackbarProps({
+      actionHandler: props.actionHandler,
+      actionText: props.actionText,
+      actionTextStyle: props.actionTextStyle,
+      autoHideDuration: props.autoHideDuration,
+      fadeInDuration: props.fadeInDuration,
+      fadeOutDuration: props.fadeOutDuration,
+      forceFadeOutDuration: props.forceFadeOutDuration,
+      message: props.message,
+      messageTextStyle: props.messageTextStyle,
+      positionStyle: props.positionStyle,
+      style: props.style,
+      timestamp: props.timestamp,
+    });
 
     const fadeInAnimationConfig = {
       toValue: 1,
@@ -119,7 +136,21 @@ export const Snackbar: React.FC<SnackbarProps> = props => {
         }
       }
     });
-  }, [props, animationStart]);
+  }, [
+    animationStart,
+    props.actionHandler,
+    props.actionText,
+    props.actionTextStyle,
+    props.autoHideDuration,
+    props.fadeInDuration,
+    props.fadeOutDuration,
+    props.forceFadeOutDuration,
+    props.message,
+    props.messageTextStyle,
+    props.positionStyle,
+    props.style,
+    props.timestamp,
+  ]);
 
   const forceFadeout = useCallback(
     (fadeOutDuration?: number, callback?: () => void) => {
@@ -160,7 +191,7 @@ export const Snackbar: React.FC<SnackbarProps> = props => {
       return;
     }
     show();
-  }, [props, show, forceFadeout]);
+  }, [show, forceFadeout, props.hide, props.message, props.hideFadeOutDuration, props.forceFadeOutDuration]);
 
   const snackbarStyle = StyleSheet.flatten([styles.snackbar, props.style]);
 

--- a/example-app/SantokuApp/src/components/overlay/snackbar/WithSnackbar.tsx
+++ b/example-app/SantokuApp/src/components/overlay/snackbar/WithSnackbar.tsx
@@ -49,12 +49,14 @@ function WithSnackbar(props: {initialState?: SnackbarShowProps; children: React.
     () => ({
       show: (message: string, showProps?: SnackbarShowContextProps) => {
         setState({
+          timestamp: Date.now(),
           ...showProps,
           message,
         });
       },
       showWithCloseButton: (message: string, showProps?: SnackbarShowCloseButtonContextProps) => {
         setState({
+          timestamp: Date.now(),
           ...showProps,
           actionText: m('閉じる'),
           actionHandler: snackbarContext.hide,


### PR DESCRIPTION
## ✅ What's done

- [x] Snackbarの中に定義されている関数で、HooksAPIのdependenciesに`props`を指定していた部分を、厳密に使用している項目だけを指定するように変更
- [x] `props`に`timestamp`を追加（`timestamp`以外の項目が同一の場合にSnackbarが表示されなくなってしまうため）

---

## Tests

- [x] 自動テスト
- [x] Snackbarのデモ画面で打鍵

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 4a/Android 12)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
