### PR TITLE
📝: 学習コンテンツにrn-spoilerのExpo SDK 44、45対応を反映

### DIFF
--- a/website/docs/react-native/learn/todo-app/networking/generate-api-client.mdx
+++ b/website/docs/react-native/learn/todo-app/networking/generate-api-client.mdx
@@ -51,9 +51,8 @@ npm install -D @openapitools/openapi-generator-cli
 
 ```diff title="package.json"
      "reset-cache:all": "node .script/runner.js reset-cache --all",
--    "reset-cache:interactive": "node .script/runner.js reset-cache --interactive"
-+    "reset-cache:interactive": "node .script/runner.js reset-cache --interactive",
-+    "api:gen-client": "openapi-generator-cli generate -g typescript-fetch -i https://raw.githubusercontent.com/{@inject: organization}/mobile-app-hands-on-backend/main/rest-api-specification/openapi.yaml -o src/backend/generated-rest-client --additional-properties supportsES6=true,typescriptThreePlus=true"
+     "reset-cache:interactive": "node .script/runner.js reset-cache --interactive",
++    "api:gen-client": "openapi-generator-cli generate -g typescript-fetch -i https://raw.githubusercontent.com/{@inject: organization}/mobile-app-hands-on-backend/main/rest-api-specification/openapi.yaml -o src/backend/generated-rest-client --additional-properties supportsES6=true,typescriptThreePlus=true",
    },
 ```
 

--- a/website/docs/react-native/learn/todo-app/screens/auth.mdx
+++ b/website/docs/react-native/learn/todo-app/screens/auth.mdx
@@ -127,14 +127,18 @@ export const UserContextProvider: React.FC = ({children}) => {
 + import {UserContextProvider} from 'contexts/UserContext';
   import {RootStackNav} from 'navigation';
   import React from 'react';
+  import {StyleSheet} from 'react-native';
+  import {GestureHandlerRootView} from 'react-native-gesture-handler';
   
   export const App = () => {
     return (
-+     <UserContextProvider>
-        <NavigationContainer>
-          <RootStackNav />
-        </NavigationContainer>
-+     </UserContextProvider>
+      <GestureHandlerRootView style={StyleSheet.absoluteFill}>
++       <UserContextProvider>
+          <NavigationContainer>
+            <RootStackNav />
+          </NavigationContainer>
++       </UserContextProvider>
+      </GestureHandlerRootView>
     );
   };
 ```


### PR DESCRIPTION
## ✅ What's done

- [x] rn-spoilerのExpo SDKアップグレード対応を学習コンテンツに反映
  - `App.tsx`に、`GestureHandlerRootView`を追加
  - `package.json`のscripts追加に伴う対応
 
＜参考＞
  - [⬆️: Upgrade Expo SDK to 45 ](https://github.com/ws-4020/rn-spoiler/pull/109)
  - [⬆️: Upgrade Expo SDK to 44 ](https://github.com/ws-4020/rn-spoiler/pull/106)

---

## Other (messages to reviewers, concerns, etc.)

なし
