### PR TITLE
✨: [wip] DateTimePickerを追加

### DIFF
--- a/example-app/SantokuApp/ios/Podfile.lock
+++ b/example-app/SantokuApp/ios/Podfile.lock
@@ -425,6 +425,8 @@ PODS:
     - React-Core
   - RNCPicker (2.2.1):
     - React-Core
+  - RNDateTimePicker (4.0.0):
+    - React-Core
   - RNFBApp (14.9.0):
     - Firebase/CoreOnly (= 8.15.0)
     - React-Core
@@ -542,6 +544,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBCrashlytics (from `../node_modules/@react-native-firebase/crashlytics`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
@@ -670,6 +673,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNCPicker:
     :path: "../node_modules/@react-native-picker/picker"
+  RNDateTimePicker:
+    :path: "../node_modules/@react-native-community/datetimepicker"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBCrashlytics:
@@ -754,6 +759,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 6bd5a7ba3dde1c3facba418aa273f449bdc5437a
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
+  RNDateTimePicker: 2224ee77a86b7123377597a015502435e2e49957
   RNFBApp: d3a0f69a3cc67c609f962acf67f483a841ffc49f
   RNFBCrashlytics: 297dea939dd7608ffdfaf90cdb869c586749f8b4
   RNFBMessaging: fefc7807402d03f418bdc5e80c60fbc91d943c50

--- a/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
+++ b/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		6909A3A626E1EC0000F9111D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6909A3A526E1EC0000F9111D /* GoogleService-Info.plist */; };
+		69506AA92845DE0200FCFD34 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 69506AAB2845DE0200FCFD34 /* InfoPlist.strings */; };
 		699A764426E6E48500D48F9D /* RCTThrowErrorModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 699A764326E6E48500D48F9D /* RCTThrowErrorModule.m */; };
 		96905EF65AED1B983A6B3ABC /* libPods-SantokuApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-SantokuApp.a */; };
 /* End PBXBuildFile section */
@@ -28,6 +29,8 @@
 		3280BADF6F7E2E51C7BC7D30 /* Pods-SantokuApp.releaseinhouse.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SantokuApp.releaseinhouse.xcconfig"; path = "Target Support Files/Pods-SantokuApp/Pods-SantokuApp.releaseinhouse.xcconfig"; sourceTree = "<group>"; };
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-SantokuApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SantokuApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6909A3A526E1EC0000F9111D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		69506AAA2845DE0200FCFD34 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		69506AAC2845DE0700FCFD34 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		699A764226E6E45C00D48F9D /* RCTThrowErrorModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTThrowErrorModule.h; sourceTree = "<group>"; };
 		699A764326E6E48500D48F9D /* RCTThrowErrorModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTThrowErrorModule.m; sourceTree = "<group>"; };
 		69DBD4902763515A006D47A1 /* SantokuAppReleaseInHouse.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = SantokuAppReleaseInHouse.entitlements; path = SantokuApp/SantokuAppReleaseInHouse.entitlements; sourceTree = "<group>"; };
@@ -70,6 +73,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+				69506AAB2845DE0200FCFD34 /* InfoPlist.strings */,
 			);
 			name = SantokuApp;
 			sourceTree = "<group>";
