### PR TITLE
👷:  CIで使用するJavaのバージョンを8 -> 11に変更

### DIFF
--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -61,6 +61,11 @@ stages:
         displayName: 'Use Node.js 16.14.2'
         inputs:
           versionSpec: '16.14.2'
+      - task: JavaToolInstaller@0
+        inputs:
+          versionSpec: '11'
+          jdkArchitectureOption: 'x64'
+          jdkSourceOption: 'PreInstalled'
       - task: Cache@2
         displayName: Cache npm
         inputs:


### PR DESCRIPTION
## ✅ What's done

- [ ] #859 のCIのAndroidビルドがJavaのバージョン起因で失敗しているため、ビルド時のJavaのバージョンを11に変更

<!-- 該当するものがなければ、このセクション（この行から「---」の前の行まで）を削除してください。 -->
## ⏸ What's not done

- やっていないこと（やる予定がないこと）を箇条書きで記載してください
- 解決できていない課題・障害があれば、それも記載してください

---

## Other (messages to reviewers, concerns, etc.)

#859 のエラー内容
https://github.com/ws-4020/mobile-app-crib-notes/pull/859#issuecomment-1143286810

CIで使用しているmacOS-11のJavaのデフォルトバージョン
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#java

