### PR TITLE
📌: gradle-download-taskをRenovate管理から除外

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,8 @@
         'gradle',
         // expo-template-bare-minimum
         'com.android.tools.build:gradle',
+        // expo-template-bare-minimum
+        'de.undercouch:gradle-download-task',
       ],
       matchPackagePrefixes: [
         'com.facebook.flipper',


### PR DESCRIPTION
## ✅ What's done

- [x] `gradle-download-task`はExpoアップグレードでVerUpするので、Renovateの管理対象から除外

---

## Other (messages to reviewers, concerns, etc.)

なし
