### PR TITLE
🚑: Fix wrong option name to run Android variant

### DIFF
--- a/website/docs/react-native/santoku/development/build-configuration/build-variants.mdx
+++ b/website/docs/react-native/santoku/development/build-configuration/build-variants.mdx
@@ -170,7 +170,7 @@ Android向けのビルドには、Google Playのアップロード鍵を保存�
 起動時に`variants`と`appIdSuffix`の2つのオプションを渡すと、ビルドタイプとプロダクトフレーバーを指定してAndroidアプリを起動できます。
 
 ```bash
-npm run android -- --appId jp.fintan.mobile.SantokuApp --variants "<flavor><Type>" --appIdSuffix "<flavorSuffix><typeSuffix>"
+npm run android -- --appId jp.fintan.mobile.SantokuApp --variant "<flavor><Type>" --appIdSuffix "<flavorSuffix><typeSuffix>"
 ```
 
 例えばビルドタイプDebug、プロダクトフレーバーDevSantokuAppでアプリを実行するには次のようにしてください。


### PR DESCRIPTION
## ✅ What's done

- [x] Fix wrong option name to run Android variant

---

## Other (messages to reviewers, concerns, etc.)

なし