### PR TITLE
🔧:onSelectedItemChangeのパラメータ定義を変更

### DIFF
--- a/example-app/SantokuApp/src/components/picker/SelectPicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPicker.tsx
@@ -36,17 +36,17 @@ export type SelectPickerProps<ItemT> = {
   /**
    * 選択されたアイテムのKey
    */
-  selectedItemKey: React.Key | undefined;
+  selectedItemKey?: React.Key;
   /**
    * アイテムが選択された場合に呼び出される関数
    */
-  onSelectedItemChange?: (selectedItem: Item<ItemT> | undefined) => void;
+  onSelectedItemChange?: (selectedItem?: Item<ItemT>) => void;
   /**
    * PickerBackdropをタップして閉じた場合に呼び出される関数
    *
    * @platform ios
    */
-  onDismiss?: (selectedItem: Item<ItemT> | undefined) => void;
+  onDismiss?: (selectedItem?: Item<ItemT>) => void;
   /**
    * DeleteLabelがタップされた場合に呼び出される関数
    * タップ後、SelectPickerは自動で閉じます。
@@ -54,7 +54,7 @@ export type SelectPickerProps<ItemT> = {
    *
    * @platform ios
    */
-  onDelete?: (selectedItem: Item<ItemT> | undefined) => void;
+  onDelete?: (selectedItem?: Item<ItemT>) => void;
   /**
    * CancelLabelがタップされた場合に呼び出される関数
    * タップ後、SelectPickerは自動で閉じます。
@@ -62,7 +62,7 @@ export type SelectPickerProps<ItemT> = {
    *
    * @platform ios
    */
-  onCancel?: (selectedItem: Item<ItemT> | undefined) => void;
+  onCancel?: (selectedItem?: Item<ItemT>) => void;
   /**
    * [iOS]
    * DoneLabelがタップされた場合に呼び出される関数
@@ -72,7 +72,7 @@ export type SelectPickerProps<ItemT> = {
    * [Android]
    * アイテムが選択された場合に呼び出される関数
    */
-  onDone?: (selectedItem: Item<ItemT> | undefined) => void;
+  onDone?: (selectedItem?: Item<ItemT>) => void;
   /**
    * プレースホルダ
    */

--- a/example-app/SantokuApp/src/components/picker/SelectPicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPicker.tsx
@@ -40,7 +40,7 @@ export type SelectPickerProps<ItemT> = {
   /**
    * アイテムが選択された場合に呼び出される関数
    */
-  onSelectedItemChange?: (itemIndex: number, itemValue?: ItemT, itemKey?: React.Key) => void;
+  onSelectedItemChange?: (selectedItem: Item<ItemT> | undefined) => void;
   /**
    * PickerBackdropをタップして閉じた場合に呼び出される関数
    *

--- a/example-app/SantokuApp/src/components/picker/useSelectPickerAndroidUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useSelectPickerAndroidUseCase.ts
@@ -7,9 +7,9 @@ export const useSelectPickerAndroidUseCase = <ItemT extends unknown>(props: Sele
   const {getSelectedItem, inputValue} = useSelectPickerUseCase<ItemT>(props);
   const {onSelectedItemChange, onDone} = props;
   const onValueChange = useCallback(
-    (key: React.Key, index: number) => {
+    (key: React.Key) => {
       const selectedItem = getSelectedItem(key);
-      onSelectedItemChange?.(index, selectedItem?.value, key);
+      onSelectedItemChange?.(selectedItem);
       onDone?.(selectedItem);
     },
     [getSelectedItem, onDone, onSelectedItemChange],

--- a/example-app/SantokuApp/src/components/picker/useSelectPickerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useSelectPickerUseCase.ts
@@ -42,9 +42,9 @@ export const useSelectPickerUseCase = <ItemT extends unknown>({
     [items],
   );
   const onValueChange = useCallback(
-    (key: React.Key | ItemT, index: number) => {
+    (key: React.Key | ItemT) => {
       const selectedItem = getSelectedItem(key);
-      onSelectedItemChange?.(index, selectedItem?.value, selectedItem?.key);
+      onSelectedItemChange?.(selectedItem);
     },
     [getSelectedItem, onSelectedItemChange],
   );

--- a/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
+++ b/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
@@ -32,8 +32,8 @@ export const usePickerScreenUseCase = () => {
   //////////////////////////////////////////////////////////////////////////////////
   const [items1Key, setItems1Key] = useState<React.Key>();
   const [items1CanceledKey, setItems1CanceledKey] = useState<React.Key>();
-  const onSelectedItemChangeForItem1 = useCallback((_, __, key?: React.Key) => {
-    setItems1Key(key);
+  const onSelectedItemChangeForItem1 = useCallback((selectedItem?: Item<Item1Type>) => {
+    setItems1Key(selectedItem?.key);
   }, []);
   const items1InputValue = useMemo(
     () => items1.find(item => item.key === items1Key)?.inputLabel ?? placeholder,
@@ -61,16 +61,16 @@ export const usePickerScreenUseCase = () => {
     () => items2.find(item => item.value === items2Value)?.inputLabel ?? placeholder,
     [items2Value],
   );
-  const onSelectedItemChangeForItem2 = useCallback((_, value?: string | undefined, __?) => {
-    setItems2Value(value);
+  const onSelectedItemChangeForItem2 = useCallback((selectedItem?: Item<string>) => {
+    setItems2Value(selectedItem?.value);
   }, []);
 
   //////////////////////////////////////////////////////////////////////////////////
   // Items3
   //////////////////////////////////////////////////////////////////////////////////
   const [items3Key, setItems3Key] = useState<React.Key>();
-  const onSelectedItemChangeForItem3 = useCallback((_, __, key?: React.Key) => {
-    setItems3Key(key);
+  const onSelectedItemChangeForItem3 = useCallback((selectedItem?: Item<string>) => {
+    setItems3Key(selectedItem?.key);
   }, []);
 
   //////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## ✅ What's done

- [x] onSelectedItemChangeのパラメータ定義を「selectedItem?: Item＜ItemT＞」に変更
- [x] undefined定義を省略形で統一 

## Tests

- [x] Demo画面にて手動打鍵（Android/iOS）

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone 12/iOS 15)
- [X] Android
  - [x] エミュレータ (Pixel 4/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
