### PR TITLE
🚑: Align the version of the iOS Release build with the others

### DIFF
--- a/example-app/SantokuApp/ios/SantokuApp/Info.plist
+++ b/example-app/SantokuApp/ios/SantokuApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
## ✅ What's done

- [x] Fix the version in `Info.plist`

---

## Tests

- [x] Launch app

## Devices

- [x] iOS
  - [ ] ~~シミュレータ (iPhone Xs/iOS 14)~~
  - [x] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [ ] ~~エミュレータ (Pixel 3a/Android 11)~~
  - [x] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし