### PR TITLE
📌: @react-native-async-storageをRenovate管理から除外

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,7 @@
       enabled: false,
       matchPackageNames: [
         '@babel/core',
+        '@react-native-async-storage/async-storage',
         '@react-native-community/netinfo',
         '@react-native-masked-view/masked-view',
         '@react-native-picker/picker',


### PR DESCRIPTION
## ✅ What's done

- [x] `@react-native-async-storage`はExpoアップグレードでVerUpするので、Renovateの管理対象から除外

---

## Other (messages to reviewers, concerns, etc.)

なし
