### PR TITLE
🚑: .eslintrc.jsにreact-hooks/recommendedを追加

### DIFF
--- a/example-app/SantokuApp/.eslintrc.js
+++ b/example-app/SantokuApp/.eslintrc.js
@@ -4,7 +4,7 @@
 module.exports = {
   root: true,
   // universe/native: https://github.com/expo/expo/tree/master/packages/eslint-config-universe
-  extends: ['universe/native'],
+  extends: ['universe/native', 'plugin:react-hooks/recommended'],
   overrides: [
     {
       files: ['*.ts', '*.tsx', '*.d.ts'],


### PR DESCRIPTION
## ✅ What's done

#808 で`plugin:react-hooks/recommended`を`.eslintrc`の`extends`から外したが（`universe/native`に入っていると思ったため）、`eslint-config-universe`では、[`react-hooks/exhaustive-deps`を`off`に設定](https://github.com/expo/expo/blob/master/packages/eslint-config-universe/shared/react.js#L40)していたため、`plugin:react-hooks/recommended`を`.eslintrc`の`extends`に再度追加しました。

---

## Other (messages to reviewers, concerns, etc.)

なし
