### PR TITLE
🔧: In Jest testing, suppress warning log by React Query

### DIFF
--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -2,5 +2,9 @@ module.exports = {
   preset: 'jest-expo',
   // __mocks__ディレクトリをjestディレクトリ内に配置したいので、ルートディレクトリにjestを設定しています。
   roots: ['<rootDir>/src', 'jest'],
-  setupFiles: ['<rootDir>/jest/setup/global.js', '<rootDir>/jest/setup/react-navigation.js'],
+  setupFiles: [
+    '<rootDir>/jest/setup/global.js',
+    '<rootDir>/jest/setup/react-navigation.js',
+    '<rootDir>/jest/setup/react-query.js',
+  ],
 };

--- a/example-app/SantokuApp/jest/setup/react-query.js
+++ b/example-app/SantokuApp/jest/setup/react-query.js
@@ -1,0 +1,8 @@
+// ✅ no more noisy error logs on the console by React Query when promises are rejected.
+import {setLogger} from 'react-query';
+
+setLogger({
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+});

--- a/example-app/SantokuApp/jest/setup/react-query.js
+++ b/example-app/SantokuApp/jest/setup/react-query.js
@@ -1,4 +1,5 @@
-// ✅ no more noisy error logs on the console by React Query when promises are rejected.
+// no more noisy error logs on the console by React Query when promises are rejected.
+// https://react-query.tanstack.com/guides/testing#turn-off-network-error-logging
 import {setLogger} from 'react-query';
 
 setLogger({


### PR DESCRIPTION
## ✅ What's done

- [x] Mock the logger of React Query

---

## Tests

- [x] `npm run test`
  - [x] Warning logs are not output.

## Other (messages to reviewers, concerns, etc.)

なし