@@ -205,7 +209,7 @@
 			knownRegions = (
 				en,
 				Base,
-				"ja-JP",
+				ja,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
@@ -223,6 +227,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				69506AA92845DE0200FCFD34 /* InfoPlist.strings in Resources */,
 				6909A3A626E1EC0000F9111D /* GoogleService-Info.plist in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
 			);
@@ -362,6 +367,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		69506AAB2845DE0200FCFD34 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				69506AAA2845DE0200FCFD34 /* ja */,
+				69506AAC2845DE0700FCFD34 /* en */,
+			);
+			name = InfoPlist.strings;
+			path = SantokuApp;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {

--- a/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
+++ b/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 			knownRegions = (
 				en,
 				Base,
-				ja,
+				"ja-JP",
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;

--- a/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
+++ b/example-app/SantokuApp/ios/SantokuApp.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;

--- a/example-app/SantokuApp/ios/SantokuApp/en.lproj/InfoPlist.strings
+++ b/example-app/SantokuApp/ios/SantokuApp/en.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* 
+  InfoPlist.strings
+  SantokuApp
+*/

--- a/example-app/SantokuApp/ios/SantokuApp/ja.lproj/InfoPlist.strings
+++ b/example-app/SantokuApp/ios/SantokuApp/ja.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* 
+  InfoPlist.strings
+  SantokuApp
+*/

--- a/example-app/SantokuApp/package-lock.json
+++ b/example-app/SantokuApp/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@react-native-async-storage/async-storage": "~1.15.0",
+        "@react-native-community/datetimepicker": "4.0.0",
         "@react-native-community/netinfo": "7.1.3",
         "@react-native-firebase/app": "~14.9.0",
         "@react-native-firebase/crashlytics": "~14.9.0",
@@ -4863,6 +4864,14 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-4.0.0.tgz",
+      "integrity": "sha512-q3JfDHX5PI0AxFeMsB6jcHSXODloXAqBVsOfkIvm+YbAe1TUs/xZ3qGazsKVBk9EdFyHO4k+S1Q8tQkEnk2YrQ==",
+      "dependencies": {
+        "invariant": "^2.2.4"
       }
     },
     "node_modules/@react-native-community/netinfo": {
@@ -26703,6 +26712,14 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "@react-native-community/datetimepicker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-4.0.0.tgz",
+      "integrity": "sha512-q3JfDHX5PI0AxFeMsB6jcHSXODloXAqBVsOfkIvm+YbAe1TUs/xZ3qGazsKVBk9EdFyHO4k+S1Q8tQkEnk2YrQ==",
+      "requires": {
+        "invariant": "^2.2.4"
       }
     },
     "@react-native-community/netinfo": {

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -66,7 +66,8 @@
     "react-native-web": "0.17.1",
     "react-native-webview": "11.15.0",
     "react-query": "^3.34.8",
-    "yup": "~0.32.11"
+    "yup": "~0.32.11",
+    "@react-native-community/datetimepicker": "4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.test.tsx
@@ -1,0 +1,179 @@
+import {fireEvent, render} from '@testing-library/react-native';
+import React from 'react';
+import {StyleSheet, TextInputProps, View, ViewStyle} from 'react-native';
+
+import {DateTimePicker} from './DateTimePicker.android';
+import {DateTimePickerItemsAndroidProps} from './DateTimePickerItems';
+
+describe('DateTimePicker only with required props', () => {
+  it('renders successfully if invisible', () => {
+    const sut = render(
+      <DateTimePicker textInputProps={{testID: 'textInput'}} pickerItemsProps={{testID: 'pickerItems'}} />,
+    );
+
+    expect(sut).toMatchSnapshot('DateTimePicker if invisible.');
+
+    const textInput = sut.queryByTestId('textInput');
+    const pickerItems = sut.queryByTestId('pickerItems');
+    expect(textInput).not.toBeNull();
+    expect(pickerItems).toBeNull();
+  });
+
+  it('renders successfully if visible', () => {
+    // selectedValueに固定値を入れないと、Snapshot取得時に毎回値が変わってしまうので、OptionalPropsですが指定しています。
+    const selectedValue = new Date(2022, 5, 31, 0, 0, 0, 0);
+    // 自動テストだと、displayを指定しないとレンダリングされなかったため、OptionalPropsですがdisplayAndroidを指定してます。
+    const displayAndroid = 'calendar';
+    // formatTextを指定しないと、タイムゾーンの表記が環境によって違うので、どの環境でも変わらないように指定しています。
+    const formatText = (date?: Date) => (date ? date.toISOString() : '');
+    const sut = render(
+      <DateTimePicker
+        selectedValue={selectedValue}
+        textInputProps={{testID: 'textInput'}}
+        pickerItemsProps={{testID: 'pickerItems'}}
+        displayAndroid={displayAndroid}
+        formatText={formatText}
+      />,
+    );
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+
+    expect(sut).toMatchSnapshot('DateTimePicker if visible.');
+
+    const textInput = sut.queryByTestId('textInput');
+    const pickerItems = sut.queryByTestId('pickerItems');
+    expect(textInput).not.toBeNull();
+    expect(pickerItems).not.toBeNull();
+  });
+});
+
+describe('DateTimePicker with default value', () => {
+  it('defaultValue should be set at open if selectedValue does not exist,', () => {
+    const defaultValue = new Date(2022, 5, 10);
+    const sut = render(
+      <DateTimePicker
+        defaultValue={defaultValue}
+        pickerItemsProps={{testID: 'pickerItems'}}
+        displayAndroid="calendar"
+      />,
+    );
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+    expect(sut.getByTestId('pickerItems').props.date).toBe(defaultValue.getTime());
+  });
+});
+
+describe('DateTimePicker with all props', () => {
+  it('should be applied all properly with default xxx component', () => {
+    const onSelectedItemChange = jest.fn();
+    const onDone = jest.fn();
+    const formatText = jest.fn();
+    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
+    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
+    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    /**
+     * onDoneは自動テストではイベント発火できませんでした
+     */
+    const sut = render(
+      <DateTimePicker
+        selectedValue={selectedValue}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChange}
+        placeholder="please select..."
+        textInputProps={{style: {color: 'red'}, testID: 'textInput'}}
+        pickerItemsProps={{style: {backgroundColor: 'yellow'}, testID: 'pickerItems'}}
+        onDone={onDone}
+        formatText={formatText}
+        mode="date"
+        displayAndroid="calendar"
+      />,
+    );
+
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+
+    expect(sut).toMatchSnapshot('DateTimePicker all properly with default xxx component.');
+
+    // assert PickerItems
+    const pickerItems = sut.getByTestId('pickerItems');
+    const pickerItemsProps = pickerItems.props as DateTimePickerItemsAndroidProps;
+    // selectedValueはDateTimePickerItemsAndroidPropsで定義されていない「date」でレンダリングされます
+    // @ts-ignore
+    expect(pickerItemsProps.date).toBe(selectedValue.getTime());
+    expect(pickerItemsProps.maximumDate).toBe(maximumDate.getTime());
+    expect(pickerItemsProps.minimumDate).toBe(minimumDate.getTime());
+    expect(pickerItemsProps.mode).toBe('date');
+    // displayはdisplayIOSというPropでレンダリングされます
+    // Platform.OSをモック化してandroidを返却するようにしても「displayIOS」でレンダリングされます
+    // @ts-ignore
+    expect(pickerItemsProps.displayIOS).toBe('calendar');
+    const pickerItemsStyle = pickerItemsProps.style as ViewStyle;
+    const flattenPickerItemsStyle = StyleSheet.flatten(pickerItemsStyle);
+    expect(flattenPickerItemsStyle.backgroundColor).toBe('yellow');
+
+    // assert textInput
+    const textInput = sut.getByTestId('textInput');
+    const textInputProps = textInput.props as TextInputProps;
+    expect(textInputProps.style).toEqual({color: 'red'});
+  });
+
+  it('should be applied all properly with custom xxx component', () => {
+    const CustomTextInput = <View testID="customTextInput" />;
+    const onSelectedItemChange = jest.fn();
+    const onDone = jest.fn();
+    const formatText = jest.fn();
+    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
+    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
+    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    /**
+     * onDoneは自動テストではイベント発火できませんでした
+     */
+    const sut = render(
+      <DateTimePicker
+        selectedValue={selectedValue}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChange}
+        placeholder="please select..."
+        textInputProps={{testID: 'defaultTextInput'}}
+        pickerItemsProps={{style: {backgroundColor: 'yellow'}, testID: 'pickerItems'}}
+        textInputComponent={CustomTextInput}
+        onDone={onDone}
+        formatText={formatText}
+        mode="date"
+        displayAndroid="calendar"
+      />,
+    );
+
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+
+    expect(sut).toMatchSnapshot('DateTimePicker all properly with custom xxx component.');
+
+    // assert PickerItems
+    const pickerItems = sut.getByTestId('pickerItems');
+    const pickerItemsProps = pickerItems.props as DateTimePickerItemsAndroidProps;
+    // selectedValueはDateTimePickerItemsAndroidPropsで定義されていない「date」でレンダリングされます
+    // @ts-ignore
+    expect(pickerItemsProps.date).toBe(selectedValue.getTime());
+    expect(pickerItemsProps.maximumDate).toBe(maximumDate.getTime());
+    expect(pickerItemsProps.minimumDate).toBe(minimumDate.getTime());
+    expect(pickerItemsProps.mode).toBe('date');
+    // displayはdisplayIOSというPropでレンダリングされます
+    // Platform.OSをモック化してandroidを返却するようにしても「displayIOS」でレンダリングされます
+    // @ts-ignore
+    expect(pickerItemsProps.displayIOS).toBe('calendar');
+    const pickerItemsStyle = pickerItemsProps.style as ViewStyle;
+    const flattenPickerItemsStyle = StyleSheet.flatten(pickerItemsStyle);
+    expect(flattenPickerItemsStyle.backgroundColor).toBe('yellow');
+
+    // assert textInput
+    const defaultTextInput = sut.queryByTestId('defaultTextInput');
+    const customTextInput = sut.queryByTestId('customTextInput');
+    expect(defaultTextInput).toBeNull();
+    expect(customTextInput).not.toBeNull();
+  });
+});

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.test.tsx
@@ -21,7 +21,7 @@ describe('DateTimePicker only with required props', () => {
 
   it('renders successfully if visible', () => {
     // selectedValueに固定値を入れないと、Snapshot取得時に毎回値が変わってしまうので、OptionalPropsですが指定しています。
-    const selectedValue = new Date(1656601200000);
+    const selectedValue = new Date('2022-05-30T00:00:00.000Z');
     // 自動テストだと、displayを指定しないとレンダリングされなかったため、OptionalPropsですがdisplayAndroidを指定してます。
     const displayAndroid = 'calendar';
     // formatTextを指定しないと、タイムゾーンの表記が環境によって違うので、どの環境でも変わらないように指定しています。
@@ -49,7 +49,7 @@ describe('DateTimePicker only with required props', () => {
 
 describe('DateTimePicker with default value', () => {
   it('defaultValue should be set at open if selectedValue does not exist,', () => {
-    const defaultValue = new Date(1654786800000);
+    const defaultValue = new Date('2022-05-10T00:00:00.000Z');
     const sut = render(
       <DateTimePicker
         defaultValue={defaultValue}
@@ -68,9 +68,9 @@ describe('DateTimePicker with all props', () => {
     const onSelectedItemChange = jest.fn();
     const onDone = jest.fn();
     const formatText = jest.fn();
-    const selectedValue = new Date(1643641200000);
-    const maximumDate = new Date(1656601200000);
-    const minimumDate = new Date(1612105200000);
+    const selectedValue = new Date('2022-01-01T00:00:00.000Z');
+    const maximumDate = new Date('2022-05-31T00:00:00.000Z');
+    const minimumDate = new Date('2017-01-01T00:00:00.000Z');
     /**
      * onDoneは自動テストではイベント発火できませんでした
      */
@@ -124,9 +124,9 @@ describe('DateTimePicker with all props', () => {
     const onSelectedItemChange = jest.fn();
     const onDone = jest.fn();
     const formatText = jest.fn();
-    const selectedValue = new Date(1643641200000);
-    const maximumDate = new Date(1656601200000);
-    const minimumDate = new Date(1612105200000);
+    const selectedValue = new Date('2022-01-01T00:00:00.000Z');
+    const maximumDate = new Date('2022-05-31T00:00:00.000Z');
+    const minimumDate = new Date('2017-01-01T00:00:00.000Z');
     /**
      * onDoneは自動テストではイベント発火できませんでした
      */

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.test.tsx
@@ -21,7 +21,7 @@ describe('DateTimePicker only with required props', () => {
 
   it('renders successfully if visible', () => {
     // selectedValueに固定値を入れないと、Snapshot取得時に毎回値が変わってしまうので、OptionalPropsですが指定しています。
-    const selectedValue = new Date(2022, 5, 31, 0, 0, 0, 0);
+    const selectedValue = new Date(1656601200000);
     // 自動テストだと、displayを指定しないとレンダリングされなかったため、OptionalPropsですがdisplayAndroidを指定してます。
     const displayAndroid = 'calendar';
     // formatTextを指定しないと、タイムゾーンの表記が環境によって違うので、どの環境でも変わらないように指定しています。
@@ -49,7 +49,7 @@ describe('DateTimePicker only with required props', () => {
 
 describe('DateTimePicker with default value', () => {
   it('defaultValue should be set at open if selectedValue does not exist,', () => {
-    const defaultValue = new Date(2022, 5, 10);
+    const defaultValue = new Date(1654786800000);
     const sut = render(
       <DateTimePicker
         defaultValue={defaultValue}
@@ -68,9 +68,9 @@ describe('DateTimePicker with all props', () => {
     const onSelectedItemChange = jest.fn();
     const onDone = jest.fn();
     const formatText = jest.fn();
-    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
-    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
-    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    const selectedValue = new Date(1643641200000);
+    const maximumDate = new Date(1656601200000);
+    const minimumDate = new Date(1612105200000);
     /**
      * onDoneは自動テストではイベント発火できませんでした
      */
@@ -124,9 +124,9 @@ describe('DateTimePicker with all props', () => {
     const onSelectedItemChange = jest.fn();
     const onDone = jest.fn();
     const formatText = jest.fn();
-    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
-    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
-    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    const selectedValue = new Date(1643641200000);
+    const maximumDate = new Date(1656601200000);
+    const minimumDate = new Date(1612105200000);
     /**
      * onDoneは自動テストではイベント発火できませんでした
      */

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
@@ -7,7 +7,6 @@ import {useDateTimePickerAndroidUseCase} from './useDateTimePickerAndroidUseCase
 
 type DateTimePickerAndroidProps = Omit<
   DateTimePickerProps,
-  | 'onDismiss'
   | 'onDelete'
   | 'onCancel'
   | 'mode'

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
@@ -49,17 +49,31 @@ export const DateTimePicker = (props: DateTimePickerAndroidProps) => {
           )}
         </View>
       </Pressable>
-      {isVisible && (
-        <DateTimePickerItems
-          value={requiredSelectedValue}
-          onChange={onValueChange}
-          mode={mode}
-          display={displayAndroid}
-          maximumDate={maximumDate}
-          minimumDate={minimumDate}
-          {...pickerItemsProps}
-        />
-      )}
+      <DateTimePickerItemsComponent
+        isVisible={isVisible}
+        value={requiredSelectedValue}
+        onChange={onValueChange}
+        mode={mode}
+        display={displayAndroid}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        {...pickerItemsProps}
+      />
     </>
   );
 };
+
+type DateTimePickerItemsComponentProps = DateTimePickerItemsProps & {isVisible: boolean};
+
+// Memo workaround for https://github.com/react-native-community/datetimepicker/issues/54
+const areEqual = (prevProps: DateTimePickerItemsComponentProps, nextProps: DateTimePickerItemsComponentProps) => {
+  return prevProps.isVisible === nextProps.isVisible && prevProps.value.getTime() === nextProps.value.getTime();
+};
+
+const DateTimePickerItemsComponent = React.memo((props: DateTimePickerItemsProps & {isVisible: boolean}) => {
+  const {isVisible, ...pickerItemsProps} = props;
+  if (!isVisible) {
+    return null;
+  }
+  return <DateTimePickerItems {...pickerItemsProps} />;
+}, areEqual);

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
@@ -11,6 +11,7 @@ type DateTimePickerAndroidProps = Omit<
   | 'onDelete'
   | 'onCancel'
   | 'mode'
+  | 'displayIOS'
   | 'pickerAccessoryComponent'
   | 'pickerItemsComponent'
   | 'pickerItemsContainerProps'
@@ -19,11 +20,11 @@ type DateTimePickerAndroidProps = Omit<
   | 'pickerContainerProps'
   | 'pickerAccessoryProps'
 > & {
-  pickerItemsProps: Omit<
+  pickerItemsProps?: Omit<
     DateTimePickerItemsAndroidProps,
     'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
   >;
-  mode: Exclude<DateTimePickerItemsProps['mode'], 'countdown' | 'datetime'>;
+  mode?: Exclude<DateTimePickerItemsProps['mode'], 'countdown' | 'datetime'>;
 };
 export const DateTimePicker = (props: DateTimePickerAndroidProps) => {
   const {isVisible, requiredSelectedValue, inputValue, onValueChange, open} = useDateTimePickerAndroidUseCase(props);
@@ -37,7 +38,6 @@ export const DateTimePicker = (props: DateTimePickerAndroidProps) => {
     textInputComponent,
     pickerItemsProps,
   } = props;
-
   return (
     <>
       <Pressable onPress={open} testID="pressableContainer">

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.android.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {Pressable, TextInput, View} from 'react-native';
+
+import {DateTimePickerProps} from './DateTimePicker';
+import {DateTimePickerItems, DateTimePickerItemsAndroidProps, DateTimePickerItemsProps} from './DateTimePickerItems';
+import {useDateTimePickerAndroidUseCase} from './useDateTimePickerAndroidUseCase';
+
+type DateTimePickerAndroidProps = Omit<
+  DateTimePickerProps,
+  | 'onDismiss'
+  | 'onDelete'
+  | 'onCancel'
+  | 'mode'
+  | 'pickerAccessoryComponent'
+  | 'pickerItemsComponent'
+  | 'pickerItemsContainerProps'
+  | 'pickerItemsProps'
+  | 'pickerBackdropProps'
+  | 'pickerContainerProps'
+  | 'pickerAccessoryProps'
+> & {
+  pickerItemsProps: Omit<
+    DateTimePickerItemsAndroidProps,
+    'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
+  >;
+  mode: Exclude<DateTimePickerItemsProps['mode'], 'countdown' | 'datetime'>;
+};
+export const DateTimePicker = (props: DateTimePickerAndroidProps) => {
+  const {isVisible, requiredSelectedValue, inputValue, onValueChange, open} = useDateTimePickerAndroidUseCase(props);
+  const {
+    maximumDate,
+    minimumDate,
+    mode,
+    displayAndroid,
+    placeholder,
+    textInputProps,
+    textInputComponent,
+    pickerItemsProps,
+  } = props;
+
+  return (
+    <>
+      <Pressable onPress={open} testID="pressableContainer">
+        <View pointerEvents="box-only">
+          {textInputComponent ? (
+            textInputComponent
+          ) : (
+            // テキスト入力とスタイルを合わせるために、TextではなくTextInputを使用する
+            <TextInput placeholder={placeholder} value={inputValue} editable={false} {...textInputProps} />
+          )}
+        </View>
+      </Pressable>
+      {isVisible && (
+        <DateTimePickerItems
+          value={requiredSelectedValue}
+          onChange={onValueChange}
+          mode={mode}
+          display={displayAndroid}
+          maximumDate={maximumDate}
+          minimumDate={minimumDate}
+          {...pickerItemsProps}
+        />
+      )}
+    </>
+  );
+};

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
@@ -35,7 +35,7 @@ describe('DateTimePicker only with required props', () => {
 
   it('renders successfully if visible', () => {
     // selectedValueに固定値を入れないと、Snapshot取得時に毎回値が変わってしまうので、OptionalPropsですが指定しています。
-    const selectedValue = new Date(2022, 5, 31, 0, 0, 0, 0);
+    const selectedValue = new Date('2022-05-30T00:00:00.000Z');
     // formatTextを指定しないと、タイムゾーンの表記が環境によって違うので、どの環境でも変わらないように指定しています。
     const formatText = (date?: Date) => (date ? date.toISOString() : '');
     const sut = render(
@@ -70,7 +70,7 @@ describe('DateTimePicker only with required props', () => {
 
 describe('DateTimePicker with default value', () => {
   it('defaultValue should be set at open if selectedValue does not exist,', () => {
-    const defaultValue = new Date(2022, 5, 10);
+    const defaultValue = new Date('2022-05-10T00:00:00.000Z');
     const sut = render(<DateTimePicker defaultValue={defaultValue} pickerItemsProps={{testID: 'pickerItems'}} />);
     const pressableContainer = sut.getByTestId('pressableContainer');
     fireEvent.press(pressableContainer);
@@ -86,9 +86,9 @@ describe('DateTimePicker with all props', () => {
     const onCancel = jest.fn();
     const onDone = jest.fn();
     const formatText = jest.fn();
-    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
-    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
-    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    const selectedValue = new Date('2022-01-01T00:00:00.000Z');
+    const maximumDate = new Date('2022-05-31T00:00:00.000Z');
+    const minimumDate = new Date('2017-01-01T00:00:00.000Z');
     const sut = render(
       <DateTimePicker
         selectedValue={selectedValue}
@@ -206,9 +206,9 @@ describe('DateTimePicker with all props', () => {
     const CustomPickerAccessory = <View testID="customPickerAccessory" />;
     const CustomPicker = <View testID="customPicker" />;
     const CustomTextInput = <View testID="customTextInput" />;
-    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
-    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
-    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    const selectedValue = new Date('2022-01-01T00:00:00.000Z');
+    const maximumDate = new Date('2022-05-31T00:00:00.000Z');
+    const minimumDate = new Date('2017-01-01T00:00:00.000Z');
     const onSelectedItemChange = jest.fn();
     const onDismiss = jest.fn();
     const formatText = jest.fn();

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
@@ -1,0 +1,278 @@
+import {fireEvent, render} from '@testing-library/react-native';
+import React from 'react';
+import {StyleSheet, TextInputProps, View, ViewProps, ViewStyle} from 'react-native';
+
+import {DateTimePicker} from './DateTimePicker.ios';
+import {DateTimePickerItemsIOSProps} from './DateTimePickerItems';
+import {PickerBackdropProps} from './PickerBackdrop';
+import {PickerContainerProps} from './PickerContainer';
+
+describe('DateTimePicker only with required props', () => {
+  it('renders successfully if invisible', () => {
+    const sut = render(
+      <DateTimePicker
+        textInputProps={{testID: 'textInput'}}
+        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerContainerProps={{testID: 'pickerContainer'}}
+        pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
+        pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
+      />,
+    );
+
+    expect(sut).toMatchSnapshot('DateTimePicker if invisible.');
+
+    const pickerBackdrop = sut.queryByTestId('pickerBackdrop');
+    const pickerContainer = sut.queryByTestId('pickerContainer');
+    const pickerAccessory = sut.queryByTestId('pickerAccessory');
+    const pickerItemsContainer = sut.queryByTestId('pickerItemsContainer');
+    const textInput = sut.queryByTestId('textInput');
+    expect(pickerBackdrop).toBeNull();
+    expect(pickerContainer).toBeNull();
+    expect(pickerAccessory).toBeNull();
+    expect(pickerItemsContainer).toBeNull();
+    expect(textInput).not.toBeNull();
+  });
+
+  it('renders successfully if visible', () => {
+    // selectedValueに固定値を入れないと、Snapshot取得時に毎回値が変わってしまうので、OptionalPropsですが指定しています。
+    const selectedValue = new Date(2022, 5, 31, 0, 0, 0, 0);
+    // formatTextを指定しないと、タイムゾーンの表記が環境によって違うので、どの環境でも変わらないように指定しています。
+    const formatText = (date?: Date) => (date ? date.toISOString() : '');
+    const sut = render(
+      <DateTimePicker
+        selectedValue={selectedValue}
+        textInputProps={{testID: 'textInput'}}
+        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerContainerProps={{testID: 'pickerContainer'}}
+        pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
+        pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
+        pickerItemsProps={{testID: 'pickerItems'}}
+        formatText={formatText}
+      />,
+    );
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+
+    expect(sut).toMatchSnapshot('DateTimePicker if visible.');
+
+    const pickerBackdrop = sut.queryByTestId('pickerBackdrop');
+    const pickerContainer = sut.queryByTestId('pickerContainer');
+    const pickerAccessory = sut.queryByTestId('pickerAccessory');
+    const pickerItemsContainer = sut.queryByTestId('pickerItemsContainer');
+    const textInput = sut.queryByTestId('textInput');
+    expect(pickerBackdrop).not.toBeNull();
+    expect(pickerContainer).not.toBeNull();
+    expect(pickerAccessory).not.toBeNull();
+    expect(pickerItemsContainer).not.toBeNull();
+    expect(textInput).not.toBeNull();
+  });
+});
+
+describe('DateTimePicker with default value', () => {
+  it('defaultValue should be set at open if selectedValue does not exist,', () => {
+    const defaultValue = new Date(2022, 5, 10);
+    const sut = render(<DateTimePicker defaultValue={defaultValue} pickerItemsProps={{testID: 'pickerItems'}} />);
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+    expect(sut.getByTestId('pickerItems').props.date).toBe(defaultValue.getTime());
+  });
+});
+
+describe('DateTimePicker with all props', () => {
+  it('should be applied all properly with default xxx component', () => {
+    const onSelectedItemChange = jest.fn();
+    const onDismiss = jest.fn();
+    const onDelete = jest.fn();
+    const onCancel = jest.fn();
+    const onDone = jest.fn();
+    const formatText = jest.fn();
+    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
+    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
+    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    const sut = render(
+      <DateTimePicker
+        selectedValue={selectedValue}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChange}
+        onDismiss={onDismiss}
+        placeholder="please select..."
+        textInputProps={{style: {color: 'red'}, testID: 'textInput'}}
+        pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
+        pickerItemsProps={{style: {backgroundColor: 'yellow'}, testID: 'pickerItems'}}
+        pickerBackdropProps={{
+          style: {backgroundColor: 'green', borderColor: 'red'},
+          modalProps: {testID: 'modal'},
+          testID: 'pickerBackdrop',
+        }}
+        pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
+        pickerAccessoryProps={{
+          containerProps: {style: {backgroundColor: 'blue'}, testID: 'pickerAccessory'},
+          deleteLabel: 'delete',
+          cancelLabel: 'cancel',
+          doneLabel: 'done',
+          deleteTouchableContainerProps: {testID: 'deleteLink'},
+          cancelTouchableContainerProps: {testID: 'cancelLink'},
+          doneTouchableContainerProps: {testID: 'doneLink'},
+        }}
+        onDelete={onDelete}
+        onCancel={onCancel}
+        onDone={onDone}
+        formatText={formatText}
+        mode="date"
+        displayIOS="spinner"
+      />,
+    );
+
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+
+    expect(sut).toMatchSnapshot('DateTimePicker all properly with default xxx component.');
+
+    // assert pickerContainer
+    const pickerContainer = sut.getByTestId('pickerContainer');
+    const pickerContainerProps = pickerContainer.props as PickerContainerProps;
+    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+
+    // assert pickerItemsContainer
+    const pickerItemsContainer = sut.getByTestId('pickerItemsContainer');
+    const pickerItemsContainerProps = pickerItemsContainer.props as ViewProps;
+    expect(pickerItemsContainerProps.pointerEvents).toBe('none');
+
+    // assert PickerItems
+    const pickerItems = sut.getByTestId('pickerItems');
+    const pickerItemsProps = pickerItems.props as DateTimePickerItemsIOSProps;
+    expect(pickerItemsProps.date).toBe(selectedValue.getTime());
+    expect(pickerItemsProps.maximumDate).toBe(maximumDate.getTime());
+    expect(pickerItemsProps.minimumDate).toBe(minimumDate.getTime());
+    expect(pickerItemsProps.mode).toBe('date');
+    // displayはdisplayIOSというPropでレンダリングされます
+    // @ts-ignore
+    // @ts-ignore
+    expect(pickerItemsProps.displayIOS).toBe('spinner');
+    const pickerItemsStyle = pickerItemsProps.style as ViewStyle;
+    const flattenPickerItemsStyle = StyleSheet.flatten(pickerItemsStyle);
+    expect(flattenPickerItemsStyle.backgroundColor).toBe('yellow');
+
+    // assert textInput
+    const textInput = sut.getByTestId('textInput');
+    const textInputProps = textInput.props as TextInputProps;
+    expect(textInputProps.style).toEqual({color: 'red'});
+
+    // assert pickerBackdrop
+    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
+    const modal = sut.getByTestId('modal');
+    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
+    fireEvent(modal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(pressableContainer);
+
+    // assert pickerAccessory
+    const pickerAccessory = sut.getByTestId('pickerAccessory');
+    const pickerAccessoryProps = pickerAccessory.props as ViewProps;
+    expect(pickerAccessoryProps.style).toEqual({
+      backgroundColor: 'blue',
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      paddingHorizontal: 10,
+      paddingVertical: 8,
+    });
+    const deleteLink = sut.getByTestId('deleteLink');
+    const deleteText = sut.queryByText('delete');
+    expect(deleteText).not.toBeNull();
+    fireEvent.press(deleteLink);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    fireEvent.press(pressableContainer);
+    const cancelLink = sut.getByTestId('cancelLink');
+    const cancelText = sut.queryByText('cancel');
+    expect(cancelText).not.toBeNull();
+    fireEvent.press(cancelLink);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    fireEvent.press(pressableContainer);
+    const doneLink = sut.getByTestId('doneLink');
+    const doneText = sut.queryByText('done');
+    expect(doneText).not.toBeNull();
+    fireEvent.press(doneLink);
+    expect(onDone).toHaveBeenCalledTimes(1);
+
+    // formatText
+    expect(formatText).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be applied all properly with custom xxx component', () => {
+    const CustomPickerAccessory = <View testID="customPickerAccessory" />;
+    const CustomPicker = <View testID="customPicker" />;
+    const CustomTextInput = <View testID="customTextInput" />;
+    const selectedValue = new Date(2022, 1, 1, 0, 0, 0, 0);
+    const maximumDate = new Date(2022, 5, 31, 0, 0, 0, 0);
+    const minimumDate = new Date(maximumDate.getFullYear() - 1, 1, 1, 0, 0, 0, 0);
+    const onSelectedItemChange = jest.fn();
+    const onDismiss = jest.fn();
+    const formatText = jest.fn();
+    const sut = render(
+      <DateTimePicker
+        selectedValue={selectedValue}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChange}
+        onDismiss={onDismiss}
+        placeholder="please select..."
+        textInputProps={{testID: 'defaultTextInput'}}
+        pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
+        pickerBackdropProps={{
+          style: {backgroundColor: 'green', borderColor: 'red'},
+          modalProps: {testID: 'modal'},
+          testID: 'pickerBackdrop',
+        }}
+        pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
+        pickerAccessoryProps={{containerProps: {testID: 'defaultPickerAccessory'}}}
+        pickerAccessoryComponent={CustomPickerAccessory}
+        pickerItemsComponent={CustomPicker}
+        textInputComponent={CustomTextInput}
+        formatText={formatText}
+        mode="date"
+        displayIOS="spinner"
+      />,
+    );
+    const pressableContainer = sut.getByTestId('pressableContainer');
+    fireEvent.press(pressableContainer);
+
+    expect(sut).toMatchSnapshot('DateTimePicker all properly with custom xxx component.');
+
+    // assert pickerBackdrop
+    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
+    const modal = sut.getByTestId('modal');
+    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
+    fireEvent(modal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(pressableContainer);
+
+    // assert pickerContainer
+    const pickerContainer = sut.getByTestId('pickerContainer');
+    const pickerContainerProps = pickerContainer.props as PickerContainerProps;
+    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+
+    // assert pickerAccessory
+    const defaultPickerAccessory = sut.queryByTestId('defaultPickerAccessory');
+    const customPickerAccessory = sut.queryByTestId('customPickerAccessory');
+    expect(defaultPickerAccessory).toBeNull();
+    expect(customPickerAccessory).not.toBeNull();
+
+    // assert pickerItemsContainer
+    const pickerItemsContainer = sut.getByTestId('pickerItemsContainer');
+    const pickerItemsContainerProps = pickerItemsContainer.props as ViewProps;
+    expect(pickerItemsContainerProps.pointerEvents).toBe('none');
+
+    // assert textInput
+    const defaultTextInput = sut.queryByTestId('defaultTextInput');
+    const customTextInput = sut.queryByTestId('customTextInput');
+    expect(defaultTextInput).toBeNull();
+    expect(customTextInput).not.toBeNull();
+  });
+});

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
@@ -8,8 +8,8 @@ import {PickerBackdrop} from './PickerBackdrop';
 import {PickerContainer} from './PickerContainer';
 import {useDateTimePickerUseCase} from './useDateTimePickerUseCase';
 
-type DateTimePickerIOSProps = Omit<DateTimePickerProps, 'pickerItemsProps'> & {
-  pickerItemsProps: Omit<
+type DateTimePickerIOSProps = Omit<DateTimePickerProps, 'displayAndroid' | 'pickerItemsProps'> & {
+  pickerItemsProps?: Omit<
     DateTimePickerItemsIOSProps,
     'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
   >;
@@ -34,7 +34,7 @@ export const DateTimePicker = (props: DateTimePickerIOSProps) => {
     maximumDate,
     minimumDate,
     mode,
-    displayIOS,
+    displayIOS = 'spinner',
     placeholder,
     textInputProps,
     pickerAccessoryComponent,

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
@@ -14,6 +14,27 @@ type DateTimePickerIOSProps = Omit<DateTimePickerProps, 'displayAndroid' | 'pick
     'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
   >;
 };
+/**
+ * 日時を表示するPickerとしてReact Native DateTimePickerを使用しています。
+ * React Native DateTimePickerは、NativeのUIDatePickerを使用しています。
+ * UIDatePickerは、↓に記載されている「Support for Languages and Regions」の設定を追加しないと、OSに設定されている言語・地域に従った表示になりません。
+ * https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions
+ *
+ * 言語・地域を追加する大まかな手順は以下になります。
+ * - Add Localizations
+ *   - Xcodeを開いて、PROJECT -> Info ->LocalizationsにLocalizationを追加
+ * - View Localizable Resources
+ *   - Xcodeを開いて、左ペインのナビゲータエリアでTargetを選択
+ *   - New FileでStrings Fileを「InfoPlist」というファイル名で作成（拡張子の.stringsは自動で付与されます）
+ *   - 作成した「InfoPlist」を選択して、右ペインのLocalization -> Localize...をタップ
+ *   - 対応するLocalizationを選択
+ *
+ * 上記を実行すると、「en.lproj」、「ja.lproj」のようなLocalization毎のディレクトリが作成され、それぞれのディレクトリの中にInfoPlist.stringsファイルが作成されます。
+ * InfoPlist.stringsの中身は特に何も定義されていない空のファイルですが、UIDatePickerを使用するだけであれば定義の追加は必要ありません。
+ *
+ * 参考までに、このアプリでLocalizationの対応を実施したPRのリンクを記載します。
+ * https://github.com/ws-4020/mobile-app-crib-notes/pull/861
+ */
 export const DateTimePicker = (props: DateTimePickerIOSProps) => {
   const {
     isVisible,

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
@@ -19,7 +19,7 @@ export const DateTimePicker = (props: DateTimePickerIOSProps) => {
     isVisible,
     requiredSelectedValue,
     inputValue,
-    handleBackdropPress,
+    handleDismiss,
     pickerBackdropEntering,
     pickerBackdropExiting,
     pickerContainerEntering,
@@ -56,7 +56,7 @@ export const DateTimePicker = (props: DateTimePickerIOSProps) => {
     <>
       <PickerBackdrop
         isVisible={isVisible}
-        onPress={handleBackdropPress}
+        onPress={handleDismiss}
         entering={pickerBackdropEntering}
         exiting={pickerBackdropExiting}
         {...pickerBackdropProps}>

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {Pressable, StyleSheet, TextInput, View} from 'react-native';
+
+import {DateTimePickerProps} from './DateTimePicker';
+import {DateTimePickerItems, DateTimePickerItemsIOSProps} from './DateTimePickerItems';
+import {DefaultPickerAccessory} from './DefaultPickerAccessory';
+import {PickerBackdrop} from './PickerBackdrop';
+import {PickerContainer} from './PickerContainer';
+import {useDateTimePickerUseCase} from './useDateTimePickerUseCase';
+
+type DateTimePickerIOSProps = Omit<DateTimePickerProps, 'pickerItemsProps'> & {
+  pickerItemsProps: Omit<
+    DateTimePickerItemsIOSProps,
+    'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
+  >;
+};
+export const DateTimePicker = (props: DateTimePickerIOSProps) => {
+  const {
+    isVisible,
+    requiredSelectedValue,
+    inputValue,
+    handleBackdropPress,
+    pickerBackdropEntering,
+    pickerBackdropExiting,
+    pickerContainerEntering,
+    pickerContainerExiting,
+    onValueChange,
+    open,
+    handleDelete,
+    handleCancel,
+    handleDone,
+  } = useDateTimePickerUseCase(props);
+  const {
+    maximumDate,
+    minimumDate,
+    mode,
+    displayIOS,
+    placeholder,
+    textInputProps,
+    pickerAccessoryComponent,
+    pickerItemsComponent,
+    textInputComponent,
+    pickerItemsContainerProps: {style: pickerItemsContainerStyle, ...pickerItemsContainerProps} = {},
+    pickerItemsProps,
+    pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting, ...pickerBackdropProps} = {},
+    pickerContainerProps: {
+      entering: containerEntering,
+      exiting: containerExiting,
+      style: pickerContainerStyle,
+      ...pickerContainerProps
+    } = {},
+    pickerAccessoryProps,
+  } = props;
+
+  return (
+    <>
+      <PickerBackdrop
+        isVisible={isVisible}
+        onPress={handleBackdropPress}
+        entering={pickerBackdropEntering}
+        exiting={pickerBackdropExiting}
+        {...pickerBackdropProps}>
+        <PickerContainer
+          isVisible={isVisible}
+          entering={pickerContainerEntering}
+          exiting={pickerContainerExiting}
+          style={StyleSheet.flatten([styles.pickerContainer, pickerContainerStyle])}
+          {...pickerContainerProps}>
+          {pickerAccessoryComponent ? (
+            pickerAccessoryComponent
+          ) : (
+            <DefaultPickerAccessory
+              onDelete={handleDelete}
+              onCancel={handleCancel}
+              onDone={handleDone}
+              {...pickerAccessoryProps}
+            />
+          )}
+          <View {...pickerItemsContainerProps}>
+            {pickerItemsComponent ? (
+              pickerItemsComponent
+            ) : (
+              <DateTimePickerItems
+                value={requiredSelectedValue}
+                onChange={onValueChange}
+                mode={mode}
+                display={displayIOS}
+                maximumDate={maximumDate}
+                minimumDate={minimumDate}
+                {...pickerItemsProps}
+              />
+            )}
+          </View>
+        </PickerContainer>
+      </PickerBackdrop>
+      <Pressable onPress={open} testID="pressableContainer">
+        <View pointerEvents="box-only">
+          {textInputComponent ? (
+            textInputComponent
+          ) : (
+            // テキスト入力とスタイルを合わせるために、TextではなくTextInputを使用する
+            <TextInput placeholder={placeholder} value={inputValue} editable={false} {...textInputProps} />
+          )}
+        </View>
+      </Pressable>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  pickerContainer: {
+    backgroundColor: 'white',
+  },
+});

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
@@ -2,12 +2,20 @@ import {log} from 'framework/logging';
 import React from 'react';
 import {Platform, TextInputProps as RNETextInputProps, ViewProps} from 'react-native';
 
-import {DateTimePickerItemsProps} from './DateTimePickerItems';
+import {
+  DateTimePickerItemsAndroidProps,
+  DateTimePickerItemsIOSProps,
+  DateTimePickerItemsProps,
+} from './DateTimePickerItems';
 import {DefaultPickerAccessoryProps} from './DefaultPickerAccessory';
 import {PickerBackdropProps} from './PickerBackdrop';
 import {PickerContainerProps} from './PickerContainer';
 
 type TextInputProps = Omit<RNETextInputProps, 'value' | 'editable'>;
+
+export type PickerItemsProps =
+  | Omit<DateTimePickerItemsIOSProps, 'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'>
+  | Omit<DateTimePickerItemsAndroidProps, 'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'>;
 
 export type DateTimePickerProps = {
   /**
@@ -118,10 +126,7 @@ export type DateTimePickerProps = {
    * なお、pickerItemsComponentを指定した場合は使用されません。
    * @see https://github.com/react-native-datetimepicker/datetimepicker#component-props--params-of-the-android-imperative-api
    */
-  pickerItemsProps?: Omit<
-    DateTimePickerItemsProps,
-    'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
-  >;
+  pickerItemsProps?: PickerItemsProps;
   /**
    * PickerBackdropのProps
    * @platform ios

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
@@ -30,12 +30,14 @@ export type DateTimePickerProps = {
    * DeleteLabelがタップされた場合に呼び出される関数
    * タップ後、SelectPickerは自動で閉じます。
    * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   * @platform ios
    */
   onDelete?: (date?: Date) => void;
   /**
    * CancelLabelがタップされた場合に呼び出される関数
    * タップ後、SelectPickerは自動で閉じます。
    * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   * @platform ios
    */
   onCancel?: (date?: Date) => void;
   /**
@@ -108,6 +110,7 @@ export type DateTimePickerProps = {
   textInputProps?: TextInputProps;
   /**
    * Pickerコンポーネントを囲むContainerのProps
+   * @platform ios
    */
   pickerItemsContainerProps?: ViewProps;
   /**
@@ -121,15 +124,18 @@ export type DateTimePickerProps = {
   >;
   /**
    * PickerBackdropのProps
+   * @platform ios
    */
   pickerBackdropProps?: Omit<PickerBackdropProps, 'isVisible' | 'onPress'>;
   /**
    * PickerContainerのProps
+   * @platform ios
    */
   pickerContainerProps?: Omit<PickerContainerProps, 'isVisible'>;
   /**
    * PickerAccessoryのProps
    * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   * @platform ios
    */
   pickerAccessoryProps?: Omit<DefaultPickerAccessoryProps, 'onDelete' | 'onCancel' | 'onDone'>;
 };

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
@@ -88,11 +88,13 @@ export type DateTimePickerProps = {
   /**
    * ヘッダコンポーネント
    * 指定しない場合は、{@link DefaultPickerAccessory}がデフォルトで表示されます。
+   * @platform ios
    */
   pickerAccessoryComponent?: React.ReactNode;
   /**
    * Pickerコンポーネント
    * 指定しない場合は、{@link SelectPickerItems}がデフォルトで表示されます。
+   * @platform ios
    */
   pickerItemsComponent?: React.ReactNode;
   /**

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.tsx
@@ -1,0 +1,140 @@
+import {log} from 'framework/logging';
+import React from 'react';
+import {Platform, TextInputProps as RNETextInputProps, ViewProps} from 'react-native';
+
+import {DateTimePickerItemsProps} from './DateTimePickerItems';
+import {DefaultPickerAccessoryProps} from './DefaultPickerAccessory';
+import {PickerBackdropProps} from './PickerBackdrop';
+import {PickerContainerProps} from './PickerContainer';
+
+type TextInputProps = Omit<RNETextInputProps, 'value' | 'editable'>;
+
+export type DateTimePickerProps = {
+  /**
+   * 選択されたアイテムのKey
+   */
+  selectedValue?: Date;
+  /**
+   * 選択されたアイテムが存在しない場合のデフォルト値
+   */
+  defaultValue?: Date;
+  /**
+   * アイテムが選択された場合に呼び出される関数
+   */
+  onSelectedItemChange?: (date?: Date) => void;
+  /**
+   * PickerBackdropをタップして閉じた場合に呼び出される関数
+   */
+  onDismiss?: (date?: Date) => void;
+  /**
+   * DeleteLabelがタップされた場合に呼び出される関数
+   * タップ後、SelectPickerは自動で閉じます。
+   * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   */
+  onDelete?: (date?: Date) => void;
+  /**
+   * CancelLabelがタップされた場合に呼び出される関数
+   * タップ後、SelectPickerは自動で閉じます。
+   * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   */
+  onCancel?: (date?: Date) => void;
+  /**
+   * DoneLabelがタップされた場合に呼び出される関数
+   * タップ後、SelectPickerは自動で閉じます。
+   * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   */
+  onDone?: (date?: Date) => void;
+  /**
+   * 選択した日時のフォーマッタ
+   */
+  formatText?: (date?: Date) => string | undefined;
+  /**
+   * 選択可能な最大日時
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#maximumdate-optional
+   */
+  maximumDate?: Date;
+  /**
+   * 選択可能な最小日時
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#minimumdate-optional
+   */
+  minimumDate?: Date;
+  /**
+   * 時刻の表示を24時間表記にするかどうか
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#is24hour-optional-windows-and-android-only
+   */
+  is24Hour?: boolean;
+  /**
+   * Pickerのモード
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#mode-optional
+   */
+  mode?: DateTimePickerItemsProps['mode'];
+  /**
+   * Pickerの表示方法
+   * このコンポーネントでは、spinnerとinlineのみ使用できます。
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#display-optional
+   * @platform ios
+   */
+  displayIOS?: Exclude<DateTimePickerItemsProps['display'], 'clock' | 'calendar' | 'compact' | 'default'>;
+  /**
+   * Pickerの表示方法
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#display-optional
+   * @platform android
+   */
+  displayAndroid?: Exclude<DateTimePickerItemsProps['display'], 'compact' | 'inline'>;
+  /**
+   * プレースホルダ
+   */
+  placeholder?: string;
+  /**
+   * ヘッダコンポーネント
+   * 指定しない場合は、{@link DefaultPickerAccessory}がデフォルトで表示されます。
+   */
+  pickerAccessoryComponent?: React.ReactNode;
+  /**
+   * Pickerコンポーネント
+   * 指定しない場合は、{@link SelectPickerItems}がデフォルトで表示されます。
+   */
+  pickerItemsComponent?: React.ReactNode;
+  /**
+   * 選択されたアイテムを表示するテキストコンポーネント
+   */
+  textInputComponent?: React.ReactNode;
+  /**
+   * 選択されたアイテムを表示するテキストコンポーネントのProps
+   * なお、textInputComponentを指定した場合は使用されません。
+   */
+  textInputProps?: TextInputProps;
+  /**
+   * Pickerコンポーネントを囲むContainerのProps
+   */
+  pickerItemsContainerProps?: ViewProps;
+  /**
+   * PickerのProps
+   * なお、pickerItemsComponentを指定した場合は使用されません。
+   * @see https://github.com/react-native-datetimepicker/datetimepicker#component-props--params-of-the-android-imperative-api
+   */
+  pickerItemsProps?: Omit<
+    DateTimePickerItemsProps,
+    'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
+  >;
+  /**
+   * PickerBackdropのProps
+   */
+  pickerBackdropProps?: Omit<PickerBackdropProps, 'isVisible' | 'onPress'>;
+  /**
+   * PickerContainerのProps
+   */
+  pickerContainerProps?: Omit<PickerContainerProps, 'isVisible'>;
+  /**
+   * PickerAccessoryのProps
+   * なお、pickerAccessoryComponentを指定した場合は使用されません。
+   */
+  pickerAccessoryProps?: Omit<DefaultPickerAccessoryProps, 'onDelete' | 'onCancel' | 'onDone'>;
+};
+
+export const DateTimePicker = (props: DateTimePickerProps) => {
+  React.useEffect(() => {
+    log.warn(`DateTimePicker is not supported on: ${Platform.OS}`);
+  }, []);
+  return null;
+};

--- a/example-app/SantokuApp/src/components/picker/DateTimePickerItems.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePickerItems.tsx
@@ -1,0 +1,10 @@
+import RNDateTimePicker, {AndroidNativeProps, IOSNativeProps} from '@react-native-community/datetimepicker';
+import React from 'react';
+
+export type DateTimePickerItemsIOSProps = IOSNativeProps;
+export type DateTimePickerItemsAndroidProps = AndroidNativeProps;
+export type DateTimePickerItemsProps = DateTimePickerItemsIOSProps | DateTimePickerItemsAndroidProps;
+
+export const DateTimePickerItems = (props: DateTimePickerItemsProps) => {
+  return <RNDateTimePicker {...props} />;
+};

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.android.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.android.test.tsx.snap
@@ -56,12 +56,12 @@ Array [
         rejectResponderTermination={true}
         testID="textInput"
         underlineColorAndroid="transparent"
-        value="2022-06-30T15:00:00.000Z"
+        value="2022-05-30T00:00:00.000Z"
       />
     </View>
   </View>,
   <RNDateTimePicker
-    date={1656601200000}
+    date={1653868800000}
     displayIOS="calendar"
     enabled={true}
     mode="date"
@@ -104,11 +104,11 @@ Array [
     </View>
   </View>,
   <RNDateTimePicker
-    date={1643641200000}
+    date={1640995200000}
     displayIOS="calendar"
     enabled={true}
-    maximumDate={1656601200000}
-    minimumDate={1612105200000}
+    maximumDate={1653955200000}
+    minimumDate={1483228800000}
     mode="date"
     onChange={[Function]}
     onResponderTerminationRequest={[Function]}
@@ -164,11 +164,11 @@ Array [
     </View>
   </View>,
   <RNDateTimePicker
-    date={1643641200000}
+    date={1640995200000}
     displayIOS="calendar"
     enabled={true}
-    maximumDate={1656601200000}
-    minimumDate={1612105200000}
+    maximumDate={1653955200000}
+    minimumDate={1483228800000}
     mode="date"
     onChange={[Function]}
     onResponderTerminationRequest={[Function]}

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.android.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.android.test.tsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateTimePicker only with required props renders successfully if invisible: DateTimePicker if invisible. 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="pressableContainer"
+>
+  <View
+    pointerEvents="box-only"
+  >
+    <TextInput
+      allowFontScaling={true}
+      editable={false}
+      rejectResponderTermination={true}
+      testID="textInput"
+      underlineColorAndroid="transparent"
+    />
+  </View>
+</View>
+`;
+
+exports[`DateTimePicker only with required props renders successfully if visible: DateTimePicker if visible. 1`] = `
+Array [
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="pressableContainer"
+  >
+    <View
+      pointerEvents="box-only"
+    >
+      <TextInput
+        allowFontScaling={true}
+        editable={false}
+        rejectResponderTermination={true}
+        testID="textInput"
+        underlineColorAndroid="transparent"
+        value="2022-06-30T15:00:00.000Z"
+      />
+    </View>
+  </View>,
+  <RNDateTimePicker
+    date={1656601200000}
+    displayIOS="calendar"
+    enabled={true}
+    mode="date"
+    onChange={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "height": 216,
+      }
+    }
+    testID="pickerItems"
+  />,
+]
+`;
+
+exports[`DateTimePicker with all props should be applied all properly with custom xxx component: DateTimePicker all properly with custom xxx component. 1`] = `
+Array [
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="pressableContainer"
+  >
+    <View
+      pointerEvents="box-only"
+    >
+      <View
+        testID="customTextInput"
+      />
+    </View>
+  </View>,
+  <RNDateTimePicker
+    date={1643641200000}
+    displayIOS="calendar"
+    enabled={true}
+    maximumDate={1656601200000}
+    minimumDate={1612105200000}
+    mode="date"
+    onChange={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "height": 216,
+        },
+        Object {
+          "backgroundColor": "yellow",
+        },
+      ]
+    }
+    testID="pickerItems"
+  />,
+]
+`;
+
+exports[`DateTimePicker with all props should be applied all properly with default xxx component: DateTimePicker all properly with default xxx component. 1`] = `
+Array [
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="pressableContainer"
+  >
+    <View
+      pointerEvents="box-only"
+    >
+      <TextInput
+        allowFontScaling={true}
+        editable={false}
+        placeholder="please select..."
+        rejectResponderTermination={true}
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+        testID="textInput"
+        underlineColorAndroid="transparent"
+      />
+    </View>
+  </View>,
+  <RNDateTimePicker
+    date={1643641200000}
+    displayIOS="calendar"
+    enabled={true}
+    maximumDate={1656601200000}
+    minimumDate={1612105200000}
+    mode="date"
+    onChange={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "height": 216,
+        },
+        Object {
+          "backgroundColor": "yellow",
+        },
+      ]
+    }
+    testID="pickerItems"
+  />,
+]
+`;

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
@@ -159,7 +159,7 @@ Array [
             testID="pickerItemsContainer"
           >
             <RNDateTimePicker
-              date={1656601200000}
+              date={1653868800000}
               displayIOS="spinner"
               enabled={true}
               mode="date"
@@ -202,7 +202,7 @@ Array [
         rejectResponderTermination={true}
         testID="textInput"
         underlineColorAndroid="transparent"
-        value="2022-06-30T15:00:00.000Z"
+        value="2022-05-30T00:00:00.000Z"
       />
     </View>
   </View>,
@@ -596,11 +596,11 @@ Array [
             testID="pickerItemsContainer"
           >
             <RNDateTimePicker
-              date={1643641200000}
+              date={1640995200000}
               displayIOS="spinner"
               enabled={true}
-              maximumDate={1656601200000}
-              minimumDate={1612105200000}
+              maximumDate={1653955200000}
+              minimumDate={1483228800000}
               mode="date"
               onChange={[Function]}
               onResponderTerminationRequest={[Function]}

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
@@ -1,0 +1,659 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateTimePicker only with required props renders successfully if invisible: DateTimePicker if invisible. 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="pressableContainer"
+>
+  <View
+    pointerEvents="box-only"
+  >
+    <TextInput
+      allowFontScaling={true}
+      editable={false}
+      rejectResponderTermination={true}
+      testID="textInput"
+      underlineColorAndroid="transparent"
+    />
+  </View>
+</View>
+`;
+
+exports[`DateTimePicker only with required props renders successfully if visible: DateTimePicker if visible. 1`] = `
+Array [
+  <Modal
+    animationType="none"
+    hardwareAccelerated={false}
+    onRequestClose={[Function]}
+    statusBarTranslucent={true}
+    transparent={true}
+    visible={true}
+  >
+    <View
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "bottom": 0,
+          "display": "flex",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        animatedStyle={
+          Object {
+            "value": Object {},
+          }
+        }
+        collapsable={false}
+        entering={
+          FadeIn {
+            "build": [Function],
+            "callbackV": [Function],
+            "durationV": 500,
+            "randomizeDelay": false,
+          }
+        }
+        exiting={
+          FadeOut {
+            "build": [Function],
+            "callbackV": [Function],
+            "durationV": 500,
+            "randomizeDelay": false,
+          }
+        }
+        style={
+          Object {
+            "backgroundColor": "rgba(0,0,0,0.4)",
+            "flex": 1,
+          }
+        }
+        testID="pickerBackdrop"
+      />
+    </View>
+    <View
+      pointerEvents="box-none"
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "flex-end",
+        }
+      }
+    >
+      <View
+        animatedStyle={
+          Object {
+            "value": Object {},
+          }
+        }
+        collapsable={false}
+      >
+        <View
+          animatedStyle={
+            Object {
+              "value": Object {},
+            }
+          }
+          collapsable={false}
+          entering={
+            SlideInDown {
+              "build": [Function],
+              "callbackV": [Function],
+              "durationV": 500,
+              "randomizeDelay": false,
+            }
+          }
+          exiting={
+            SlideOutDown {
+              "build": [Function],
+              "callbackV": [Function],
+              "durationV": 500,
+              "randomizeDelay": false,
+            }
+          }
+          pointerEvents="box-none"
+          style={
+            Object {
+              "backgroundColor": "white",
+            }
+          }
+          testID="pickerContainer"
+        >
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "justifyContent": "flex-end",
+                "paddingHorizontal": 10,
+                "paddingVertical": 8,
+              }
+            }
+            testID="pickerAccessory"
+          />
+          <View
+            testID="pickerItemsContainer"
+          >
+            <RNDateTimePicker
+              date={1656601200000}
+              displayIOS="spinner"
+              enabled={true}
+              mode="date"
+              onChange={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "height": 216,
+                }
+              }
+              testID="pickerItems"
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="pressableContainer"
+  >
+    <View
+      pointerEvents="box-only"
+    >
+      <TextInput
+        allowFontScaling={true}
+        editable={false}
+        rejectResponderTermination={true}
+        testID="textInput"
+        underlineColorAndroid="transparent"
+        value="2022-06-30T15:00:00.000Z"
+      />
+    </View>
+  </View>,
+]
+`;
+
+exports[`DateTimePicker with all props should be applied all properly with custom xxx component: DateTimePicker all properly with custom xxx component. 1`] = `
+Array [
+  <Modal
+    animationType="none"
+    hardwareAccelerated={false}
+    onRequestClose={[Function]}
+    statusBarTranslucent={true}
+    testID="modal"
+    transparent={true}
+    visible={true}
+  >
+    <View
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "bottom": 0,
+          "display": "flex",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        animatedStyle={
+          Object {
+            "value": Object {},
+          }
+        }
+        collapsable={false}
+        entering={
+          FadeIn {
+            "build": [Function],
+            "callbackV": [Function],
+            "durationV": 500,
+            "randomizeDelay": false,
+          }
+        }
+        exiting={
+          FadeOut {
+            "build": [Function],
+            "callbackV": [Function],
+            "durationV": 500,
+            "randomizeDelay": false,
+          }
+        }
+        style={
+          Object {
+            "backgroundColor": "green",
+            "borderColor": "red",
+            "flex": 1,
+          }
+        }
+        testID="pickerBackdrop"
+      />
+    </View>
+    <View
+      pointerEvents="box-none"
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "flex-end",
+        }
+      }
+    >
+      <View
+        animatedStyle={
+          Object {
+            "value": Object {},
+          }
+        }
+        collapsable={false}
+      >
+        <View
+          animatedStyle={
+            Object {
+              "value": Object {},
+            }
+          }
+          collapsable={false}
+          entering={
+            SlideInDown {
+              "build": [Function],
+              "callbackV": [Function],
+              "durationV": 500,
+              "randomizeDelay": false,
+            }
+          }
+          exiting={
+            SlideOutDown {
+              "build": [Function],
+              "callbackV": [Function],
+              "durationV": 500,
+              "randomizeDelay": false,
+            }
+          }
+          pointerEvents="box-none"
+          style={
+            Object {
+              "backgroundColor": "yellow",
+              "borderColor": "black",
+            }
+          }
+          testID="pickerContainer"
+        >
+          <View
+            testID="customPickerAccessory"
+          />
+          <View
+            pointerEvents="none"
+            testID="pickerItemsContainer"
+          >
+            <View
+              testID="customPicker"
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="pressableContainer"
+  >
+    <View
+      pointerEvents="box-only"
+    >
+      <View
+        testID="customTextInput"
+      />
+    </View>
+  </View>,
+]
+`;
+
+exports[`DateTimePicker with all props should be applied all properly with default xxx component: DateTimePicker all properly with default xxx component. 1`] = `
+Array [
+  <Modal
+    animationType="none"
+    hardwareAccelerated={false}
+    onRequestClose={[Function]}
+    statusBarTranslucent={true}
+    testID="modal"
+    transparent={true}
+    visible={true}
+  >
+    <View
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "bottom": 0,
+          "display": "flex",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        animatedStyle={
+          Object {
+            "value": Object {},
+          }
+        }
+        collapsable={false}
+        entering={
+          FadeIn {
+            "build": [Function],
+            "callbackV": [Function],
+            "durationV": 500,
+            "randomizeDelay": false,
+          }
+        }
+        exiting={
+          FadeOut {
+            "build": [Function],
+            "callbackV": [Function],
+            "durationV": 500,
+            "randomizeDelay": false,
+          }
+        }
+        style={
+          Object {
+            "backgroundColor": "green",
+            "borderColor": "red",
+            "flex": 1,
+          }
+        }
+        testID="pickerBackdrop"
+      />
+    </View>
+    <View
+      pointerEvents="box-none"
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "flex-end",
+        }
+      }
+    >
+      <View
+        animatedStyle={
+          Object {
+            "value": Object {},
+          }
+        }
+        collapsable={false}
+      >
+        <View
+          animatedStyle={
+            Object {
+              "value": Object {},
+            }
+          }
+          collapsable={false}
+          entering={
+            SlideInDown {
+              "build": [Function],
+              "callbackV": [Function],
+              "durationV": 500,
+              "randomizeDelay": false,
+            }
+          }
+          exiting={
+            SlideOutDown {
+              "build": [Function],
+              "callbackV": [Function],
+              "durationV": 500,
+              "randomizeDelay": false,
+            }
+          }
+          pointerEvents="box-none"
+          style={
+            Object {
+              "backgroundColor": "yellow",
+              "borderColor": "black",
+            }
+          }
+          testID="pickerContainer"
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "blue",
+                "flexDirection": "row",
+                "justifyContent": "flex-end",
+                "paddingHorizontal": 10,
+                "paddingVertical": 8,
+              }
+            }
+            testID="pickerAccessory"
+          >
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="deleteLink"
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#d9545e",
+                    "fontWeight": "bold",
+                    "paddingHorizontal": 10,
+                  }
+                }
+              >
+                delete
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            />
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="cancelLink"
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#4577CC",
+                    "fontWeight": "bold",
+                    "paddingHorizontal": 10,
+                  }
+                }
+              >
+                cancel
+              </Text>
+            </View>
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="doneLink"
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#4577CC",
+                    "fontWeight": "bold",
+                    "paddingHorizontal": 10,
+                  }
+                }
+              >
+                done
+              </Text>
+            </View>
+          </View>
+          <View
+            pointerEvents="none"
+            testID="pickerItemsContainer"
+          >
+            <RNDateTimePicker
+              date={1643641200000}
+              displayIOS="spinner"
+              enabled={true}
+              maximumDate={1656601200000}
+              minimumDate={1612105200000}
+              mode="date"
+              onChange={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "height": 216,
+                  },
+                  Object {
+                    "backgroundColor": "yellow",
+                  },
+                ]
+              }
+              testID="pickerItems"
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="pressableContainer"
+  >
+    <View
+      pointerEvents="box-only"
+    >
+      <TextInput
+        allowFontScaling={true}
+        editable={false}
+        placeholder="please select..."
+        rejectResponderTermination={true}
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+        testID="textInput"
+        underlineColorAndroid="transparent"
+      />
+    </View>
+  </View>,
+]
+`;

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
@@ -1,22 +1,48 @@
+import {Event, AndroidEvent} from '@react-native-community/datetimepicker';
 import {useCallback} from 'react';
 
 import {DateTimePickerProps} from './DateTimePicker';
 import {useDateTimePickerUseCase} from './useDateTimePickerUseCase';
 
 export const useDateTimePickerAndroidUseCase = (props: DateTimePickerProps) => {
-  const {handleDone, ...useCase} = useDateTimePickerUseCase(props);
-  const {onSelectedItemChange} = props;
+  const {setIsVisible, close, ...useCase} = useDateTimePickerUseCase(props);
+  const {onDismiss, onDone, onSelectedItemChange} = props;
+
+  const open = useCallback(() => {
+    setIsVisible(true);
+  }, [setIsVisible]);
+
+  const handleDismiss = useCallback(
+    (selectedValue?: Date) => {
+      onDismiss?.(selectedValue);
+      close();
+    },
+    [close, onDismiss],
+  );
+
+  const handleDone = useCallback(
+    (selectedValue?: Date) => {
+      onDone?.(selectedValue);
+      close();
+    },
+    [close, onDone],
+  );
 
   const onValueChange = useCallback(
-    (_, date?: Date) => {
+    (event: Event | AndroidEvent, date?: Date) => {
       onSelectedItemChange?.(date);
-      handleDone();
+      if (event.type === 'dismissed') {
+        handleDismiss(date);
+      } else if (event.type === 'set') {
+        handleDone(date);
+      }
     },
-    [handleDone, onSelectedItemChange],
+    [handleDismiss, handleDone, onSelectedItemChange],
   );
 
   return {
     ...useCase,
     onValueChange,
+    open,
   };
 };

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
@@ -1,4 +1,4 @@
-import {Event, AndroidEvent} from '@react-native-community/datetimepicker';
+import {AndroidEvent, Event} from '@react-native-community/datetimepicker';
 import {useCallback} from 'react';
 
 import {DateTimePickerProps} from './DateTimePicker';
@@ -14,16 +14,16 @@ export const useDateTimePickerAndroidUseCase = (props: DateTimePickerProps) => {
 
   const handleDismiss = useCallback(
     (selectedValue?: Date) => {
-      onDismiss?.(selectedValue);
       close();
+      onDismiss?.(selectedValue);
     },
     [close, onDismiss],
   );
 
   const handleDone = useCallback(
     (selectedValue?: Date) => {
-      onDone?.(selectedValue);
       close();
+      onDone?.(selectedValue);
     },
     [close, onDone],
   );

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
@@ -9,7 +9,6 @@ export const useDateTimePickerAndroidUseCase = (props: DateTimePickerProps) => {
 
   const onValueChange = useCallback(
     (_, date?: Date) => {
-      console.log(date);
       onSelectedItemChange?.(date);
       handleDone();
     },

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerAndroidUseCase.ts
@@ -1,0 +1,23 @@
+import {useCallback} from 'react';
+
+import {DateTimePickerProps} from './DateTimePicker';
+import {useDateTimePickerUseCase} from './useDateTimePickerUseCase';
+
+export const useDateTimePickerAndroidUseCase = (props: DateTimePickerProps) => {
+  const {handleDone, ...useCase} = useDateTimePickerUseCase(props);
+  const {onSelectedItemChange} = props;
+
+  const onValueChange = useCallback(
+    (_, date?: Date) => {
+      console.log(date);
+      onSelectedItemChange?.(date);
+      handleDone();
+    },
+    [handleDone, onSelectedItemChange],
+  );
+
+  return {
+    ...useCase,
+    onValueChange,
+  };
+};

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerUseCase.ts
@@ -19,7 +19,9 @@ export const useDateTimePickerUseCase = ({
   pickerContainerProps: {entering: containerEntering, exiting: containerExiting} = {},
 }: DateTimePickerProps) => {
   const [isVisible, setIsVisible] = useState(false);
-  const close = useCallback(() => setIsVisible(false), []);
+  const close = useCallback(() => {
+    setIsVisible(false);
+  }, []);
   const pickerBackdropEntering = useMemo(
     () => backdropEntering ?? PICKER_BACKDROP_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
     [backdropEntering],
@@ -42,7 +44,7 @@ export const useDateTimePickerUseCase = ({
     },
     [onSelectedItemChange],
   );
-  const requiredSelectedValue = selectedValue ?? defaultValue;
+  const requiredSelectedValue = useMemo(() => selectedValue ?? defaultValue, [defaultValue, selectedValue]);
   const inputValue = useMemo(() => {
     if (formatText) {
       return formatText(selectedValue);
@@ -59,7 +61,7 @@ export const useDateTimePickerUseCase = ({
     }
     setIsVisible(true);
   }, [defaultValue, onSelectedItemChange, selectedValue]);
-  const handleBackdropPress = useCallback(() => {
+  const handleDismiss = useCallback(() => {
     onDismiss?.(selectedValue);
     close();
   }, [close, onDismiss, selectedValue]);
@@ -78,15 +80,17 @@ export const useDateTimePickerUseCase = ({
 
   return {
     isVisible,
+    setIsVisible,
     requiredSelectedValue,
     inputValue,
-    handleBackdropPress,
+    handleDismiss,
     pickerBackdropEntering,
     pickerBackdropExiting,
     pickerContainerEntering,
     pickerContainerExiting,
     onValueChange,
     open,
+    close,
     handleDelete,
     handleCancel,
     handleDone,

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerUseCase.ts
@@ -1,0 +1,94 @@
+import {useCallback, useMemo, useState} from 'react';
+
+import {DateTimePickerProps} from './DateTimePicker';
+import {PICKER_BACKDROP_DEFAULT_ENTERING, PICKER_BACKDROP_DEFAULT_EXITING} from './PickerBackdrop';
+import {PICKER_CONTAINER_DEFAULT_ENTERING, PICKER_CONTAINER_DEFAULT_EXITING} from './PickerContainer';
+
+const DEFAULT_DURATION = 500;
+
+export const useDateTimePickerUseCase = ({
+  selectedValue,
+  defaultValue = new Date(),
+  onSelectedItemChange,
+  onDismiss,
+  onDelete,
+  onCancel,
+  onDone,
+  formatText,
+  pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting} = {},
+  pickerContainerProps: {entering: containerEntering, exiting: containerExiting} = {},
+}: DateTimePickerProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const close = useCallback(() => setIsVisible(false), []);
+  const pickerBackdropEntering = useMemo(
+    () => backdropEntering ?? PICKER_BACKDROP_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
+    [backdropEntering],
+  );
+  const pickerBackdropExiting = useMemo(
+    () => backdropExiting ?? PICKER_BACKDROP_DEFAULT_EXITING.duration(DEFAULT_DURATION),
+    [backdropExiting],
+  );
+  const pickerContainerEntering = useMemo(
+    () => containerEntering ?? PICKER_CONTAINER_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
+    [containerEntering],
+  );
+  const pickerContainerExiting = useMemo(
+    () => containerExiting ?? PICKER_CONTAINER_DEFAULT_EXITING.duration(DEFAULT_DURATION),
+    [containerExiting],
+  );
+  const onValueChange = useCallback(
+    (_, date?: Date) => {
+      onSelectedItemChange?.(date);
+    },
+    [onSelectedItemChange],
+  );
+  const requiredSelectedValue = selectedValue ?? defaultValue;
+  const inputValue = useMemo(() => {
+    if (formatText) {
+      return formatText(selectedValue);
+    }
+    if (!selectedValue) {
+      return undefined;
+    }
+    return selectedValue.toString();
+  }, [formatText, selectedValue]);
+
+  const open = useCallback(() => {
+    if (selectedValue == null) {
+      onSelectedItemChange?.(defaultValue);
+    }
+    setIsVisible(true);
+  }, [defaultValue, onSelectedItemChange, selectedValue]);
+  const handleBackdropPress = useCallback(() => {
+    onDismiss?.(selectedValue);
+    close();
+  }, [close, onDismiss, selectedValue]);
+  const handleDelete = useCallback(() => {
+    onDelete?.(selectedValue);
+    close();
+  }, [close, onDelete, selectedValue]);
+  const handleCancel = useCallback(() => {
+    onCancel?.(selectedValue);
+    close();
+  }, [close, onCancel, selectedValue]);
+  const handleDone = useCallback(() => {
+    onDone?.(selectedValue);
+    close();
+  }, [close, onDone, selectedValue]);
+
+  return {
+    isVisible,
+    requiredSelectedValue,
+    inputValue,
+    handleBackdropPress,
+    pickerBackdropEntering,
+    pickerBackdropExiting,
+    pickerContainerEntering,
+    pickerContainerExiting,
+    onValueChange,
+    open,
+    handleDelete,
+    handleCancel,
+    handleDone,
+  };
+};

--- a/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
@@ -3,8 +3,8 @@ import {DateTimePicker} from 'components/picker/DateTimePicker';
 import {m} from 'framework/message';
 import {DemoStackParamList} from 'navigation/types';
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
-import {Input} from 'react-native-elements';
+import {Platform, StyleSheet, View} from 'react-native';
+import {Input, Text} from 'react-native-elements';
 
 import {usePickerScreenUseCase} from './usePickerScreenUseCase';
 
@@ -27,13 +27,19 @@ const Screen: React.FC = () => {
     onDeleteForYearMonthPicker,
     onCancelForYearMonthPicker,
     onDoneForYearMonthPicker,
-    selectedDate,
-    onSelectedItemChangeForDate,
-    onDismissForDate,
-    onDeleteForDate,
-    onCancelForDate,
-    onDoneForDate,
+    maximumDate,
+    minimumDate,
     formatDate,
+    selectedDate1,
+    onSelectedItemChangeForDate1,
+    onDismissForDate1,
+    onDeleteForDate1,
+    onCancelForDate1,
+    onDoneForDate1,
+    selectedDate2,
+    onSelectedItemChangeForDate2,
+    selectedDate3,
+    onSelectedItemChangeForDate3,
     placeholder,
   } = usePickerScreenUseCase();
 
@@ -51,7 +57,6 @@ const Screen: React.FC = () => {
         pickerAccessoryProps={{deleteLabel: m('消去'), cancelLabel: m('キャンセル'), doneLabel: m('完了')}}
         textInputComponent={<Input placeholder={placeholder} value={items1InputValue} editable={false} />}
       />
-      <View style={styles.space} />
       <Text>■YearMonthPicker</Text>
       <YearMonthPicker
         selectedValue={yearMonth}
@@ -69,19 +74,51 @@ const Screen: React.FC = () => {
         textInputProps={{style: styles.pickerTextInputStyle}}
       />
       <View style={styles.space} />
-      <Text>■DateTimePicker</Text>
+      <Text>■DateTimePicker1</Text>
       <DateTimePicker
-        selectedValue={selectedDate}
-        defaultValue={new Date()}
-        onSelectedItemChange={onSelectedItemChangeForDate}
-        onDismiss={onDismissForDate}
-        onDelete={onDeleteForDate}
-        onCancel={onCancelForDate}
-        onDone={onDoneForDate}
+        selectedValue={selectedDate1}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChangeForDate1}
+        onDismiss={onDismissForDate1}
+        onDelete={onDeleteForDate1}
+        onCancel={onCancelForDate1}
+        onDone={onDoneForDate1}
         formatText={formatDate}
         mode="date"
         displayIOS="spinner"
+        displayAndroid="calendar"
         pickerAccessoryProps={{deleteLabel: m('消去'), cancelLabel: m('キャンセル'), doneLabel: m('完了')}}
+        textInputProps={{style: styles.pickerTextInputStyle}}
+        placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: spinner' : 'display: calendar'}`}
+      />
+      <View style={styles.space} />
+      <Text>■DateTimePicker</Text>
+      <DateTimePicker
+        selectedValue={selectedDate2}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChangeForDate2}
+        formatText={formatDate}
+        mode="date"
+        displayIOS="inline"
+        displayAndroid="spinner"
+        textInputProps={{style: styles.pickerTextInputStyle}}
+        placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: inline' : 'display: spinner'}`}
+      />
+      <View style={styles.space} />
+      <Text>■DateTimePicker</Text>
+      <DateTimePicker
+        selectedValue={selectedDate3}
+        defaultValue={maximumDate}
+        onSelectedItemChange={onSelectedItemChangeForDate3}
+        mode="time"
+        displayIOS="spinner"
+        displayAndroid="clock"
+        textInputProps={{style: styles.pickerTextInputStyle}}
+        placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: spinner' : 'display: clock'}`}
       />
     </View>
   );
@@ -104,12 +141,6 @@ const styles = StyleSheet.create({
   dateMonthPicker: {
     width: '50%',
   },
-  selectPicker3TextInputStyle: {
-    borderBottomWidth: 1,
-    borderColor: 'grey',
-    paddingVertical: 5,
-    color: 'black',
-  },
   pickerTextInputStyle: {
     borderBottomWidth: 1,
     borderColor: 'grey',
@@ -117,6 +148,6 @@ const styles = StyleSheet.create({
     color: 'black',
   },
   space: {
-    height: 10,
+    height: 20,
   },
 });

--- a/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
@@ -94,7 +94,7 @@ const Screen: React.FC = () => {
         placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: spinner' : 'display: calendar'}`}
       />
       <View style={styles.space} />
-      <Text>■DateTimePicker</Text>
+      <Text>■DateTimePicker2</Text>
       <DateTimePicker
         selectedValue={selectedDate2}
         maximumDate={maximumDate}
@@ -105,11 +105,12 @@ const Screen: React.FC = () => {
         mode="date"
         displayIOS="inline"
         displayAndroid="spinner"
+        pickerAccessoryProps={{doneLabel: m('完了')}}
         textInputProps={{style: styles.pickerTextInputStyle}}
         placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: inline' : 'display: spinner'}`}
       />
       <View style={styles.space} />
-      <Text>■DateTimePicker</Text>
+      <Text>■DateTimePicker3</Text>
       <DateTimePicker
         selectedValue={selectedDate3}
         defaultValue={maximumDate}

--- a/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
@@ -103,8 +103,6 @@ const Screen: React.FC = () => {
         onSelectedItemChange={onSelectedItemChangeForDate2}
         formatText={formatDate}
         mode="date"
-        displayIOS="inline"
-        displayAndroid="spinner"
         pickerAccessoryProps={{doneLabel: m('完了')}}
         textInputProps={{style: styles.pickerTextInputStyle}}
         placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: inline' : 'display: spinner'}`}

--- a/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
@@ -118,6 +118,7 @@ const Screen: React.FC = () => {
         mode="time"
         displayIOS="spinner"
         displayAndroid="clock"
+        pickerAccessoryProps={{doneLabel: m('完了')}}
         textInputProps={{style: styles.pickerTextInputStyle}}
         placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: spinner' : 'display: clock'}`}
       />

--- a/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
@@ -103,6 +103,8 @@ const Screen: React.FC = () => {
         onSelectedItemChange={onSelectedItemChangeForDate2}
         formatText={formatDate}
         mode="date"
+        displayIOS="inline"
+        displayAndroid="spinner"
         pickerAccessoryProps={{doneLabel: m('完了')}}
         textInputProps={{style: styles.pickerTextInputStyle}}
         placeholder={`mode:date,${Platform.OS === 'ios' ? 'display: inline' : 'display: spinner'}`}

--- a/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
+++ b/example-app/SantokuApp/src/screens/demo/picker/PickerScreen.tsx
@@ -1,4 +1,5 @@
 import {SelectPicker, YearMonthPicker} from 'components/picker';
+import {DateTimePicker} from 'components/picker/DateTimePicker';
 import {m} from 'framework/message';
 import {DemoStackParamList} from 'navigation/types';
 import React from 'react';
@@ -26,6 +27,13 @@ const Screen: React.FC = () => {
     onDeleteForYearMonthPicker,
     onCancelForYearMonthPicker,
     onDoneForYearMonthPicker,
+    selectedDate,
+    onSelectedItemChangeForDate,
+    onDismissForDate,
+    onDeleteForDate,
+    onCancelForDate,
+    onDoneForDate,
+    formatDate,
     placeholder,
   } = usePickerScreenUseCase();
 
@@ -59,6 +67,21 @@ const Screen: React.FC = () => {
         onDone={onDoneForYearMonthPicker}
         pickerAccessoryProps={{deleteLabel: m('消去'), cancelLabel: m('キャンセル'), doneLabel: m('完了')}}
         textInputProps={{style: styles.pickerTextInputStyle}}
+      />
+      <View style={styles.space} />
+      <Text>■DateTimePicker</Text>
+      <DateTimePicker
+        selectedValue={selectedDate}
+        defaultValue={new Date()}
+        onSelectedItemChange={onSelectedItemChangeForDate}
+        onDismiss={onDismissForDate}
+        onDelete={onDeleteForDate}
+        onCancel={onCancelForDate}
+        onDone={onDoneForDate}
+        formatText={formatDate}
+        mode="date"
+        displayIOS="spinner"
+        pickerAccessoryProps={{deleteLabel: m('消去'), cancelLabel: m('キャンセル'), doneLabel: m('完了')}}
       />
     </View>
   );

--- a/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
+++ b/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
@@ -98,9 +98,7 @@ export const usePickerScreenUseCase = () => {
   // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておく
   const canceledDate1 = useRef<Date>();
   const onSelectedItemChangeForDate1 = useCallback((selectedValue?: Date) => {
-    if (Platform.OS === 'ios') {
-      setSelectedDate1(selectedValue);
-    }
+    setSelectedDate1(selectedValue);
   }, []);
   const onDismissForDate1 = useCallback((selectedValue?: Date) => {
     if (Platform.OS === 'android') {

--- a/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
+++ b/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
@@ -25,7 +25,7 @@ export const usePickerScreenUseCase = () => {
   // Items1
   //////////////////////////////////////////////////////////////////////////////////
   const [items1Key, setItems1Key] = useState<React.Key>();
-  // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておく
+  // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておきます。
   const items1CanceledKey = useRef<React.Key>();
   const onSelectedItemChangeForItem1 = useCallback((selectedItem?: Item<Item1Type>) => {
     setItems1Key(selectedItem?.key);
@@ -51,9 +51,9 @@ export const usePickerScreenUseCase = () => {
   //////////////////////////////////////////////////////////////////////////////////
   // YearMonthPicker
   //////////////////////////////////////////////////////////////////////////////////
-  // 再レンダリング時に毎回YearMonthが変わらないようにRefで保持する
-  // Refで保持しているため、PickerScreenを開いている間は、maximumYearMonth/minimumYearMonthは変わらない
-  // 一旦前の画面に戻って、再度PickerScreenを開くと、maximumYearMonth/minimumYearMonthは更新される
+  // 再レンダリング時に毎回YearMonthが変わらないようにRefで保持します。
+  // Refで保持しているため、PickerScreenを開いている間は、maximumYearMonth/minimumYearMonthは変わりません。
+  // 一旦前の画面に戻って、再度PickerScreenを開くと、maximumYearMonth/minimumYearMonthは更新されます。
   const maximumYearMonth = useRef(YearMonthUtil.now()).current;
   // maximumYearMonthの5年前をminimumYearMonthとする
   const minimumYearMonth = useRef(YearMonthUtil.addMonth(maximumYearMonth, -60)).current;
@@ -77,33 +77,55 @@ export const usePickerScreenUseCase = () => {
   //////////////////////////////////////////////////////////////////////////////////
   // DateTimePicker
   //////////////////////////////////////////////////////////////////////////////////
-  // 再レンダリング時に毎回YearMonthが変わらないようにRefで保持する
-  // Refで保持しているため、PickerScreenを開いている間は、maximumYearMonth/minimumYearMonthは変わらない
-  // 一旦前の画面に戻って、再度PickerScreenを開くと、maximumYearMonth/minimumYearMonthは更新される
-  const maximumDate = useRef(YearMonthUtil.now()).current;
+  // 再レンダリング時に毎回日時が変わらないようにRefで保持します。
+  // Refで保持しているため、PickerScreenを開いている間は、maximumDate/minimumDateは変わりません。
+  // 一旦前の画面に戻って、再度PickerScreenを開くと、maximumDate/minimumDateは更新されます。
+  const maximumDate = useRef(new Date()).current;
   // maximumYearMonthの5年前をminimumYearMonthとする
-  const minimumDate = useRef(YearMonthUtil.addMonth(maximumYearMonth, -60)).current;
-  const [selectedDate, setSelectedDate] = useState<Date>();
-  // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておく
-  const canceledDate = useRef<Date>();
-  const onSelectedItemChangeForDate = useCallback((selectedValue?: Date) => {
-    setSelectedDate(selectedValue);
-  }, []);
-  const onDismissForDate = useCallback((selectedValue?: Date) => {
-    canceledDate.current = selectedValue;
-  }, []);
-  const onDeleteForDate = useCallback(() => {
-    setSelectedDate(undefined);
-    canceledDate.current = undefined;
-  }, []);
-  const onCancelForDate = useCallback(() => {
-    setSelectedDate(canceledDate.current);
-  }, []);
-  const onDoneForDate = useCallback((selectedValue?: Date) => {
-    canceledDate.current = selectedValue;
-  }, []);
+  const minimumDate = useRef(
+    new Date(maximumDate.getFullYear() - 5, maximumDate.getMonth(), maximumDate.getDate()),
+  ).current;
   const formatDate = useCallback((date?: Date) => {
     return date ? `${date.getUTCFullYear()}/${date.getMonth() + 1}/${date.getDate()}` : '';
+  }, []);
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // DateTimePicker1
+  //////////////////////////////////////////////////////////////////////////////////
+  const [selectedDate1, setSelectedDate1] = useState<Date>();
+  // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておく
+  const canceledDate1 = useRef<Date>();
+  const onSelectedItemChangeForDate1 = useCallback((selectedValue?: Date) => {
+    setSelectedDate1(selectedValue);
+  }, []);
+  const onDismissForDate1 = useCallback((selectedValue?: Date) => {
+    canceledDate1.current = selectedValue;
+  }, []);
+  const onDeleteForDate1 = useCallback(() => {
+    setSelectedDate1(undefined);
+    canceledDate1.current = undefined;
+  }, []);
+  const onCancelForDate1 = useCallback(() => {
+    setSelectedDate1(canceledDate1.current);
+  }, []);
+  const onDoneForDate1 = useCallback((selectedValue?: Date) => {
+    canceledDate1.current = selectedValue;
+  }, []);
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // DateTimePicker2
+  //////////////////////////////////////////////////////////////////////////////////
+  const [selectedDate2, setSelectedDate2] = useState<Date>();
+  const onSelectedItemChangeForDate2 = useCallback((selectedValue?: Date) => {
+    setSelectedDate2(selectedValue);
+  }, []);
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // DateTimePicker3
+  //////////////////////////////////////////////////////////////////////////////////
+  const [selectedDate3, setSelectedDate3] = useState<Date>();
+  const onSelectedItemChangeForDate3 = useCallback((selectedValue?: Date) => {
+    setSelectedDate3(selectedValue);
   }, []);
 
   return {
@@ -125,13 +147,17 @@ export const usePickerScreenUseCase = () => {
     onDoneForYearMonthPicker,
     maximumDate,
     minimumDate,
-    selectedDate,
-    onSelectedItemChangeForDate,
-    onDismissForDate,
-    onDeleteForDate,
-    onCancelForDate,
-    onDoneForDate,
     formatDate,
+    selectedDate1,
+    onSelectedItemChangeForDate1,
+    onDismissForDate1,
+    onDeleteForDate1,
+    onCancelForDate1,
+    onDoneForDate1,
+    selectedDate2,
+    onSelectedItemChangeForDate2,
+    selectedDate3,
+    onSelectedItemChangeForDate3,
     placeholder,
   };
 };

--- a/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
+++ b/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
@@ -1,5 +1,6 @@
 import {Item, YearMonth, YearMonthUtil} from 'components/picker';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
+import {Platform} from 'react-native';
 
 type Item1Type = {
   a: string;
@@ -19,6 +20,10 @@ const items1: Item<Item1Type>[] = [
 ];
 
 const placeholder = 'please select...';
+
+const formatDate = (date?: Date) => {
+  return date ? `${date.getUTCFullYear()}/${date.getMonth() + 1}/${date.getDate()}` : '';
+};
 
 export const usePickerScreenUseCase = () => {
   //////////////////////////////////////////////////////////////////////////////////
@@ -85,9 +90,6 @@ export const usePickerScreenUseCase = () => {
   const minimumDate = useRef(
     new Date(maximumDate.getFullYear() - 5, maximumDate.getMonth(), maximumDate.getDate()),
   ).current;
-  const formatDate = useCallback((date?: Date) => {
-    return date ? `${date.getUTCFullYear()}/${date.getMonth() + 1}/${date.getDate()}` : '';
-  }, []);
 
   //////////////////////////////////////////////////////////////////////////////////
   // DateTimePicker1
@@ -96,10 +98,16 @@ export const usePickerScreenUseCase = () => {
   // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておく
   const canceledDate1 = useRef<Date>();
   const onSelectedItemChangeForDate1 = useCallback((selectedValue?: Date) => {
-    setSelectedDate1(selectedValue);
+    if (Platform.OS === 'ios') {
+      setSelectedDate1(selectedValue);
+    }
   }, []);
   const onDismissForDate1 = useCallback((selectedValue?: Date) => {
-    canceledDate1.current = selectedValue;
+    if (Platform.OS === 'android') {
+      setSelectedDate1(canceledDate1.current);
+    } else if (Platform.OS === 'ios') {
+      canceledDate1.current = selectedValue;
+    }
   }, []);
   const onDeleteForDate1 = useCallback(() => {
     setSelectedDate1(undefined);

--- a/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
+++ b/example-app/SantokuApp/src/screens/demo/picker/usePickerScreenUseCase.ts
@@ -74,6 +74,38 @@ export const usePickerScreenUseCase = () => {
     setYearMonthCanceledKey(yearMonth);
   }, []);
 
+  //////////////////////////////////////////////////////////////////////////////////
+  // DateTimePicker
+  //////////////////////////////////////////////////////////////////////////////////
+  // 再レンダリング時に毎回YearMonthが変わらないようにRefで保持する
+  // Refで保持しているため、PickerScreenを開いている間は、maximumYearMonth/minimumYearMonthは変わらない
+  // 一旦前の画面に戻って、再度PickerScreenを開くと、maximumYearMonth/minimumYearMonthは更新される
+  const maximumDate = useRef(YearMonthUtil.now()).current;
+  // maximumYearMonthの5年前をminimumYearMonthとする
+  const minimumDate = useRef(YearMonthUtil.addMonth(maximumYearMonth, -60)).current;
+  const [selectedDate, setSelectedDate] = useState<Date>();
+  // キャンセルをタップした時に、Pickerを開く前の値に戻せるようにRefで保持しておく
+  const canceledDate = useRef<Date>();
+  const onSelectedItemChangeForDate = useCallback((selectedValue?: Date) => {
+    setSelectedDate(selectedValue);
+  }, []);
+  const onDismissForDate = useCallback((selectedValue?: Date) => {
+    canceledDate.current = selectedValue;
+  }, []);
+  const onDeleteForDate = useCallback(() => {
+    setSelectedDate(undefined);
+    canceledDate.current = undefined;
+  }, []);
+  const onCancelForDate = useCallback(() => {
+    setSelectedDate(canceledDate.current);
+  }, []);
+  const onDoneForDate = useCallback((selectedValue?: Date) => {
+    canceledDate.current = selectedValue;
+  }, []);
+  const formatDate = useCallback((date?: Date) => {
+    return date ? `${date.getUTCFullYear()}/${date.getMonth() + 1}/${date.getDate()}` : '';
+  }, []);
+
   return {
     items1,
     items1Key,
@@ -91,6 +123,15 @@ export const usePickerScreenUseCase = () => {
     onDeleteForYearMonthPicker,
     onCancelForYearMonthPicker,
     onDoneForYearMonthPicker,
+    maximumDate,
+    minimumDate,
+    selectedDate,
+    onSelectedItemChangeForDate,
+    onDismissForDate,
+    onDeleteForDate,
+    onCancelForDate,
+    onDoneForDate,
+    formatDate,
     placeholder,
   };
 };


### PR DESCRIPTION
## ✅ What's done

- [ ] DeployGateにアップロードして確認中
- [x] DateTimePickerを追加
- [x] iOSアプリのLocalizationに`ja-JP`を追加（[react-native-datetimepicker - Localization note](https://github.com/react-native-datetimepicker/datetimepicker#localization-note) ）

---

## Tests

- [ ] デモ画面で打鍵

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 15)
- [ ] Android
  - [x] エミュレータ (Pixel 4a/Android 12)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
