### PR TITLE
🚑: Fix broken aspect ratio of images in Tab

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -130,6 +130,8 @@ html[data-theme="dark"] .header-github-link::before {
 .markdown img {
   display: block;
   margin: auto;
+  width: auto;
+  height: auto;
   max-width: 100%;
   max-height: 50em;
 }


### PR DESCRIPTION
## ✅ What's done

- [x] Fix broken aspect ratio of images in Tab (website)

---

## Tests

- [x] `npm start`
  - [x]  http://localhost:3000/mobile-app-crib-notes/react-native/learn/basic-concepts/react-native-basics/components/view

| Before | After |
|--------|------|
| ![Aspect ratio is broken...](https://user-images.githubusercontent.com/44867563/162423152-266c73c3-0f80-4e1f-9c15-7930ff4f644b.png) | ![スクリーンショット 2022-04-08 20 00 44](https://user-images.githubusercontent.com/44867563/162423221-7eae1ea5-cbfd-4d22-bb0d-34365088546c.png) |


## Other (messages to reviewers, concerns, etc.)

なし