### PR TITLE
🔧: asdfで使用するJavaのディストリビューションをAzul Zuluに変更

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.14.2
-java temurin-11.0.14+101
+java zulu-11.56.19
 ruby 3.0.3


### PR DESCRIPTION
## ✅ What's done

- [x] `asdf-java`に、arm64に対応した`temurin-11.xxx`が存在しなかったので、ディストリビューションを`Azul Zulu`に変更

＜参考＞
https://reactnative.dev/docs/environment-setup（React Nativeの公式では`Azul Zulu`をお薦めしている）
https://github.com/halcyon/asdf-java/blob/master/data/jdk-macosx-aarch64.tsv#L239

## ⏸ What's not done

なし

---

## Other (messages to reviewers, concerns, etc.)

なし
