### PR TITLE
🐛: PickerコンポーネントでReanimatedのLayout Animationsを使用しないように変更

### DIFF
--- a/example-app/SantokuApp/jest/setup/react-native-reanimated.js
+++ b/example-app/SantokuApp/jest/setup/react-native-reanimated.js
@@ -1,2 +1,7 @@
+// jest.advanceTimersByTimeを使用した際に、TypeError: Cannot read properties of undefined (reading 'now')が発生してしまう問題に対応
+// https://github.com/software-mansion/react-native-reanimated/issues/3125
+global.ReanimatedDataMock = {
+  now: () => Date.now(),
+};
 // https://docs.swmansion.com/react-native-reanimated/docs/guide/testing/
 require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
@@ -7,6 +7,13 @@ import {DateTimePickerItemsIOSProps} from './DateTimePickerItems';
 import {PickerBackdropProps} from './PickerBackdrop';
 import {PickerContainerProps} from './PickerContainer';
 
+jest.doMock('react-native/Libraries/Utilities/Dimensions', () => ({
+  get: jest.fn().mockReturnValue({width: 400, height: 1000}),
+  set: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+}));
+
 describe('DateTimePicker only with required props', () => {
   it('renders successfully if invisible', () => {
     const sut = render(
@@ -133,7 +140,11 @@ describe('DateTimePicker with all props', () => {
     // assert pickerContainer
     const pickerContainer = sut.getByTestId('pickerContainer');
     const pickerContainerProps = pickerContainer.props as PickerContainerProps;
-    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+    expect(pickerContainerProps.style).toEqual({
+      backgroundColor: 'yellow',
+      borderColor: 'black',
+      transform: [{translateY: 1000}],
+    });
 
     // assert pickerItemsContainer
     const pickerItemsContainer = sut.getByTestId('pickerItemsContainer');
@@ -165,7 +176,7 @@ describe('DateTimePicker with all props', () => {
     const modal = sut.getByTestId('modal');
     const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
     fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);
@@ -248,7 +259,7 @@ describe('DateTimePicker with all props', () => {
     const modal = sut.getByTestId('modal');
     const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
     fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);
@@ -256,7 +267,11 @@ describe('DateTimePicker with all props', () => {
     // assert pickerContainer
     const pickerContainer = sut.getByTestId('pickerContainer');
     const pickerContainerProps = pickerContainer.props as PickerContainerProps;
-    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+    expect(pickerContainerProps.style).toEqual({
+      backgroundColor: 'yellow',
+      borderColor: 'black',
+      transform: [{translateY: 1000}],
+    });
 
     // assert pickerAccessory
     const defaultPickerAccessory = sut.queryByTestId('defaultPickerAccessory');

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.test.tsx
@@ -19,7 +19,7 @@ describe('DateTimePicker only with required props', () => {
     const sut = render(
       <DateTimePicker
         textInputProps={{testID: 'textInput'}}
-        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerBackdropProps={{pressableProps: {testID: 'pickerBackdrop'}}}
         pickerContainerProps={{testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
         pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
@@ -49,7 +49,7 @@ describe('DateTimePicker only with required props', () => {
       <DateTimePicker
         selectedValue={selectedValue}
         textInputProps={{testID: 'textInput'}}
-        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerBackdropProps={{pressableProps: {testID: 'pickerBackdrop'}}}
         pickerContainerProps={{testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
         pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
@@ -109,9 +109,8 @@ describe('DateTimePicker with all props', () => {
         pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
         pickerItemsProps={{style: {backgroundColor: 'yellow'}, testID: 'pickerItems'}}
         pickerBackdropProps={{
-          style: {backgroundColor: 'green', borderColor: 'red'},
-          modalProps: {testID: 'modal'},
-          testID: 'pickerBackdrop',
+          modalProps: {testID: 'pickerBackdropModal'},
+          pressableProps: {testID: 'pickerBackdropPressable', style: {backgroundColor: 'green', borderColor: 'red'}},
         }}
         pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
         pickerAccessoryProps={{
@@ -172,11 +171,21 @@ describe('DateTimePicker with all props', () => {
     expect(textInputProps.style).toEqual({color: 'red'});
 
     // assert pickerBackdrop
-    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
-    const modal = sut.getByTestId('modal');
-    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
-    fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
+    const pickerBackdropPressable = sut.getByTestId('pickerBackdropPressable');
+    const pickerBackdropModal = sut.getByTestId('pickerBackdropModal');
+    const pickerBackdropProps = pickerBackdropPressable.props as PickerBackdropProps;
+    fireEvent(pickerBackdropModal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({
+      backgroundColor: 'green',
+      borderColor: 'red',
+      opacity: 0.4,
+      bottom: 0,
+      display: 'flex',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    });
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);
@@ -235,9 +244,8 @@ describe('DateTimePicker with all props', () => {
         textInputProps={{testID: 'defaultTextInput'}}
         pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
         pickerBackdropProps={{
-          style: {backgroundColor: 'green', borderColor: 'red'},
-          modalProps: {testID: 'modal'},
-          testID: 'pickerBackdrop',
+          modalProps: {testID: 'pickerBackdropModal'},
+          pressableProps: {testID: 'pickerBackdropPressable', style: {backgroundColor: 'green', borderColor: 'red'}},
         }}
         pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'defaultPickerAccessory'}}}
@@ -255,11 +263,21 @@ describe('DateTimePicker with all props', () => {
     expect(sut).toMatchSnapshot('DateTimePicker all properly with custom xxx component.');
 
     // assert pickerBackdrop
-    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
-    const modal = sut.getByTestId('modal');
-    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
-    fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
+    const pickerBackdropPressable = sut.getByTestId('pickerBackdropPressable');
+    const pickerBackdropModal = sut.getByTestId('pickerBackdropModal');
+    const pickerBackdropProps = pickerBackdropPressable.props as PickerBackdropProps;
+    fireEvent(pickerBackdropModal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({
+      backgroundColor: 'green',
+      borderColor: 'red',
+      opacity: 0.4,
+      bottom: 0,
+      display: 'flex',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    });
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
@@ -14,6 +14,9 @@ export type DateTimePickerIOSProps = Omit<DateTimePickerProps, 'displayAndroid' 
     'value' | 'onChange' | 'mode' | 'display' | 'maximumDate' | 'minimumDate'
   >;
 };
+
+const DEFAULT_DURATION = 500;
+
 /**
  * 日時を表示するPickerとしてReact Native DateTimePickerを使用しています。
  * React Native DateTimePickerは、NativeのUIDatePickerを使用しています。
@@ -45,10 +48,6 @@ export const DateTimePicker = (props: DateTimePickerIOSProps) => {
     requiredSelectedValue,
     inputValue,
     handleDismiss,
-    pickerBackdropEntering,
-    pickerBackdropExiting,
-    pickerContainerEntering,
-    pickerContainerExiting,
     onValueChange,
     open,
     handleDelete,
@@ -67,11 +66,15 @@ export const DateTimePicker = (props: DateTimePickerIOSProps) => {
     textInputComponent,
     pickerItemsContainerProps: {style: pickerItemsContainerStyle, ...pickerItemsContainerProps} = {},
     pickerItemsProps,
-    pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting, ...pickerBackdropProps} = {},
+    pickerBackdropProps: {
+      fadeInDuration = DEFAULT_DURATION,
+      fadeOutDuration = DEFAULT_DURATION,
+      ...pickerBackdropProps
+    } = {},
     pickerContainerProps: {
-      entering: containerEntering,
-      exiting: containerExiting,
       style: pickerContainerStyle,
+      slideInDuration = DEFAULT_DURATION,
+      slideOutDuration = DEFAULT_DURATION,
       ...pickerContainerProps
     } = {},
     pickerAccessoryProps,
@@ -82,14 +85,14 @@ export const DateTimePicker = (props: DateTimePickerIOSProps) => {
       <PickerBackdrop
         isVisible={isVisible}
         onPress={handleDismiss}
-        entering={pickerBackdropEntering}
-        exiting={pickerBackdropExiting}
+        fadeInDuration={fadeInDuration}
+        fadeOutDuration={fadeOutDuration}
         {...pickerBackdropProps}>
         <PickerContainer
           isVisible={isVisible}
-          entering={pickerContainerEntering}
-          exiting={pickerContainerExiting}
           style={[styles.pickerContainer, pickerContainerStyle]}
+          slideInDuration={slideInDuration}
+          slideOutDuration={slideOutDuration}
           {...pickerContainerProps}>
           {pickerAccessoryComponent ? (
             pickerAccessoryComponent

--- a/example-app/SantokuApp/src/components/picker/PickerBackdrop.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/PickerBackdrop.test.tsx
@@ -1,9 +1,8 @@
 import {act, fireEvent, render} from '@testing-library/react-native';
 import React from 'react';
-import {ModalProps, PressableProps, ViewProps} from 'react-native';
-import Reanimated from 'react-native-reanimated';
+import {ModalProps, PressableProps} from 'react-native';
 
-import {DEFAULT_FADE_IN_DURATION, DEFAULT_FADE_OUT_DURATION, DEFAULT_OPACITY, PickerBackdrop} from './PickerBackdrop';
+import {DEFAULT_FADE_OUT_DURATION, PickerBackdrop} from './PickerBackdrop';
 
 // If advancing a timer changes the state of a component, the timer must be run within an act.
 // However, since act is `Thenable`, ESLint will issue a warning if you do not do something like await.
@@ -17,7 +16,6 @@ jest.useFakeTimers('modern');
 
 // TODO: Jest v27にアップデートできたら、withReanimatedTimerでテストを実装できるか検証する。
 //       （JestのバージョンはExpoに依存しているので、Expoでのアップデートを待っている状態）
-const startAnimation = () => act(() => jest.advanceTimersByTime(1));
 
 describe('PickerBackdrop only with required props', () => {
   it('returns null if not visible', () => {
@@ -27,52 +25,22 @@ describe('PickerBackdrop only with required props', () => {
   });
 
   it('renders successfully only with required props', () => {
-    const sut = render(<PickerBackdrop isVisible testID="backdropAnimated" />);
-    const animatedView = sut.getByTestId('backdropAnimated');
+    const sut = render(<PickerBackdrop isVisible pressableProps={{testID: 'pressable'}} />);
     //////////////////////////////////////////////////////////////////////////////////
     // 初期表示
     //////////////////////////////////////////////////////////////////////////////////
     // エラーが起きずにレンダリングされること
+    const pressable = sut.queryByTestId('pressable');
+    expect(pressable).not.toBeNull();
     expect(sut).toMatchSnapshot('Before animation started');
-    expect(animatedView).toHaveAnimatedStyle({opacity: 0});
-
-    startAnimation();
-
-    // アニメーション中は`opacity`が変化すること
-    act(() => jest.advanceTimersByTime(DEFAULT_FADE_IN_DURATION / 2));
-    expect(animatedView).toHaveAnimatedStyle({opacity: DEFAULT_OPACITY / 2});
-    expect(sut).toMatchSnapshot('Animating (fade in)');
-
-    // アニメーションが完了すると`opacity`が設定値に到達していること
-    act(() => jest.advanceTimersByTime(DEFAULT_FADE_IN_DURATION / 2));
-    expect(animatedView).toHaveAnimatedStyle({opacity: DEFAULT_OPACITY});
-    expect(sut).toMatchSnapshot('Just After fade in animation completed');
-
-    // アニメーションが完了したあとは変化しないこと
-    act(() => jest.advanceTimersByTime(10));
-    expect(animatedView).toHaveAnimatedStyle({opacity: DEFAULT_OPACITY});
-    expect(sut).toMatchSnapshot('Just After fade in animation completed');
 
     //////////////////////////////////////////////////////////////////////////////////
     // 非表示にする
     //////////////////////////////////////////////////////////////////////////////////
-    sut.update(<PickerBackdrop isVisible={false} />);
-
-    startAnimation();
-
-    // アニメーション中は`opacity`が変化すること
-    act(() => jest.advanceTimersByTime(DEFAULT_FADE_OUT_DURATION / 2));
-    expect(animatedView).toHaveAnimatedStyle({opacity: DEFAULT_OPACITY / 2});
-    expect(sut).toMatchSnapshot('Animating (fade out)');
-
-    // アニメーションが完了するとコンポーネントが消えること
-    act(() => jest.advanceTimersByTime(DEFAULT_FADE_OUT_DURATION / 2));
-    expect(sut.container.children).toEqual([]);
-    expect(sut).toMatchSnapshot('Just After fade out animation completed');
-
-    // アニメーションが完了した後も少し時間を進めて、何も変わらないことを確認する
-    act(() => jest.advanceTimersByTime(10));
-    expect(sut.container.children).toEqual([]);
+    sut.update(<PickerBackdrop isVisible={false} pressableProps={{testID: 'pressable'}} />);
+    act(() => jest.advanceTimersByTime(DEFAULT_FADE_OUT_DURATION));
+    const pressable2 = sut.queryByTestId('pressable');
+    expect(pressable2).toBeNull();
     expect(sut).toMatchSnapshot('Just After fade out animation completed');
   });
 });
@@ -84,7 +52,6 @@ describe('PickerBackdrop with `onPress', () => {
       <PickerBackdrop
         isVisible
         onPress={onPress}
-        testID="pickerBackDrop"
         pressableProps={{testID: 'pressable'}}
         modalProps={{testID: 'modal'}}
       />,
@@ -111,7 +78,6 @@ describe('PickerBackdrop with all props', () => {
     const sut = render(
       <PickerBackdrop
         isVisible
-        testID="animatedView"
         onPress={onPress}
         modalProps={{
           testID: 'modal',
@@ -121,7 +87,11 @@ describe('PickerBackdrop with all props', () => {
           transparent: false,
           presentationStyle: 'fullScreen',
         }}
-        pressableProps={{testID: 'pressable', style: {display: 'none'}, onLongPress}}
+        pressableProps={{
+          testID: 'pressable',
+          style: {display: 'none', backgroundColor: 'red', opacity: 0.8},
+          onLongPress,
+        }}
         animatedProps={{pointerEvents: 'none'}}
         style={{backgroundColor: 'green', borderColor: 'red'}}
         fadeInDuration={200}
@@ -131,7 +101,6 @@ describe('PickerBackdrop with all props', () => {
     expect(sut).toMatchSnapshot('PickerBackdrop with all props.');
     const modal = sut.getByTestId('modal');
     const pressable = sut.getByTestId('pressable');
-    const animatedView = sut.getByTestId('animatedView');
 
     // assert modal
     fireEvent(modal, 'onRequestClose');
@@ -144,10 +113,6 @@ describe('PickerBackdrop with all props', () => {
     expect(modalProps.presentationStyle).toBe('fullScreen');
     expect(onPress).toHaveBeenCalledTimes(1);
 
-    // assert animatedView
-    const animatedViewProps = animatedView.props as Reanimated.AnimateProps<ViewProps>;
-    expect(animatedViewProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
-
     // fadeInDurationで指定した時間の1msc前ではafterFadeInは実行されない
     act(() => jest.advanceTimersByTime(199));
     expect(afterFadeIn).not.toHaveBeenCalled();
@@ -159,7 +124,16 @@ describe('PickerBackdrop with all props', () => {
     fireEvent.press(pressable);
     fireEvent(pressable, 'onLongPress');
     const pressableProps = pressable.props as PressableProps;
-    expect(pressableProps.style).toEqual({bottom: 0, display: 'none', left: 0, position: 'absolute', right: 0, top: 0});
+    expect(pressableProps.style).toEqual({
+      backgroundColor: 'red',
+      opacity: 0.8,
+      bottom: 0,
+      display: 'none',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    });
     expect(onPress).toHaveBeenCalledTimes(2);
     expect(onLongPress).toHaveBeenCalledTimes(1);
 
@@ -169,7 +143,6 @@ describe('PickerBackdrop with all props', () => {
     const afterFadeOut = jest.fn();
     sut.update(<PickerBackdrop isVisible={false} afterFadeOut={afterFadeOut} fadeOutDuration={100} />);
 
-    startAnimation();
     // fadeOutDurationで指定した時間の1msc前ではafterFadeOutは実行されない
     act(() => jest.advanceTimersByTime(99));
     expect(afterFadeOut).not.toHaveBeenCalled();

--- a/example-app/SantokuApp/src/components/picker/PickerBackdrop.tsx
+++ b/example-app/SantokuApp/src/components/picker/PickerBackdrop.tsx
@@ -1,67 +1,64 @@
 import {composePressableStyles} from 'framework/utilities';
 import React, {useMemo} from 'react';
-import {Modal as RNModal, ModalProps, Omit, Pressable, PressableProps, StyleSheet, ViewProps} from 'react-native';
-import Reanimated, {BaseAnimationBuilder, FadeIn, FadeOut, Keyframe} from 'react-native-reanimated';
+import {Modal as RNModal, ModalProps, Pressable, PressableProps, StyleSheet, ViewProps} from 'react-native';
+import Reanimated, {useAnimatedStyle, WithTimingConfig} from 'react-native-reanimated';
 
 import {usePickerBackdropUseCase} from './usePickerBackdropUseCase';
 
-export const PICKER_BACKDROP_DEFAULT_COLOR = 'rgba(0,0,0,0.4)';
-export const PICKER_BACKDROP_DEFAULT_FADE_IN_DURATION = 300;
-export const PICKER_BACKDROP_DEFAULT_FADE_OUT_DURATION = 150;
-export const PICKER_BACKDROP_DEFAULT_ENTERING = FadeIn.duration(PICKER_BACKDROP_DEFAULT_FADE_IN_DURATION);
-export const PICKER_BACKDROP_DEFAULT_EXITING = FadeOut.duration(PICKER_BACKDROP_DEFAULT_FADE_OUT_DURATION);
+export const DEFAULT_BACKGROUND_COLOR = 'black';
+export const DEFAULT_OPACITY = 0.4;
+export const DEFAULT_FADE_IN_DURATION = 300;
+export const DEFAULT_FADE_OUT_DURATION = 150;
 
-export type PickerBackdropProps = Omit<Reanimated.AnimateProps<ViewProps>, 'entering' | 'exiting'> & {
+// React Native ReanimatedのLayout Animationsを使用すると↓の不具合が発生するため、指定できないようにしています。
+// https://github.com/software-mansion/react-native-reanimated/issues/2906
+export type PickerBackdropProps = Omit<Reanimated.AnimateProps<ViewProps>, 'exiting' | 'entering'> & {
   isVisible: boolean;
   onPress?: () => unknown;
-  /**
-   * iOSの場合、アニメーションが終わった後に呼び出されます。
-   * Androidの場合、アニメーションが始まった時に呼び出されます。
-   */
-  enteringCallback?: (finished: boolean) => unknown;
-  exitingCallback?: (finished: boolean) => unknown;
+  afterFadeIn?: (finished?: boolean) => unknown;
+  afterFadeOut?: (finished?: boolean) => unknown;
+  fadeInDuration?: number;
+  fadeOutDuration?: number;
+  opacity?: number;
   pressableProps?: PressableProps;
   modalProps?: ModalProps;
-  /**
-   * enteringに指定したAnimationBuilderなどでwithCallbackを指定しても、このコンポーネントの中で上書きしているため実行できません。
-   * withCallbackで実行する関数は、enteringCallbackで指定してください。
-   */
-  entering?: BaseAnimationBuilder | Keyframe;
-  /**
-   * exitingに指定したAnimationBuilderなどでwithCallbackを指定しても、このコンポーネントの中で上書きしているため実行できません。
-   * withCallbackで実行する関数は、exitingCallbackで指定してください。
-   */
-  exiting?: BaseAnimationBuilder | Keyframe;
+  fadeInConfig?: WithTimingConfig;
+  fadeOutConfig?: WithTimingConfig;
 };
 
 export const PickerBackdrop: React.FC<PickerBackdropProps> = ({
   isVisible,
+  opacity = DEFAULT_OPACITY,
   onPress,
-  entering = PICKER_BACKDROP_DEFAULT_ENTERING,
-  exiting = PICKER_BACKDROP_DEFAULT_EXITING,
-  enteringCallback,
-  exitingCallback,
+  afterFadeIn,
+  afterFadeOut,
+  fadeInDuration = DEFAULT_FADE_IN_DURATION,
+  fadeOutDuration = DEFAULT_FADE_OUT_DURATION,
   pressableProps: {style: pressableStyle, ...pressableProps} = {},
   modalProps: {style: modalStyle, ...modalProps} = {},
-  /**
-   * このコンポーネントでは、ReanimatedのEntering/Exitingを使用してアニメーションを実現しています。
-   * Entering/Exitingを使用した場合は、opacityを設定しても反映されません。
-   * backgroundColorにrgbaで指定してください。（e.g. backgroundColor: rgba(0,0,0,0.4)）
-   */
+  fadeInConfig,
+  fadeOutConfig,
   style,
   children,
   ...animatedViewProps
 }) => {
-  const {isModalVisible, composedEnteringCallback, composedExitingCallback} = usePickerBackdropUseCase({
+  const {isModalVisible, animatedOpacity} = usePickerBackdropUseCase({
     isVisible,
-    enteringCallback,
-    exitingCallback,
+    opacity,
+    afterFadeIn,
+    afterFadeOut,
+    fadeInDuration,
+    fadeOutDuration,
+    fadeInConfig,
+    fadeOutConfig,
   });
 
+  const animatedStyle = useAnimatedStyle(() => ({opacity: animatedOpacity.value}));
   const composedPressableStyles = useMemo(
     () => composePressableStyles([styles.pressable, pressableStyle]),
     [pressableStyle],
   );
+  const composedBackdropStyle = useMemo(() => StyleSheet.flatten([styles.backdrop, style]), [style]);
 
   return !isModalVisible ? null : (
     <RNModal
@@ -73,16 +70,9 @@ export const PickerBackdrop: React.FC<PickerBackdropProps> = ({
       onRequestClose={onPress}
       style={modalStyle}
       {...modalProps}>
-      {isVisible && (
-        <Pressable onPress={onPress} style={composedPressableStyles} {...pressableProps}>
-          <Reanimated.View
-            entering={entering.withCallback(composedEnteringCallback)}
-            exiting={exiting.withCallback(composedExitingCallback)}
-            style={[styles.backdrop, style]}
-            {...animatedViewProps}
-          />
-        </Pressable>
-      )}
+      <Pressable onPress={onPress} style={composedPressableStyles} {...pressableProps}>
+        <Reanimated.View style={[composedBackdropStyle, animatedStyle]} {...animatedViewProps} />
+      </Pressable>
       {children}
     </RNModal>
   );
@@ -95,6 +85,6 @@ const styles = StyleSheet.create({
   },
   backdrop: {
     flex: 1,
-    backgroundColor: PICKER_BACKDROP_DEFAULT_COLOR,
+    backgroundColor: DEFAULT_BACKGROUND_COLOR,
   },
 });

--- a/example-app/SantokuApp/src/components/picker/PickerBackdrop.tsx
+++ b/example-app/SantokuApp/src/components/picker/PickerBackdrop.tsx
@@ -1,7 +1,7 @@
 import {composePressableStyles} from 'framework/utilities';
 import React, {useMemo} from 'react';
 import {Modal as RNModal, ModalProps, Pressable, PressableProps, StyleSheet, ViewProps} from 'react-native';
-import Reanimated, {useAnimatedStyle, WithTimingConfig} from 'react-native-reanimated';
+import Reanimated, {WithTimingConfig} from 'react-native-reanimated';
 
 import {usePickerBackdropUseCase} from './usePickerBackdropUseCase';
 
@@ -38,11 +38,9 @@ export const PickerBackdrop: React.FC<PickerBackdropProps> = ({
   modalProps: {style: modalStyle, ...modalProps} = {},
   fadeInConfig,
   fadeOutConfig,
-  style,
   children,
-  ...animatedViewProps
 }) => {
-  const {isModalVisible, animatedOpacity} = usePickerBackdropUseCase({
+  const {isModalVisible} = usePickerBackdropUseCase({
     isVisible,
     opacity,
     afterFadeIn,
@@ -53,26 +51,22 @@ export const PickerBackdrop: React.FC<PickerBackdropProps> = ({
     fadeOutConfig,
   });
 
-  const animatedStyle = useAnimatedStyle(() => ({opacity: animatedOpacity.value}));
   const composedPressableStyles = useMemo(
     () => composePressableStyles([styles.pressable, pressableStyle]),
     [pressableStyle],
   );
-  const composedBackdropStyle = useMemo(() => StyleSheet.flatten([styles.backdrop, style]), [style]);
 
   return !isModalVisible ? null : (
     <RNModal
       visible
       statusBarTranslucent
-      animationType="none"
+      animationType="fade"
       transparent
       // 戻るボタンが押されたとき（onRequestClose）は、背景がタップされたときと同じ振る舞いになるようにしておく。
       onRequestClose={onPress}
       style={modalStyle}
       {...modalProps}>
-      <Pressable onPress={onPress} style={composedPressableStyles} {...pressableProps}>
-        <Reanimated.View style={[composedBackdropStyle, animatedStyle]} {...animatedViewProps} />
-      </Pressable>
+      <Pressable onPress={onPress} style={composedPressableStyles} {...pressableProps} />
       {children}
     </RNModal>
   );
@@ -82,9 +76,10 @@ const styles = StyleSheet.create({
   pressable: {
     ...StyleSheet.absoluteFillObject,
     display: 'flex',
+    opacity: 0.4,
+    backgroundColor: DEFAULT_BACKGROUND_COLOR,
   },
   backdrop: {
     flex: 1,
-    backgroundColor: DEFAULT_BACKGROUND_COLOR,
   },
 });

--- a/example-app/SantokuApp/src/components/picker/SelectPicker.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPicker.test.tsx
@@ -25,7 +25,7 @@ describe('SelectPicker only with required props', () => {
         items={items}
         selectedItemKey="1"
         textInputProps={{testID: 'textInput'}}
-        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerBackdropProps={{pressableProps: {testID: 'pickerBackdrop'}}}
         pickerContainerProps={{testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
         pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
@@ -56,7 +56,7 @@ describe('SelectPicker only with required props', () => {
         items={items}
         selectedItemKey="1"
         textInputProps={{testID: 'textInput'}}
-        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerBackdropProps={{pressableProps: {testID: 'pickerBackdrop'}}}
         pickerContainerProps={{testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
         pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
@@ -104,9 +104,8 @@ describe('SelectPicker with all props', () => {
         pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
         pickerProps={{numberOfLines: 5, testID: 'picker'}}
         pickerBackdropProps={{
-          style: {backgroundColor: 'green', borderColor: 'red'},
-          modalProps: {testID: 'modal'},
-          testID: 'pickerBackdrop',
+          modalProps: {testID: 'pickerBackdropModal'},
+          pressableProps: {testID: 'pickerBackdropPressable', style: {backgroundColor: 'green', borderColor: 'red'}},
         }}
         pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
         pickerAccessoryProps={{
@@ -155,12 +154,22 @@ describe('SelectPicker with all props', () => {
     expect(keyExtractor).toHaveBeenNthCalledWith(1, {value: '1', label: 'test1'}, 0);
     expect(keyExtractor).toHaveBeenNthCalledWith(2, {value: '2', label: 'test2'}, 1);
 
-    // assert pickerBackdrop
-    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
-    const modal = sut.getByTestId('modal');
-    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
-    fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
+    // assert pickerBackdropPressable
+    const pickerBackdropPressable = sut.getByTestId('pickerBackdropPressable');
+    const pickerBackdropModal = sut.getByTestId('pickerBackdropModal');
+    const pickerBackdropProps = pickerBackdropPressable.props as PickerBackdropProps;
+    fireEvent(pickerBackdropModal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({
+      backgroundColor: 'green',
+      borderColor: 'red',
+      opacity: 0.4,
+      bottom: 0,
+      display: 'flex',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    });
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);
@@ -215,9 +224,8 @@ describe('SelectPicker with all props', () => {
         pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
         pickerProps={{testID: 'defaultPicker'}}
         pickerBackdropProps={{
-          style: {backgroundColor: 'green', borderColor: 'red'},
-          modalProps: {testID: 'modal'},
-          testID: 'pickerBackdrop',
+          modalProps: {testID: 'pickerBackdropModal'},
+          pressableProps: {testID: 'pickerBackdropPressable', style: {backgroundColor: 'green', borderColor: 'red'}},
         }}
         pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'defaultPickerAccessory'}}}
@@ -231,12 +239,22 @@ describe('SelectPicker with all props', () => {
 
     expect(sut).toMatchSnapshot('SelectPicker all properly with custom xxx component.');
 
-    // assert pickerBackdrop
-    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
-    const modal = sut.getByTestId('modal');
-    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
-    fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
+    // assert pickerBackdropPressable
+    const pickerBackdropPressable = sut.getByTestId('pickerBackdropPressable');
+    const pickerBackdropModal = sut.getByTestId('pickerBackdropModal');
+    const pickerBackdropProps = pickerBackdropPressable.props as PickerBackdropProps;
+    fireEvent(pickerBackdropModal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({
+      backgroundColor: 'green',
+      borderColor: 'red',
+      opacity: 0.4,
+      bottom: 0,
+      display: 'flex',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    });
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);

--- a/example-app/SantokuApp/src/components/picker/SelectPicker.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPicker.test.tsx
@@ -7,6 +7,13 @@ import {PickerContainerProps} from './PickerContainer';
 import {Item, SelectPicker} from './SelectPicker';
 import {SelectPickerItemsProps} from './SelectPickerItems';
 
+jest.doMock('react-native/Libraries/Utilities/Dimensions', () => ({
+  get: jest.fn().mockReturnValue({width: 400, height: 1000}),
+  set: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+}));
+
 describe('SelectPicker only with required props', () => {
   it('renders successfully if invisible', () => {
     const items = [
@@ -124,7 +131,11 @@ describe('SelectPicker with all props', () => {
     // assert pickerContainer
     const pickerContainer = sut.getByTestId('pickerContainer');
     const pickerContainerProps = pickerContainer.props as PickerContainerProps;
-    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+    expect(pickerContainerProps.style).toEqual({
+      backgroundColor: 'yellow',
+      borderColor: 'black',
+      transform: [{translateY: 1000}],
+    });
 
     // assert pickerItemsContainer
     const pickerItemsContainer = sut.getByTestId('pickerItemsContainer');
@@ -149,7 +160,7 @@ describe('SelectPicker with all props', () => {
     const modal = sut.getByTestId('modal');
     const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
     fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);
@@ -225,7 +236,7 @@ describe('SelectPicker with all props', () => {
     const modal = sut.getByTestId('modal');
     const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
     fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);
@@ -233,7 +244,11 @@ describe('SelectPicker with all props', () => {
     // assert pickerContainer
     const pickerContainer = sut.getByTestId('pickerContainer');
     const pickerContainerProps = pickerContainer.props as PickerContainerProps;
-    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+    expect(pickerContainerProps.style).toEqual({
+      backgroundColor: 'yellow',
+      borderColor: 'black',
+      transform: [{translateY: 1000}],
+    });
 
     // assert pickerAccessory
     const defaultPickerAccessory = sut.queryByTestId('defaultPickerAccessory');

--- a/example-app/SantokuApp/src/components/picker/SelectPicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPicker.tsx
@@ -103,21 +103,11 @@ export type SelectPickerProps<ItemT> = {
   pickerAccessoryProps?: Omit<DefaultPickerAccessoryProps, 'onDelete' | 'onCancel' | 'onDone'>;
 };
 
+const DEFAULT_DURATION = 300;
+
 export const SelectPicker = <ItemT extends unknown>(props: SelectPickerProps<ItemT>) => {
-  const {
-    isVisible,
-    inputValue,
-    handleBackdropPress,
-    pickerBackdropEntering,
-    pickerBackdropExiting,
-    pickerContainerEntering,
-    pickerContainerExiting,
-    onValueChange,
-    open,
-    handleDelete,
-    handleCancel,
-    handleDone,
-  } = useSelectPickerUseCase<ItemT>(props);
+  const {isVisible, inputValue, handleBackdropPress, onValueChange, open, handleDelete, handleCancel, handleDone} =
+    useSelectPickerUseCase<ItemT>(props);
   const {
     items,
     selectedItemKey,
@@ -129,11 +119,15 @@ export const SelectPicker = <ItemT extends unknown>(props: SelectPickerProps<Ite
     textInputComponent,
     pickerItemsContainerProps: {style: pickerItemsContainerStyle, ...pickerItemsContainerProps} = {},
     pickerProps,
-    pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting, ...pickerBackdropProps} = {},
+    pickerBackdropProps: {
+      fadeInDuration = DEFAULT_DURATION,
+      fadeOutDuration = DEFAULT_DURATION,
+      ...pickerBackdropProps
+    } = {},
     pickerContainerProps: {
-      entering: containerEntering,
-      exiting: containerExiting,
       style: pickerContainerStyle,
+      slideInDuration = DEFAULT_DURATION,
+      slideOutDuration = DEFAULT_DURATION,
       ...pickerContainerProps
     } = {},
     pickerAccessoryProps,
@@ -144,14 +138,14 @@ export const SelectPicker = <ItemT extends unknown>(props: SelectPickerProps<Ite
       <PickerBackdrop
         isVisible={isVisible}
         onPress={handleBackdropPress}
-        entering={pickerBackdropEntering}
-        exiting={pickerBackdropExiting}
+        fadeInDuration={fadeInDuration}
+        fadeOutDuration={fadeOutDuration}
         {...pickerBackdropProps}>
         <PickerContainer
           isVisible={isVisible}
-          entering={pickerContainerEntering}
-          exiting={pickerContainerExiting}
           style={[styles.pickerContainer, pickerContainerStyle]}
+          slideInDuration={slideInDuration}
+          slideOutDuration={slideOutDuration}
           {...pickerContainerProps}>
           {pickerAccessoryComponent ? (
             pickerAccessoryComponent

--- a/example-app/SantokuApp/src/components/picker/SelectPickerItem.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPickerItem.tsx
@@ -1,13 +1,12 @@
 import React, {useMemo} from 'react';
 import {Pressable, PressableProps, StyleSheet, Text, TextProps} from 'react-native';
-import Animated, {interpolateColor, useAnimatedStyle} from 'react-native-reanimated';
 
 import {Item} from './SelectPicker';
 
 export type SelectPickerItemType<ItemT extends unknown> = {
   item: Item<ItemT>;
   index: number;
-  offset: Animated.SharedValue<number>;
+  offset: number;
   itemHeight: number;
   activeColor?: string;
   inactiveColor?: string;
@@ -15,40 +14,25 @@ export type SelectPickerItemType<ItemT extends unknown> = {
   textProps?: TextProps;
 };
 
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
-const AnimatedText = Animated.createAnimatedComponent(Text);
-
-export const SelectPickerItem = <ItemT extends unknown>({
+const Component = <ItemT extends unknown>({
   item: {label, inputLabel, key, value, ...itemPropsStyle},
-  index,
-  offset,
-  activeColor = '#000000',
-  inactiveColor = '#999999',
   itemHeight,
   pressableProps,
   textProps: {style: textStyle, ...textProps} = {},
 }: SelectPickerItemType<ItemT>) => {
-  const itemOffset = index * itemHeight;
-  const animatedTextStyle = useAnimatedStyle(() => {
-    const color = interpolateColor(
-      offset.value,
-      [itemOffset - itemHeight, itemOffset, itemOffset + itemHeight],
-      [inactiveColor, activeColor, inactiveColor],
-    );
-    return {color};
-  }, [itemHeight]);
-
   const pressableHeightStyle = useMemo(() => ({height: itemHeight}), [itemHeight]);
 
   return (
-    <AnimatedPressable style={StyleSheet.flatten([pressableHeightStyle, styles.pressable])} {...pressableProps}>
+    <Pressable style={StyleSheet.flatten([pressableHeightStyle, styles.pressable])} {...pressableProps}>
       {/* AnimatedStyleの場合はStyleSheet.flattenだとマージされないため、配列で指定 */}
-      <AnimatedText style={[animatedTextStyle, styles.text, textStyle, itemPropsStyle]} {...textProps}>
+      <Text style={StyleSheet.flatten([styles.text, textStyle, itemPropsStyle])} {...textProps}>
         {label}
-      </AnimatedText>
-    </AnimatedPressable>
+      </Text>
+    </Pressable>
   );
 };
+
+export const SelectPickerItem = React.memo(Component);
 
 const styles = StyleSheet.create({
   pressable: {

--- a/example-app/SantokuApp/src/components/picker/SelectPickerItems.android.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPickerItems.android.test.tsx
@@ -57,7 +57,7 @@ describe('SelectPickerItems with all props', () => {
         numberOfLines={5}
         keyExtractor={keyExtractor}
         testID="SelectPickerItems"
-        itemStyle={{fontSize: 24, fontFamily: 'test-font-Regular'}}
+        itemStyle={{fontSize: 24, fontFamily: 'test-font-Regular', color: 'yellow'}}
         accessibilityLabel="testAccessibilityLabel"
         activeColor="#424242"
         inactiveColor="#565656"
@@ -78,13 +78,11 @@ describe('SelectPickerItems with all props', () => {
 
     const item1Text = sut.getByTestId('itemText-0');
     const item1TextProps = item1Text.props as TextProps;
-    expect(item1Text).toHaveAnimatedStyle({color: 'rgba(66, 66, 66, 1)'});
     expect(item1TextProps.style).toEqual({fontSize: 24, fontFamily: 'Roboto', color: 'red'});
 
     const item3Text = sut.getByTestId('itemText-2');
     const item3TextProps = item3Text.props as TextProps;
-    expect(item3Text).toHaveAnimatedStyle({color: 'rgba(86, 86, 86, 1)'});
-    expect(item3TextProps.style).toEqual({fontSize: 24, fontFamily: 'test-font-Regular', color: 'rgba(86, 86, 86, 1)'});
+    expect(item3TextProps.style).toEqual({fontSize: 24, fontFamily: 'test-font-Regular', color: 'yellow'});
 
     // assert flatList
     const flatList = sut.getByTestId('FlatList');

--- a/example-app/SantokuApp/src/components/picker/SelectPickerItems.android.tsx
+++ b/example-app/SantokuApp/src/components/picker/SelectPickerItems.android.tsx
@@ -15,9 +15,12 @@ const Separator: React.FC<{height: number; testID?: string}> = React.memo(({heig
   );
 });
 
-const FADER_SIZE = 60;
-const FaderTop = React.memo(() => <Fader visible position={FaderPosition.TOP} size={FADER_SIZE} />);
-const FaderBottom = React.memo(() => <Fader visible position={FaderPosition.BOTTOM} size={FADER_SIZE} />);
+const FaderTop = React.memo(({itemHeight}: {itemHeight: number}) => (
+  <Fader visible position={FaderPosition.TOP} size={itemHeight * 2.5} />
+));
+const FaderBottom = React.memo(({itemHeight}: {itemHeight: number}) => (
+  <Fader visible position={FaderPosition.BOTTOM} size={itemHeight * 2.5} />
+));
 
 const DECELERATION_RATE = 0.98;
 
@@ -73,7 +76,7 @@ export const SelectPickerItems = <ItemT extends unknown>({
       return (
         <SelectPickerItem
           item={info.item}
-          offset={offset}
+          offset={offset.value}
           index={info.index}
           itemHeight={itemHeight}
           activeColor={activeColor}
@@ -121,8 +124,8 @@ export const SelectPickerItems = <ItemT extends unknown>({
         centerContent
         testID={flatListTestID}
       />
-      <FaderBottom />
-      <FaderTop />
+      <FaderBottom itemHeight={itemHeight} />
+      <FaderTop itemHeight={itemHeight} />
       <Separator height={itemHeight} testID={separatorTestID} />
     </View>
   );

--- a/example-app/SantokuApp/src/components/picker/YearMonthPicker.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/YearMonthPicker.test.tsx
@@ -9,6 +9,13 @@ import {SelectPickerItemsProps} from './SelectPickerItems';
 import {YearMonthPicker} from './YearMonthPicker';
 import {YearMonthUtil} from './YearMonthUtil';
 
+jest.doMock('react-native/Libraries/Utilities/Dimensions', () => ({
+  get: jest.fn().mockReturnValue({width: 400, height: 1000}),
+  set: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+}));
+
 describe('YearMonthPicker only with required props', () => {
   beforeAll(() => {
     const mockDate = new Date(2022, 3);
@@ -233,7 +240,11 @@ describe('YearMonthPicker with all props', () => {
     // assert pickerContainer
     const pickerContainer = sut.getByTestId('pickerContainer');
     const pickerContainerProps = pickerContainer.props as PickerContainerProps;
-    expect(pickerContainerProps.style).toEqual({backgroundColor: 'yellow', borderColor: 'black'});
+    expect(pickerContainerProps.style).toEqual({
+      backgroundColor: 'yellow',
+      borderColor: 'black',
+      transform: [{translateY: 1000}],
+    });
 
     // assert pickerItemsContainer
     const pickerItemsContainer = sut.getByTestId('pickerItemsContainer');
@@ -267,7 +278,7 @@ describe('YearMonthPicker with all props', () => {
     const modal = sut.getByTestId('modal');
     const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
     fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red'});
+    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);

--- a/example-app/SantokuApp/src/components/picker/YearMonthPicker.test.tsx
+++ b/example-app/SantokuApp/src/components/picker/YearMonthPicker.test.tsx
@@ -33,7 +33,7 @@ describe('YearMonthPicker only with required props', () => {
         minimumYearMonth={YearMonthUtil.addMonth(now, -60)}
         selectedValue={now}
         textInputProps={{testID: 'textInput'}}
-        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerBackdropProps={{pressableProps: {testID: 'pickerBackdrop'}}}
         pickerContainerProps={{testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
         pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
@@ -62,7 +62,7 @@ describe('YearMonthPicker only with required props', () => {
         minimumYearMonth={YearMonthUtil.addMonth(now, -60)}
         selectedValue={now}
         textInputProps={{testID: 'textInput'}}
-        pickerBackdropProps={{testID: 'pickerBackdrop'}}
+        pickerBackdropProps={{pressableProps: {testID: 'pickerBackdrop'}}}
         pickerContainerProps={{testID: 'pickerContainer'}}
         pickerAccessoryProps={{containerProps: {testID: 'pickerAccessory'}}}
         pickerItemsContainerProps={{testID: 'pickerItemsContainer'}}
@@ -211,9 +211,8 @@ describe('YearMonthPicker with all props', () => {
         pickerItemsContainerProps={{pointerEvents: 'none', testID: 'pickerItemsContainer'}}
         pickerProps={{numberOfLines: 5}}
         pickerBackdropProps={{
-          style: {backgroundColor: 'green', borderColor: 'red'},
-          modalProps: {testID: 'modal'},
-          testID: 'pickerBackdrop',
+          modalProps: {testID: 'pickerBackdropModal'},
+          pressableProps: {testID: 'pickerBackdropPressable', style: {backgroundColor: 'green', borderColor: 'red'}},
         }}
         pickerContainerProps={{style: {backgroundColor: 'yellow', borderColor: 'black'}, testID: 'pickerContainer'}}
         pickerAccessoryProps={{
@@ -274,11 +273,21 @@ describe('YearMonthPicker with all props', () => {
     expect(textInputProps.value).toBe('2022年4月');
 
     // assert pickerBackdrop
-    const pickerBackdrop = sut.getByTestId('pickerBackdrop');
-    const modal = sut.getByTestId('modal');
-    const pickerBackdropProps = pickerBackdrop.props as PickerBackdropProps;
-    fireEvent(modal, 'onRequestClose');
-    expect(pickerBackdropProps.style).toEqual({flex: 1, backgroundColor: 'green', borderColor: 'red', opacity: 0});
+    const pickerBackdropPressable = sut.getByTestId('pickerBackdropPressable');
+    const pickerBackdropModal = sut.getByTestId('pickerBackdropModal');
+    const pickerBackdropProps = pickerBackdropPressable.props as PickerBackdropProps;
+    fireEvent(pickerBackdropModal, 'onRequestClose');
+    expect(pickerBackdropProps.style).toEqual({
+      backgroundColor: 'green',
+      borderColor: 'red',
+      opacity: 0.4,
+      bottom: 0,
+      display: 'flex',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    });
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
     fireEvent.press(pressableContainer);

--- a/example-app/SantokuApp/src/components/picker/YearMonthPicker.tsx
+++ b/example-app/SantokuApp/src/components/picker/YearMonthPicker.tsx
@@ -99,6 +99,8 @@ export type YearMonthPickerProps = {
   itemFontFamily?: string;
 };
 
+const DEFAULT_DURATION = 300;
+
 export const YearMonthPicker = (props: YearMonthPickerProps) => {
   const {
     isVisible,
@@ -109,10 +111,6 @@ export const YearMonthPicker = (props: YearMonthPickerProps) => {
     onValueChangeYear,
     onValueChangeMonth,
     selectedLabel,
-    pickerBackdropEntering,
-    pickerBackdropExiting,
-    pickerContainerEntering,
-    pickerContainerExiting,
     open,
     handleBackdropPress,
     handleDelete,
@@ -126,11 +124,15 @@ export const YearMonthPicker = (props: YearMonthPickerProps) => {
     textInputProps,
     pickerItemsContainerProps: {style: pickerItemsContainerStyle, ...pickerItemsContainerProps} = {},
     pickerProps,
-    pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting, ...pickerBackdropProps} = {},
+    pickerBackdropProps: {
+      fadeInDuration = DEFAULT_DURATION,
+      fadeOutDuration = DEFAULT_DURATION,
+      ...pickerBackdropProps
+    } = {},
     pickerContainerProps: {
-      entering: containerEntering,
-      exiting: containerExiting,
       style: pickerContainerStyle,
+      slideInDuration = DEFAULT_DURATION,
+      slideOutDuration = DEFAULT_DURATION,
       ...pickerContainerProps
     } = {},
     pickerAccessoryProps,
@@ -141,14 +143,14 @@ export const YearMonthPicker = (props: YearMonthPickerProps) => {
       <PickerBackdrop
         isVisible={isVisible}
         onPress={handleBackdropPress}
-        entering={pickerBackdropEntering}
-        exiting={pickerBackdropExiting}
+        fadeInDuration={fadeInDuration}
+        fadeOutDuration={fadeOutDuration}
         {...pickerBackdropProps}>
         <PickerContainer
           isVisible={isVisible}
-          entering={pickerContainerEntering}
-          exiting={pickerContainerExiting}
           style={[styles.pickerContainer, pickerContainerStyle]}
+          slideInDuration={slideInDuration}
+          slideOutDuration={slideOutDuration}
           {...pickerContainerProps}>
           <DefaultPickerAccessory
             onDelete={handleDelete}

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`DateTimePicker only with required props renders successfully if invisib
 exports[`DateTimePicker only with required props renders successfully if visible: DateTimePicker if visible. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
@@ -52,34 +52,18 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "black",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "black",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdrop"
+    />
     <View
       pointerEvents="box-none"
       style={
@@ -181,11 +165,11 @@ Array [
 exports[`DateTimePicker with all props should be applied all properly with custom xxx component: DateTimePicker all properly with custom xxx component. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
-    testID="modal"
+    testID="pickerBackdropModal"
     transparent={true}
     visible={true}
   >
@@ -204,35 +188,19 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "green",
+          "borderColor": "red",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "green",
-            "borderColor": "red",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdropPressable"
+    />
     <View
       pointerEvents="box-none"
       style={
@@ -314,11 +282,11 @@ Array [
 exports[`DateTimePicker with all props should be applied all properly with default xxx component: DateTimePicker all properly with default xxx component. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
-    testID="modal"
+    testID="pickerBackdropModal"
     transparent={true}
     visible={true}
   >
@@ -337,35 +305,19 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "green",
+          "borderColor": "red",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "green",
-            "borderColor": "red",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdropPressable"
+    />
     <View
       pointerEvents="box-none"
       style={

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/DateTimePicker.ios.test.tsx.snap
@@ -64,30 +64,17 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
-            "backgroundColor": "rgba(0,0,0,0.4)",
+            "backgroundColor": "black",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -96,81 +83,69 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "white",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
           style={
             Object {
-              "backgroundColor": "white",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingHorizontal": 10,
+              "paddingVertical": 8,
             }
           }
-          testID="pickerContainer"
+          testID="pickerAccessory"
+        />
+        <View
+          testID="pickerItemsContainer"
         >
-          <View
+          <RNDateTimePicker
+            date={1653868800000}
+            displayIOS="spinner"
+            enabled={true}
+            mode="date"
+            onChange={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "paddingHorizontal": 10,
-                "paddingVertical": 8,
+                "height": 216,
               }
             }
-            testID="pickerAccessory"
+            testID="pickerItems"
           />
-          <View
-            testID="pickerItemsContainer"
-          >
-            <RNDateTimePicker
-              date={1653868800000}
-              displayIOS="spinner"
-              enabled={true}
-              mode="date"
-              onChange={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "height": 216,
-                }
-              }
-              testID="pickerItems"
-            />
-          </View>
         </View>
       </View>
     </View>
@@ -241,31 +216,18 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
             "backgroundColor": "green",
             "borderColor": "red",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -274,63 +236,51 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "yellow",
+            "borderColor": "black",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
-          style={
-            Object {
-              "backgroundColor": "yellow",
-              "borderColor": "black",
-            }
-          }
-          testID="pickerContainer"
+          testID="customPickerAccessory"
+        />
+        <View
+          pointerEvents="none"
+          testID="pickerItemsContainer"
         >
           <View
-            testID="customPickerAccessory"
+            testID="customPicker"
           />
-          <View
-            pointerEvents="none"
-            testID="pickerItemsContainer"
-          >
-            <View
-              testID="customPicker"
-            />
-          </View>
         </View>
       </View>
     </View>
@@ -399,31 +349,18 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
             "backgroundColor": "green",
             "borderColor": "red",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -432,189 +369,177 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "yellow",
+            "borderColor": "black",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
           style={
             Object {
-              "backgroundColor": "yellow",
-              "borderColor": "black",
+              "backgroundColor": "blue",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingHorizontal": 10,
+              "paddingVertical": 8,
             }
           }
-          testID="pickerContainer"
+          testID="pickerAccessory"
         >
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="deleteLink"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#d9545e",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
+                }
+              }
+            >
+              delete
+            </Text>
+          </View>
           <View
             style={
               Object {
-                "backgroundColor": "blue",
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "paddingHorizontal": 10,
-                "paddingVertical": 8,
+                "flex": 1,
               }
             }
-            testID="pickerAccessory"
+          />
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="cancelLink"
           >
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            <Text
               style={
                 Object {
-                  "opacity": 1,
+                  "color": "#4577CC",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
                 }
               }
-              testID="deleteLink"
             >
-              <Text
-                style={
-                  Object {
-                    "color": "#d9545e",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                delete
-              </Text>
-            </View>
-            <View
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-              testID="cancelLink"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#4577CC",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                cancel
-              </Text>
-            </View>
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-              testID="doneLink"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#4577CC",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                done
-              </Text>
-            </View>
+              cancel
+            </Text>
           </View>
           <View
-            pointerEvents="none"
-            testID="pickerItemsContainer"
-          >
-            <RNDateTimePicker
-              date={1640995200000}
-              displayIOS="spinner"
-              enabled={true}
-              maximumDate={1653955200000}
-              minimumDate={1483228800000}
-              mode="date"
-              onChange={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "height": 216,
-                  },
-                  Object {
-                    "backgroundColor": "yellow",
-                  },
-                ]
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
               }
-              testID="pickerItems"
-            />
+            }
+            testID="doneLink"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#4577CC",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
+                }
+              }
+            >
+              done
+            </Text>
           </View>
+        </View>
+        <View
+          pointerEvents="none"
+          testID="pickerItemsContainer"
+        >
+          <RNDateTimePicker
+            date={1640995200000}
+            displayIOS="spinner"
+            enabled={true}
+            maximumDate={1653955200000}
+            minimumDate={1483228800000}
+            mode="date"
+            onChange={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "height": 216,
+                },
+                Object {
+                  "backgroundColor": "yellow",
+                },
+              ]
+            }
+            testID="pickerItems"
+          />
         </View>
       </View>
     </View>

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/PickerBackdrop.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/PickerBackdrop.test.tsx.snap
@@ -1,16 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PickerBackdrop only with required props renders successfully only with required props: AnimatedView with invisible. 1`] = `
-<Modal
-  animationType="none"
-  hardwareAccelerated={false}
-  statusBarTranslucent={true}
-  transparent={true}
-  visible={true}
-/>
-`;
-
-exports[`PickerBackdrop only with required props renders successfully only with required props: AnimatedView with visible. 1`] = `
+exports[`PickerBackdrop only with required props renders successfully only with required props: Animating (fade in) 1`] = `
 <Modal
   animationType="none"
   hardwareAccelerated={false}
@@ -45,30 +35,17 @@ exports[`PickerBackdrop only with required props renders successfully only with 
     <View
       animatedStyle={
         Object {
-          "value": Object {},
+          "value": Object {
+            "opacity": 0.2,
+          },
         }
       }
       collapsable={false}
-      entering={
-        FadeIn {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 300,
-          "randomizeDelay": false,
-        }
-      }
-      exiting={
-        FadeOut {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 150,
-          "randomizeDelay": false,
-        }
-      }
       style={
         Object {
-          "backgroundColor": "rgba(0,0,0,0.4)",
+          "backgroundColor": "black",
           "flex": 1,
+          "opacity": 0,
         }
       }
       testID="backdropAnimated"
@@ -76,6 +53,225 @@ exports[`PickerBackdrop only with required props renders successfully only with 
   </View>
 </Modal>
 `;
+
+exports[`PickerBackdrop only with required props renders successfully only with required props: Animating (fade out) 1`] = `
+<Modal
+  animationType="none"
+  hardwareAccelerated={false}
+  statusBarTranslucent={true}
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "bottom": 0,
+        "display": "flex",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      animatedStyle={
+        Object {
+          "value": Object {
+            "opacity": 0.2,
+          },
+        }
+      }
+      collapsable={false}
+      style={
+        Object {
+          "backgroundColor": "black",
+          "flex": 1,
+          "opacity": 0,
+        }
+      }
+    />
+  </View>
+</Modal>
+`;
+
+exports[`PickerBackdrop only with required props renders successfully only with required props: Before animation started 1`] = `
+<Modal
+  animationType="none"
+  hardwareAccelerated={false}
+  statusBarTranslucent={true}
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "bottom": 0,
+        "display": "flex",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      animatedStyle={
+        Object {
+          "value": Object {
+            "opacity": 0,
+          },
+        }
+      }
+      collapsable={false}
+      style={
+        Object {
+          "backgroundColor": "black",
+          "flex": 1,
+          "opacity": 0,
+        }
+      }
+      testID="backdropAnimated"
+    />
+  </View>
+</Modal>
+`;
+
+exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade in animation completed 1`] = `
+<Modal
+  animationType="none"
+  hardwareAccelerated={false}
+  statusBarTranslucent={true}
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "bottom": 0,
+        "display": "flex",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      animatedStyle={
+        Object {
+          "value": Object {
+            "opacity": 0.4,
+          },
+        }
+      }
+      collapsable={false}
+      style={
+        Object {
+          "backgroundColor": "black",
+          "flex": 1,
+          "opacity": 0,
+        }
+      }
+      testID="backdropAnimated"
+    />
+  </View>
+</Modal>
+`;
+
+exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade in animation completed 2`] = `
+<Modal
+  animationType="none"
+  hardwareAccelerated={false}
+  statusBarTranslucent={true}
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "bottom": 0,
+        "display": "flex",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      animatedStyle={
+        Object {
+          "value": Object {
+            "opacity": 0.4,
+          },
+        }
+      }
+      collapsable={false}
+      style={
+        Object {
+          "backgroundColor": "black",
+          "flex": 1,
+          "opacity": 0,
+        }
+      }
+      testID="backdropAnimated"
+    />
+  </View>
+</Modal>
+`;
+
+exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade out animation completed 1`] = `null`;
+
+exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade out animation completed 2`] = `null`;
 
 exports[`PickerBackdrop with all props should be applied properly: PickerBackdrop with all props. 1`] = `
 <Modal
@@ -121,31 +317,18 @@ exports[`PickerBackdrop with all props should be applied properly: PickerBackdro
     <View
       animatedStyle={
         Object {
-          "value": Object {},
+          "value": Object {
+            "opacity": 0,
+          },
         }
       }
       collapsable={false}
-      entering={
-        ZoomIn {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 500,
-          "randomizeDelay": false,
-        }
-      }
-      exiting={
-        ZoomOut {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 300,
-          "randomizeDelay": false,
-        }
-      }
       style={
         Object {
           "backgroundColor": "green",
           "borderColor": "red",
           "flex": 1,
+          "opacity": 0,
         }
       }
       testID="animatedView"

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/PickerBackdrop.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/PickerBackdrop.test.tsx.snap
@@ -1,115 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PickerBackdrop only with required props renders successfully only with required props: Animating (fade in) 1`] = `
-<Modal
-  animationType="none"
-  hardwareAccelerated={false}
-  statusBarTranslucent={true}
-  transparent={true}
-  visible={true}
->
-  <View
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Object {
-        "bottom": 0,
-        "display": "flex",
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  >
-    <View
-      animatedStyle={
-        Object {
-          "value": Object {
-            "opacity": 0.2,
-          },
-        }
-      }
-      collapsable={false}
-      style={
-        Object {
-          "backgroundColor": "black",
-          "flex": 1,
-          "opacity": 0,
-        }
-      }
-      testID="backdropAnimated"
-    />
-  </View>
-</Modal>
-`;
-
-exports[`PickerBackdrop only with required props renders successfully only with required props: Animating (fade out) 1`] = `
-<Modal
-  animationType="none"
-  hardwareAccelerated={false}
-  statusBarTranslucent={true}
-  transparent={true}
-  visible={true}
->
-  <View
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Object {
-        "bottom": 0,
-        "display": "flex",
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  >
-    <View
-      animatedStyle={
-        Object {
-          "value": Object {
-            "opacity": 0.2,
-          },
-        }
-      }
-      collapsable={false}
-      style={
-        Object {
-          "backgroundColor": "black",
-          "flex": 1,
-          "opacity": 0,
-        }
-      }
-    />
-  </View>
-</Modal>
-`;
-
 exports[`PickerBackdrop only with required props renders successfully only with required props: Before animation started 1`] = `
 <Modal
-  animationType="none"
+  animationType="fade"
   hardwareAccelerated={false}
   statusBarTranslucent={true}
   transparent={true}
@@ -130,148 +23,22 @@ exports[`PickerBackdrop only with required props renders successfully only with 
     onStartShouldSetResponder={[Function]}
     style={
       Object {
+        "backgroundColor": "black",
         "bottom": 0,
         "display": "flex",
         "left": 0,
+        "opacity": 0.4,
         "position": "absolute",
         "right": 0,
         "top": 0,
       }
     }
-  >
-    <View
-      animatedStyle={
-        Object {
-          "value": Object {
-            "opacity": 0,
-          },
-        }
-      }
-      collapsable={false}
-      style={
-        Object {
-          "backgroundColor": "black",
-          "flex": 1,
-          "opacity": 0,
-        }
-      }
-      testID="backdropAnimated"
-    />
-  </View>
-</Modal>
-`;
-
-exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade in animation completed 1`] = `
-<Modal
-  animationType="none"
-  hardwareAccelerated={false}
-  statusBarTranslucent={true}
-  transparent={true}
-  visible={true}
->
-  <View
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Object {
-        "bottom": 0,
-        "display": "flex",
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  >
-    <View
-      animatedStyle={
-        Object {
-          "value": Object {
-            "opacity": 0.4,
-          },
-        }
-      }
-      collapsable={false}
-      style={
-        Object {
-          "backgroundColor": "black",
-          "flex": 1,
-          "opacity": 0,
-        }
-      }
-      testID="backdropAnimated"
-    />
-  </View>
-</Modal>
-`;
-
-exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade in animation completed 2`] = `
-<Modal
-  animationType="none"
-  hardwareAccelerated={false}
-  statusBarTranslucent={true}
-  transparent={true}
-  visible={true}
->
-  <View
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Object {
-        "bottom": 0,
-        "display": "flex",
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  >
-    <View
-      animatedStyle={
-        Object {
-          "value": Object {
-            "opacity": 0.4,
-          },
-        }
-      }
-      collapsable={false}
-      style={
-        Object {
-          "backgroundColor": "black",
-          "flex": 1,
-          "opacity": 0,
-        }
-      }
-      testID="backdropAnimated"
-    />
-  </View>
+    testID="pressable"
+  />
 </Modal>
 `;
 
 exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade out animation completed 1`] = `null`;
-
-exports[`PickerBackdrop only with required props renders successfully only with required props: Just After fade out animation completed 2`] = `null`;
 
 exports[`PickerBackdrop with all props should be applied properly: PickerBackdrop with all props. 1`] = `
 <Modal
@@ -304,35 +71,17 @@ exports[`PickerBackdrop with all props should be applied properly: PickerBackdro
     onStartShouldSetResponder={[Function]}
     style={
       Object {
+        "backgroundColor": "red",
         "bottom": 0,
         "display": "none",
         "left": 0,
+        "opacity": 0.8,
         "position": "absolute",
         "right": 0,
         "top": 0,
       }
     }
     testID="pressable"
-  >
-    <View
-      animatedStyle={
-        Object {
-          "value": Object {
-            "opacity": 0,
-          },
-        }
-      }
-      collapsable={false}
-      style={
-        Object {
-          "backgroundColor": "green",
-          "borderColor": "red",
-          "flex": 1,
-          "opacity": 0,
-        }
-      }
-      testID="animatedView"
-    />
-  </View>
+  />
 </Modal>
 `;

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/PickerContainer.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/PickerContainer.test.tsx.snap
@@ -1,105 +1,281 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PickerContainer only with required props renders successfully only with required props: AnimatedView with invisible. 1`] = `null`;
-
-exports[`PickerContainer only with required props renders successfully only with required props: AnimatedView with visible. 1`] = `
+exports[`PickerContainer only with required props renders successfully only with required props: Animating (slide in) 1`] = `
 <View
   pointerEvents="box-none"
   style={
-    Object {
-      "flex": 1,
-      "justifyContent": "flex-end",
-    }
+    Array [
+      Object {
+        "flex": 1,
+        "justifyContent": "flex-end",
+      },
+    ]
   }
 >
   <View
     animatedStyle={
       Object {
-        "value": Object {},
+        "value": Object {
+          "transform": Array [
+            Object {
+              "translateY": 75,
+            },
+          ],
+        },
       }
     }
     collapsable={false}
+    onLayout={[Function]}
+    style={
+      Object {
+        "transform": Array [
+          Object {
+            "translateY": 1000,
+          },
+        ],
+      }
+    }
+    testID="containerAnimated"
   >
     <View
-      animatedStyle={
+      style={
         Object {
-          "value": Object {},
+          "height": 400,
+          "width": "100%",
         }
       }
-      collapsable={false}
-      entering={
-        SlideInDown {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 300,
-          "randomizeDelay": false,
-        }
-      }
-      exiting={
-        SlideOutDown {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 300,
-          "randomizeDelay": false,
-        }
-      }
-      pointerEvents="box-none"
-      style={Object {}}
-      testID="containerAnimated"
     />
   </View>
 </View>
 `;
 
-exports[`PickerContainer with all props should be applied properly: PickerContainer with all props. 1`] = `
+exports[`PickerContainer only with required props renders successfully only with required props: Animating (slide out) 1`] = `
 <View
   pointerEvents="box-none"
   style={
-    Object {
-      "flex": 1,
-      "justifyContent": "flex-end",
-    }
+    Array [
+      Object {
+        "flex": 1,
+        "justifyContent": "flex-end",
+      },
+    ]
   }
 >
   <View
     animatedStyle={
       Object {
-        "value": Object {},
+        "value": Object {
+          "transform": Array [
+            Object {
+              "translateY": 75,
+            },
+          ],
+        },
       }
     }
     collapsable={false}
+    onLayout={[Function]}
+    style={
+      Object {
+        "transform": Array [
+          Object {
+            "translateY": 1000,
+          },
+        ],
+      }
+    }
+  />
+</View>
+`;
+
+exports[`PickerContainer only with required props renders successfully only with required props: Before animation started 1`] = `
+<View
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "justifyContent": "flex-end",
+      },
+    ]
+  }
+>
+  <View
+    animatedStyle={
+      Object {
+        "value": Object {
+          "transform": Array [
+            Object {
+              "translateY": 1000,
+            },
+          ],
+        },
+      }
+    }
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      Object {
+        "transform": Array [
+          Object {
+            "translateY": 1000,
+          },
+        ],
+      }
+    }
+    testID="containerAnimated"
   >
     <View
-      animatedStyle={
-        Object {
-          "value": Object {},
-        }
-      }
-      collapsable={false}
-      entering={
-        ZoomIn {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 500,
-          "randomizeDelay": false,
-        }
-      }
-      exiting={
-        ZoomOut {
-          "build": [Function],
-          "callbackV": [Function],
-          "durationV": 300,
-          "randomizeDelay": false,
-        }
-      }
-      pointerEvents="box-none"
       style={
         Object {
-          "backgroundColor": "green",
+          "height": 400,
+          "width": "100%",
         }
       }
-      testID="animatedView"
     />
   </View>
+</View>
+`;
+
+exports[`PickerContainer only with required props renders successfully only with required props: Just After slide in animation completed 1`] = `
+<View
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "justifyContent": "flex-end",
+      },
+    ]
+  }
+>
+  <View
+    animatedStyle={
+      Object {
+        "value": Object {
+          "transform": Array [
+            Object {
+              "translateY": 0,
+            },
+          ],
+        },
+      }
+    }
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      Object {
+        "transform": Array [
+          Object {
+            "translateY": 1000,
+          },
+        ],
+      }
+    }
+    testID="containerAnimated"
+  >
+    <View
+      style={
+        Object {
+          "height": 400,
+          "width": "100%",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`PickerContainer only with required props renders successfully only with required props: Just After slide in animation completed 2`] = `
+<View
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "justifyContent": "flex-end",
+      },
+    ]
+  }
+>
+  <View
+    animatedStyle={
+      Object {
+        "value": Object {
+          "transform": Array [
+            Object {
+              "translateY": 0,
+            },
+          ],
+        },
+      }
+    }
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      Object {
+        "transform": Array [
+          Object {
+            "translateY": 1000,
+          },
+        ],
+      }
+    }
+    testID="containerAnimated"
+  >
+    <View
+      style={
+        Object {
+          "height": 400,
+          "width": "100%",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`PickerContainer only with required props renders successfully only with required props: Just After slide out animation completed 1`] = `null`;
+
+exports[`PickerContainer only with required props renders successfully only with required props: Just After slide out animation completed 2`] = `null`;
+
+exports[`PickerContainer with all props should be applied properly: PickerContainer with all props. 1`] = `
+<View
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "justifyContent": "flex-end",
+      },
+    ]
+  }
+>
+  <View
+    animatedStyle={
+      Object {
+        "value": Object {
+          "transform": Array [
+            Object {
+              "translateY": 1000,
+            },
+          ],
+        },
+      }
+    }
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      Object {
+        "backgroundColor": "green",
+        "transform": Array [
+          Object {
+            "translateY": 1000,
+          },
+        ],
+      }
+    }
+    testID="animatedView"
+  />
 </View>
 `;

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/SelectPicker.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/SelectPicker.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`SelectPicker only with required props renders successfully if invisible
 exports[`SelectPicker only with required props renders successfully if visible: SelectPicker if visible. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
@@ -53,34 +53,18 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "black",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "black",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdrop"
+    />
     <View
       pointerEvents="box-none"
       style={
@@ -198,11 +182,11 @@ Array [
 exports[`SelectPicker with all props should be applied all properly with custom xxx component: SelectPicker all properly with custom xxx component. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
-    testID="modal"
+    testID="pickerBackdropModal"
     transparent={true}
     visible={true}
   >
@@ -221,35 +205,19 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "green",
+          "borderColor": "red",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "green",
-            "borderColor": "red",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdropPressable"
+    />
     <View
       pointerEvents="box-none"
       style={
@@ -331,11 +299,11 @@ Array [
 exports[`SelectPicker with all props should be applied all properly with default xxx component: SelectPicker all properly with default xxx component. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
-    testID="modal"
+    testID="pickerBackdropModal"
     transparent={true}
     visible={true}
   >
@@ -354,35 +322,19 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "green",
+          "borderColor": "red",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "green",
-            "borderColor": "red",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdropPressable"
+    />
     <View
       pointerEvents="box-none"
       style={

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/SelectPicker.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/SelectPicker.test.tsx.snap
@@ -65,30 +65,17 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
-            "backgroundColor": "rgba(0,0,0,0.4)",
+            "backgroundColor": "black",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -97,96 +84,84 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "white",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
           style={
             Object {
-              "backgroundColor": "white",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingHorizontal": 10,
+              "paddingVertical": 8,
             }
           }
-          testID="pickerContainer"
+          testID="pickerAccessory"
+        />
+        <View
+          testID="pickerItemsContainer"
         >
-          <View
-            style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "paddingHorizontal": 10,
-                "paddingVertical": 8,
+          <View>
+            <RNCPicker
+              items={
+                Array [
+                  Object {
+                    "label": "test1",
+                    "testID": undefined,
+                    "textColor": undefined,
+                    "value": "1",
+                  },
+                  Object {
+                    "label": "test2",
+                    "testID": undefined,
+                    "textColor": undefined,
+                    "value": "2",
+                  },
+                ]
               }
-            }
-            testID="pickerAccessory"
-          />
-          <View
-            testID="pickerItemsContainer"
-          >
-            <View>
-              <RNCPicker
-                items={
-                  Array [
-                    Object {
-                      "label": "test1",
-                      "testID": undefined,
-                      "textColor": undefined,
-                      "value": "1",
-                    },
-                    Object {
-                      "label": "test2",
-                      "testID": undefined,
-                      "textColor": undefined,
-                      "value": "2",
-                    },
-                  ]
-                }
-                numberOfLines={1}
-                onChange={[Function]}
-                selectedIndex={0}
-                style={
-                  Array [
-                    Object {
-                      "height": 216,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+              numberOfLines={1}
+              onChange={[Function]}
+              selectedIndex={0}
+              style={
+                Array [
+                  Object {
+                    "height": 216,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
         </View>
       </View>
@@ -258,31 +233,18 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
             "backgroundColor": "green",
             "borderColor": "red",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -291,63 +253,51 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "yellow",
+            "borderColor": "black",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
-          style={
-            Object {
-              "backgroundColor": "yellow",
-              "borderColor": "black",
-            }
-          }
-          testID="pickerContainer"
+          testID="customPickerAccessory"
+        />
+        <View
+          pointerEvents="none"
+          testID="pickerItemsContainer"
         >
           <View
-            testID="customPickerAccessory"
+            testID="customPicker"
           />
-          <View
-            pointerEvents="none"
-            testID="pickerItemsContainer"
-          >
-            <View
-              testID="customPicker"
-            />
-          </View>
         </View>
       </View>
     </View>
@@ -416,31 +366,18 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
             "backgroundColor": "green",
             "borderColor": "red",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -449,198 +386,186 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "yellow",
+            "borderColor": "black",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
           style={
             Object {
-              "backgroundColor": "yellow",
-              "borderColor": "black",
+              "backgroundColor": "blue",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingHorizontal": 10,
+              "paddingVertical": 8,
             }
           }
-          testID="pickerContainer"
+          testID="pickerAccessory"
         >
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="deleteLink"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#d9545e",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
+                }
+              }
+            >
+              delete
+            </Text>
+          </View>
           <View
             style={
               Object {
-                "backgroundColor": "blue",
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "paddingHorizontal": 10,
-                "paddingVertical": 8,
+                "flex": 1,
               }
             }
-            testID="pickerAccessory"
+          />
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="cancelLink"
           >
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            <Text
               style={
                 Object {
-                  "opacity": 1,
+                  "color": "#4577CC",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
                 }
               }
-              testID="deleteLink"
             >
-              <Text
-                style={
-                  Object {
-                    "color": "#d9545e",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                delete
-              </Text>
-            </View>
-            <View
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-              testID="cancelLink"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#4577CC",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                cancel
-              </Text>
-            </View>
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-              testID="doneLink"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#4577CC",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                done
-              </Text>
-            </View>
+              cancel
+            </Text>
           </View>
           <View
-            pointerEvents="none"
-            testID="pickerItemsContainer"
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="doneLink"
           >
-            <View>
-              <RNCPicker
-                items={
-                  Array [
-                    Object {
-                      "label": "test1",
-                      "testID": undefined,
-                      "textColor": undefined,
-                      "value": "1",
-                    },
-                    Object {
-                      "label": "test2",
-                      "testID": undefined,
-                      "textColor": undefined,
-                      "value": "2",
-                    },
-                  ]
+            <Text
+              style={
+                Object {
+                  "color": "#4577CC",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
                 }
-                numberOfLines={5}
-                onChange={[Function]}
-                selectedIndex={0}
-                style={
-                  Array [
-                    Object {
-                      "height": 216,
-                    },
-                    undefined,
-                  ]
-                }
-                testID="picker"
-              />
-            </View>
+              }
+            >
+              done
+            </Text>
+          </View>
+        </View>
+        <View
+          pointerEvents="none"
+          testID="pickerItemsContainer"
+        >
+          <View>
+            <RNCPicker
+              items={
+                Array [
+                  Object {
+                    "label": "test1",
+                    "testID": undefined,
+                    "textColor": undefined,
+                    "value": "1",
+                  },
+                  Object {
+                    "label": "test2",
+                    "testID": undefined,
+                    "textColor": undefined,
+                    "value": "2",
+                  },
+                ]
+              }
+              numberOfLines={5}
+              onChange={[Function]}
+              selectedIndex={0}
+              style={
+                Array [
+                  Object {
+                    "height": 216,
+                  },
+                  undefined,
+                ]
+              }
+              testID="picker"
+            />
           </View>
         </View>
       </View>

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/SelectPickerItems.android.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/SelectPickerItems.android.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`SelectPickerItems only with required props renders successfully if item
     style={
       Object {
         "bottom": 0,
-        "height": 60,
+        "height": 110,
         "position": "absolute",
         "width": "100%",
       }
@@ -71,7 +71,7 @@ exports[`SelectPickerItems only with required props renders successfully if item
       source={1}
       style={
         Object {
-          "height": 60,
+          "height": 110,
           "width": "100%",
         }
       }
@@ -81,7 +81,7 @@ exports[`SelectPickerItems only with required props renders successfully if item
     pointerEvents="none"
     style={
       Object {
-        "height": 60,
+        "height": 110,
         "position": "absolute",
         "top": 0,
         "width": "100%",
@@ -93,7 +93,7 @@ exports[`SelectPickerItems only with required props renders successfully if item
       source={1}
       style={
         Object {
-          "height": 60,
+          "height": 110,
           "width": "100%",
         }
       }
@@ -185,11 +185,6 @@ exports[`SelectPickerItems only with required props renders successfully with mo
       >
         <View
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -210,17 +205,8 @@ exports[`SelectPickerItems only with required props renders successfully with mo
           }
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(0, 0, 0, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
-                "color": "rgba(0, 0, 0, 1)",
                 "fontSize": 20,
               }
             }
@@ -235,11 +221,6 @@ exports[`SelectPickerItems only with required props renders successfully with mo
       >
         <View
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -260,17 +241,8 @@ exports[`SelectPickerItems only with required props renders successfully with mo
           }
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(153, 153, 153, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
-                "color": "rgba(153, 153, 153, 1)",
                 "fontSize": 20,
               }
             }
@@ -287,7 +259,7 @@ exports[`SelectPickerItems only with required props renders successfully with mo
     style={
       Object {
         "bottom": 0,
-        "height": 60,
+        "height": 110,
         "position": "absolute",
         "width": "100%",
       }
@@ -298,7 +270,7 @@ exports[`SelectPickerItems only with required props renders successfully with mo
       source={1}
       style={
         Object {
-          "height": 60,
+          "height": 110,
           "width": "100%",
         }
       }
@@ -308,7 +280,7 @@ exports[`SelectPickerItems only with required props renders successfully with mo
     pointerEvents="none"
     style={
       Object {
-        "height": 60,
+        "height": 110,
         "position": "absolute",
         "top": 0,
         "width": "100%",
@@ -320,7 +292,7 @@ exports[`SelectPickerItems only with required props renders successfully with mo
       source={1}
       style={
         Object {
-          "height": 60,
+          "height": 110,
           "width": "100%",
         }
       }
@@ -435,11 +407,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
         <View
           accessibilityLabel="testAccessibilityLabel"
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -461,14 +428,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
           testID="itemPressable-0"
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(66, 66, 66, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
                 "color": "red",
@@ -488,11 +447,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
         <View
           accessibilityLabel="testAccessibilityLabel"
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -514,14 +468,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
           testID="itemPressable-1"
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(86, 86, 86, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
                 "color": "yellow",
@@ -541,11 +487,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
         <View
           accessibilityLabel="testAccessibilityLabel"
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -567,17 +508,9 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
           testID="itemPressable-2"
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(86, 86, 86, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
-                "color": "rgba(86, 86, 86, 1)",
+                "color": "yellow",
                 "fontFamily": "test-font-Regular",
                 "fontSize": 24,
               }
@@ -594,11 +527,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
         <View
           accessibilityLabel="testAccessibilityLabel"
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -620,17 +548,9 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
           testID="itemPressable-3"
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(86, 86, 86, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
-                "color": "rgba(86, 86, 86, 1)",
+                "color": "yellow",
                 "fontFamily": "test-font-Regular",
                 "fontSize": 24,
               }
@@ -647,11 +567,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
         <View
           accessibilityLabel="testAccessibilityLabel"
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -673,17 +588,9 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
           testID="itemPressable-4"
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(86, 86, 86, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
-                "color": "rgba(86, 86, 86, 1)",
+                "color": "yellow",
                 "fontFamily": "test-font-Regular",
                 "fontSize": 24,
               }
@@ -700,11 +607,6 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
         <View
           accessibilityLabel="testAccessibilityLabel"
           accessible={true}
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -726,17 +628,9 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
           testID="itemPressable-5"
         >
           <Text
-            animatedStyle={
-              Object {
-                "value": Object {
-                  "color": "rgba(86, 86, 86, 1)",
-                },
-              }
-            }
-            collapsable={false}
             style={
               Object {
-                "color": "rgba(86, 86, 86, 1)",
+                "color": "yellow",
                 "fontFamily": "test-font-Regular",
                 "fontSize": 24,
               }
@@ -754,7 +648,7 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
     style={
       Object {
         "bottom": 0,
-        "height": 60,
+        "height": 150,
         "position": "absolute",
         "width": "100%",
       }
@@ -765,7 +659,7 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
       source={1}
       style={
         Object {
-          "height": 60,
+          "height": 150,
           "width": "100%",
         }
       }
@@ -775,7 +669,7 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
     pointerEvents="none"
     style={
       Object {
-        "height": 60,
+        "height": 150,
         "position": "absolute",
         "top": 0,
         "width": "100%",
@@ -787,7 +681,7 @@ exports[`SelectPickerItems with all props should be applied properly: SelectPick
       source={1}
       style={
         Object {
-          "height": 60,
+          "height": 150,
           "width": "100%",
         }
       }

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/YearMonthPicker.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/YearMonthPicker.test.tsx.snap
@@ -65,30 +65,17 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
-            "backgroundColor": "rgba(0,0,0,0.4)",
+            "backgroundColor": "black",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -97,240 +84,228 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "white",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
           style={
             Object {
-              "backgroundColor": "white",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingHorizontal": 10,
+              "paddingVertical": 8,
             }
           }
-          testID="pickerContainer"
+          testID="pickerAccessory"
+        />
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 10,
+            }
+          }
+          testID="pickerItemsContainer"
         >
           <View
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "paddingHorizontal": 10,
-                "paddingVertical": 8,
+                "flex": 1,
               }
             }
-            testID="pickerAccessory"
-          />
+          >
+            <View>
+              <RNCPicker
+                items={
+                  Array [
+                    Object {
+                      "label": "2017",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2017,
+                    },
+                    Object {
+                      "label": "2018",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2018,
+                    },
+                    Object {
+                      "label": "2019",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2019,
+                    },
+                    Object {
+                      "label": "2020",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2020,
+                    },
+                    Object {
+                      "label": "2021",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2021,
+                    },
+                    Object {
+                      "label": "2022",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2022,
+                    },
+                  ]
+                }
+                numberOfLines={1}
+                onChange={[Function]}
+                selectedIndex={5}
+                style={
+                  Array [
+                    Object {
+                      "height": 216,
+                    },
+                    undefined,
+                  ]
+                }
+                testID="yearPicker"
+              />
+            </View>
+          </View>
+          <Text />
           <View
             style={
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
-                "paddingHorizontal": 10,
+                "flex": 1,
               }
             }
-            testID="pickerItemsContainer"
           >
-            <View
-              style={
-                Object {
-                  "flex": 1,
+            <View>
+              <RNCPicker
+                items={
+                  Array [
+                    Object {
+                      "label": "1",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 1,
+                    },
+                    Object {
+                      "label": "2",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 2,
+                    },
+                    Object {
+                      "label": "3",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 3,
+                    },
+                    Object {
+                      "label": "4",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 4,
+                    },
+                    Object {
+                      "label": "5",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 5,
+                    },
+                    Object {
+                      "label": "6",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 6,
+                    },
+                    Object {
+                      "label": "7",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 7,
+                    },
+                    Object {
+                      "label": "8",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 8,
+                    },
+                    Object {
+                      "label": "9",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 9,
+                    },
+                    Object {
+                      "label": "10",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 10,
+                    },
+                    Object {
+                      "label": "11",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 11,
+                    },
+                    Object {
+                      "label": "12",
+                      "testID": undefined,
+                      "textColor": undefined,
+                      "value": 12,
+                    },
+                  ]
                 }
-              }
-            >
-              <View>
-                <RNCPicker
-                  items={
-                    Array [
-                      Object {
-                        "label": "2017",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2017,
-                      },
-                      Object {
-                        "label": "2018",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2018,
-                      },
-                      Object {
-                        "label": "2019",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2019,
-                      },
-                      Object {
-                        "label": "2020",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2020,
-                      },
-                      Object {
-                        "label": "2021",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2021,
-                      },
-                      Object {
-                        "label": "2022",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2022,
-                      },
-                    ]
-                  }
-                  numberOfLines={1}
-                  onChange={[Function]}
-                  selectedIndex={5}
-                  style={
-                    Array [
-                      Object {
-                        "height": 216,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="yearPicker"
-                />
-              </View>
-            </View>
-            <Text />
-            <View
-              style={
-                Object {
-                  "flex": 1,
+                numberOfLines={1}
+                onChange={[Function]}
+                selectedIndex={3}
+                style={
+                  Array [
+                    Object {
+                      "height": 216,
+                    },
+                    undefined,
+                  ]
                 }
-              }
-            >
-              <View>
-                <RNCPicker
-                  items={
-                    Array [
-                      Object {
-                        "label": "1",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 1,
-                      },
-                      Object {
-                        "label": "2",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 2,
-                      },
-                      Object {
-                        "label": "3",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 3,
-                      },
-                      Object {
-                        "label": "4",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 4,
-                      },
-                      Object {
-                        "label": "5",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 5,
-                      },
-                      Object {
-                        "label": "6",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 6,
-                      },
-                      Object {
-                        "label": "7",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 7,
-                      },
-                      Object {
-                        "label": "8",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 8,
-                      },
-                      Object {
-                        "label": "9",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 9,
-                      },
-                      Object {
-                        "label": "10",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 10,
-                      },
-                      Object {
-                        "label": "11",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 11,
-                      },
-                      Object {
-                        "label": "12",
-                        "testID": undefined,
-                        "textColor": undefined,
-                        "value": 12,
-                      },
-                    ]
-                  }
-                  numberOfLines={1}
-                  onChange={[Function]}
-                  selectedIndex={3}
-                  style={
-                    Array [
-                      Object {
-                        "height": 216,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="monthPicker"
-                />
-              </View>
+                testID="monthPicker"
+              />
             </View>
-            <Text />
           </View>
+          <Text />
         </View>
       </View>
     </View>
@@ -401,31 +376,18 @@ Array [
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "opacity": 0,
+            },
           }
         }
         collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "callbackV": [Function],
-            "durationV": 500,
-            "randomizeDelay": false,
-          }
-        }
         style={
           Object {
             "backgroundColor": "green",
             "borderColor": "red",
             "flex": 1,
+            "opacity": 0,
           }
         }
         testID="pickerBackdrop"
@@ -434,345 +396,333 @@ Array [
     <View
       pointerEvents="box-none"
       style={
-        Object {
-          "flex": 1,
-          "justifyContent": "flex-end",
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          },
+        ]
       }
     >
       <View
         animatedStyle={
           Object {
-            "value": Object {},
+            "value": Object {
+              "transform": Array [
+                Object {
+                  "translateY": 1000,
+                },
+              ],
+            },
           }
         }
         collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "backgroundColor": "yellow",
+            "borderColor": "black",
+            "transform": Array [
+              Object {
+                "translateY": 1000,
+              },
+            ],
+          }
+        }
+        testID="pickerContainer"
       >
         <View
-          animatedStyle={
-            Object {
-              "value": Object {},
-            }
-          }
-          collapsable={false}
-          entering={
-            SlideInDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          exiting={
-            SlideOutDown {
-              "build": [Function],
-              "callbackV": [Function],
-              "durationV": 500,
-              "randomizeDelay": false,
-            }
-          }
-          pointerEvents="box-none"
           style={
             Object {
-              "backgroundColor": "yellow",
-              "borderColor": "black",
+              "backgroundColor": "blue",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingHorizontal": 10,
+              "paddingVertical": 8,
             }
           }
-          testID="pickerContainer"
+          testID="pickerAccessory"
+        >
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="deleteLink"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#d9545e",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
+                }
+              }
+            >
+              delete
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          />
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="cancelLink"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#4577CC",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
+                }
+              }
+            >
+              cancel
+            </Text>
+          </View>
+          <View
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="doneLink"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#4577CC",
+                  "fontWeight": "bold",
+                  "paddingHorizontal": 10,
+                }
+              }
+            >
+              done
+            </Text>
+          </View>
+        </View>
+        <View
+          pointerEvents="none"
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 10,
+            }
+          }
+          testID="pickerItemsContainer"
         >
           <View
             style={
               Object {
-                "backgroundColor": "blue",
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "paddingHorizontal": 10,
-                "paddingVertical": 8,
+                "flex": 1,
               }
             }
-            testID="pickerAccessory"
           >
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
+            <View>
+              <RNCPicker
+                items={
+                  Array [
+                    Object {
+                      "label": "2017",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2017,
+                    },
+                    Object {
+                      "label": "2018",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2018,
+                    },
+                    Object {
+                      "label": "2019",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2019,
+                    },
+                    Object {
+                      "label": "2020",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2020,
+                    },
+                    Object {
+                      "label": "2021",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2021,
+                    },
+                    Object {
+                      "label": "2022",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2022,
+                    },
+                  ]
                 }
-              }
-              testID="deleteLink"
-            >
-              <Text
+                numberOfLines={5}
+                onChange={[Function]}
+                selectedIndex={5}
                 style={
-                  Object {
-                    "color": "#d9545e",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
+                  Array [
+                    Object {
+                      "height": 216,
+                    },
+                    undefined,
+                  ]
                 }
-              >
-                delete
-              </Text>
-            </View>
-            <View
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-              testID="cancelLink"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#4577CC",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                cancel
-              </Text>
-            </View>
-            <View
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-              testID="doneLink"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#4577CC",
-                    "fontWeight": "bold",
-                    "paddingHorizontal": 10,
-                  }
-                }
-              >
-                done
-              </Text>
+                testID="yearPicker"
+              />
             </View>
           </View>
+          <Text>
+            年
+          </Text>
           <View
-            pointerEvents="none"
             style={
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
-                "paddingHorizontal": 10,
+                "flex": 1,
               }
             }
-            testID="pickerItemsContainer"
           >
-            <View
-              style={
-                Object {
-                  "flex": 1,
+            <View>
+              <RNCPicker
+                items={
+                  Array [
+                    Object {
+                      "label": "1",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 1,
+                    },
+                    Object {
+                      "label": "2",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 2,
+                    },
+                    Object {
+                      "label": "3",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 3,
+                    },
+                    Object {
+                      "label": "4",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 4,
+                    },
+                    Object {
+                      "label": "5",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 5,
+                    },
+                    Object {
+                      "label": "6",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 6,
+                    },
+                    Object {
+                      "label": "7",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 7,
+                    },
+                    Object {
+                      "label": "8",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 8,
+                    },
+                    Object {
+                      "label": "9",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 9,
+                    },
+                    Object {
+                      "label": "10",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 10,
+                    },
+                    Object {
+                      "label": "11",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 11,
+                    },
+                    Object {
+                      "label": "12",
+                      "testID": undefined,
+                      "textColor": 4294967040,
+                      "value": 12,
+                    },
+                  ]
                 }
-              }
-            >
-              <View>
-                <RNCPicker
-                  items={
-                    Array [
-                      Object {
-                        "label": "2017",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2017,
-                      },
-                      Object {
-                        "label": "2018",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2018,
-                      },
-                      Object {
-                        "label": "2019",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2019,
-                      },
-                      Object {
-                        "label": "2020",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2020,
-                      },
-                      Object {
-                        "label": "2021",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2021,
-                      },
-                      Object {
-                        "label": "2022",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2022,
-                      },
-                    ]
-                  }
-                  numberOfLines={5}
-                  onChange={[Function]}
-                  selectedIndex={5}
-                  style={
-                    Array [
-                      Object {
-                        "height": 216,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="yearPicker"
-                />
-              </View>
-            </View>
-            <Text>
-              年
-            </Text>
-            <View
-              style={
-                Object {
-                  "flex": 1,
+                numberOfLines={5}
+                onChange={[Function]}
+                selectedIndex={3}
+                style={
+                  Array [
+                    Object {
+                      "height": 216,
+                    },
+                    undefined,
+                  ]
                 }
-              }
-            >
-              <View>
-                <RNCPicker
-                  items={
-                    Array [
-                      Object {
-                        "label": "1",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 1,
-                      },
-                      Object {
-                        "label": "2",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 2,
-                      },
-                      Object {
-                        "label": "3",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 3,
-                      },
-                      Object {
-                        "label": "4",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 4,
-                      },
-                      Object {
-                        "label": "5",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 5,
-                      },
-                      Object {
-                        "label": "6",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 6,
-                      },
-                      Object {
-                        "label": "7",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 7,
-                      },
-                      Object {
-                        "label": "8",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 8,
-                      },
-                      Object {
-                        "label": "9",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 9,
-                      },
-                      Object {
-                        "label": "10",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 10,
-                      },
-                      Object {
-                        "label": "11",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 11,
-                      },
-                      Object {
-                        "label": "12",
-                        "testID": undefined,
-                        "textColor": 4294967040,
-                        "value": 12,
-                      },
-                    ]
-                  }
-                  numberOfLines={5}
-                  onChange={[Function]}
-                  selectedIndex={3}
-                  style={
-                    Array [
-                      Object {
-                        "height": 216,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="monthPicker"
-                />
-              </View>
+                testID="monthPicker"
+              />
             </View>
-            <Text>
-              月
-            </Text>
           </View>
+          <Text>
+            月
+          </Text>
         </View>
       </View>
     </View>

--- a/example-app/SantokuApp/src/components/picker/__snapshots__/YearMonthPicker.test.tsx.snap
+++ b/example-app/SantokuApp/src/components/picker/__snapshots__/YearMonthPicker.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`YearMonthPicker only with required props renders successfully if invisi
 exports[`YearMonthPicker only with required props renders successfully if visible: YearMonthPicker if visible. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
@@ -53,34 +53,18 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "black",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "black",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdrop"
+    />
     <View
       pointerEvents="box-none"
       style={
@@ -341,11 +325,11 @@ Array [
 exports[`YearMonthPicker with all props should be applied all properly: YearMonthPicker all properly. 1`] = `
 Array [
   <Modal
-    animationType="none"
+    animationType="fade"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     statusBarTranslucent={true}
-    testID="modal"
+    testID="pickerBackdropModal"
     transparent={true}
     visible={true}
   >
@@ -364,35 +348,19 @@ Array [
       onStartShouldSetResponder={[Function]}
       style={
         Object {
+          "backgroundColor": "green",
+          "borderColor": "red",
           "bottom": 0,
           "display": "flex",
           "left": 0,
+          "opacity": 0.4,
           "position": "absolute",
           "right": 0,
           "top": 0,
         }
       }
-    >
-      <View
-        animatedStyle={
-          Object {
-            "value": Object {
-              "opacity": 0,
-            },
-          }
-        }
-        collapsable={false}
-        style={
-          Object {
-            "backgroundColor": "green",
-            "borderColor": "red",
-            "flex": 1,
-            "opacity": 0,
-          }
-        }
-        testID="pickerBackdrop"
-      />
-    </View>
+      testID="pickerBackdropPressable"
+    />
     <View
       pointerEvents="box-none"
       style={

--- a/example-app/SantokuApp/src/components/picker/useDateTimePickerIOSUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useDateTimePickerIOSUseCase.ts
@@ -1,46 +1,16 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useState} from 'react';
 
 import {DateTimePickerIOSProps} from './DateTimePicker.ios';
-import {PICKER_BACKDROP_DEFAULT_ENTERING, PICKER_BACKDROP_DEFAULT_EXITING} from './PickerBackdrop';
-import {PICKER_CONTAINER_DEFAULT_ENTERING, PICKER_CONTAINER_DEFAULT_EXITING} from './PickerContainer';
 import {useDateTimePickerUseCase} from './useDateTimePickerUseCase';
-
-const DEFAULT_DURATION = 500;
 
 export const useDateTimePickerIOSUseCase = (props: DateTimePickerIOSProps) => {
   const useCase = useDateTimePickerUseCase(props);
-  const {
-    selectedValue,
-    defaultValue = new Date(),
-    onSelectedItemChange,
-    onDismiss,
-    onDelete,
-    onCancel,
-    onDone,
-    pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting} = {},
-    pickerContainerProps: {entering: containerEntering, exiting: containerExiting} = {},
-  } = props;
+  const {selectedValue, defaultValue = new Date(), onSelectedItemChange, onDismiss, onDelete, onCancel, onDone} = props;
 
   const [isVisible, setIsVisible] = useState(false);
   const close = useCallback(() => {
     setIsVisible(false);
   }, []);
-  const pickerBackdropEntering = useMemo(
-    () => backdropEntering ?? PICKER_BACKDROP_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
-    [backdropEntering],
-  );
-  const pickerBackdropExiting = useMemo(
-    () => backdropExiting ?? PICKER_BACKDROP_DEFAULT_EXITING.duration(DEFAULT_DURATION),
-    [backdropExiting],
-  );
-  const pickerContainerEntering = useMemo(
-    () => containerEntering ?? PICKER_CONTAINER_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
-    [containerEntering],
-  );
-  const pickerContainerExiting = useMemo(
-    () => containerExiting ?? PICKER_CONTAINER_DEFAULT_EXITING.duration(DEFAULT_DURATION),
-    [containerExiting],
-  );
   const onValueChange = useCallback(
     (_, date?: Date) => {
       onSelectedItemChange?.(date);
@@ -74,10 +44,6 @@ export const useDateTimePickerIOSUseCase = (props: DateTimePickerIOSProps) => {
     ...useCase,
     isVisible,
     setIsVisible,
-    pickerBackdropEntering,
-    pickerBackdropExiting,
-    pickerContainerEntering,
-    pickerContainerExiting,
     onValueChange,
     open,
     close,

--- a/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
@@ -49,7 +49,7 @@ export const usePickerContainerUseCase = ({
 
   const clock = useSharedValue(1);
   const yOffset = useDerivedValue(() => {
-    return Math.max(clock.value * contentHeight, contentHeight - windowHeight);
+    return clock.value * contentHeight;
   }, [contentHeight, windowHeight]);
 
   const show = useCallback(() => {

--- a/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
@@ -1,0 +1,98 @@
+import {useCallback, useEffect, useState} from 'react';
+import {Dimensions, LayoutChangeEvent, useWindowDimensions} from 'react-native';
+import {
+  cancelAnimation,
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+  WithTimingConfig,
+} from 'react-native-reanimated';
+
+import {usePrevious, useVisibility} from '../../framework/utilities';
+
+type ContainerAnimationConfig = {
+  isVisible: boolean;
+  afterSlideIn?: (finished?: boolean) => unknown;
+  afterSlideOut?: (finished?: boolean) => unknown;
+  slideInDuration?: number;
+  slideOutDuration?: number;
+  slideInConfig?: WithTimingConfig;
+  slideOutConfig?: WithTimingConfig;
+};
+
+export const usePickerContainerUseCase = ({
+  isVisible,
+  afterSlideIn,
+  afterSlideOut,
+  slideInDuration,
+  slideOutDuration,
+  slideInConfig,
+  slideOutConfig,
+}: ContainerAnimationConfig) => {
+  const {
+    isVisible: isPickerVisible,
+    setVisible: setPickerIsVisible,
+    setInvisible: setPickerIsNotVisible,
+  } = useVisibility(false);
+
+  const isVisiblePrevious = usePrevious(isVisible);
+
+  // PickerContainerが表示された状態で、画面分割や回転などで画面サイズが変更されたときに、できるだけ違和感なく動くように調整する。
+  const {height: windowHeight} = useWindowDimensions();
+  const [contentHeight, setContentHeight] = useState(Dimensions.get('screen').height);
+  const updateContentHeight = useCallback((e: LayoutChangeEvent) => {
+    setContentHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  const clock = useSharedValue(1);
+  const yOffset = useDerivedValue(() => {
+    return Math.max(clock.value * contentHeight, contentHeight - windowHeight);
+  }, [contentHeight, windowHeight]);
+
+  const show = useCallback(() => {
+    setPickerIsVisible();
+    cancelAnimation(clock);
+    clock.value = withTiming(
+      0,
+      {
+        easing: Easing.out(Easing.quad),
+        duration: slideInDuration,
+        ...slideInConfig,
+      },
+      afterSlideIn && (finished => runOnJS(afterSlideIn)(finished)),
+    );
+  }, [afterSlideIn, clock, setPickerIsVisible, slideInConfig, slideInDuration]);
+
+  const hide = useCallback(() => {
+    cancelAnimation(clock);
+    clock.value = withTiming(
+      1,
+      {
+        easing: Easing.in(Easing.quad),
+        duration: slideOutDuration,
+        ...slideOutConfig,
+      },
+      finished => {
+        if (finished) {
+          runOnJS(setPickerIsNotVisible)();
+        }
+        afterSlideOut && runOnJS(afterSlideOut)(finished);
+      },
+    );
+  }, [afterSlideOut, clock, setPickerIsNotVisible, slideOutConfig, slideOutDuration]);
+
+  const transform = useAnimatedStyle(() => ({transform: [{translateY: yOffset.value}]}));
+
+  useEffect(() => {
+    if (isVisible && !isVisiblePrevious) {
+      show();
+    } else if (!isVisible && isVisiblePrevious) {
+      hide();
+    }
+  }, [hide, isVisible, isVisiblePrevious, show]);
+
+  return {isPickerVisible, transform, updateContentHeight};
+};

--- a/example-app/SantokuApp/src/components/picker/useSelectPickerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useSelectPickerUseCase.ts
@@ -1,10 +1,6 @@
 import React, {useCallback, useMemo, useState} from 'react';
 
-import {PICKER_BACKDROP_DEFAULT_ENTERING, PICKER_BACKDROP_DEFAULT_EXITING} from './PickerBackdrop';
-import {PICKER_CONTAINER_DEFAULT_ENTERING, PICKER_CONTAINER_DEFAULT_EXITING} from './PickerContainer';
 import {SelectPickerProps} from './SelectPicker';
-
-const DEFAULT_DURATION = 500;
 
 export const useSelectPickerUseCase = <ItemT extends unknown>({
   items,
@@ -14,27 +10,9 @@ export const useSelectPickerUseCase = <ItemT extends unknown>({
   onDelete,
   onCancel,
   onDone,
-  pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting} = {},
-  pickerContainerProps: {entering: containerEntering, exiting: containerExiting} = {},
 }: SelectPickerProps<ItemT>) => {
   const [isVisible, setIsVisible] = useState(false);
   const close = useCallback(() => setIsVisible(false), []);
-  const pickerBackdropEntering = useMemo(
-    () => backdropEntering ?? PICKER_BACKDROP_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
-    [backdropEntering],
-  );
-  const pickerBackdropExiting = useMemo(
-    () => backdropExiting ?? PICKER_BACKDROP_DEFAULT_EXITING.duration(DEFAULT_DURATION),
-    [backdropExiting],
-  );
-  const pickerContainerEntering = useMemo(
-    () => containerEntering ?? PICKER_CONTAINER_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
-    [containerEntering],
-  );
-  const pickerContainerExiting = useMemo(
-    () => containerExiting ?? PICKER_CONTAINER_DEFAULT_EXITING.duration(DEFAULT_DURATION),
-    [containerExiting],
-  );
   const getSelectedItem = useCallback(
     (key?: React.Key | ItemT) => {
       return items.find(item => item.key === key || item.value === key);
@@ -85,10 +63,6 @@ export const useSelectPickerUseCase = <ItemT extends unknown>({
     getSelectedItem,
     inputValue,
     handleBackdropPress,
-    pickerBackdropEntering,
-    pickerBackdropExiting,
-    pickerContainerEntering,
-    pickerContainerExiting,
     onValueChange,
     open,
     handleDelete,

--- a/example-app/SantokuApp/src/components/picker/useYearMonthPickerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/useYearMonthPickerUseCase.ts
@@ -1,13 +1,9 @@
 import React, {useCallback, useMemo, useState} from 'react';
 
 import {ApplicationError} from '../../framework/error/ApplicationError';
-import {PICKER_BACKDROP_DEFAULT_ENTERING, PICKER_BACKDROP_DEFAULT_EXITING} from './PickerBackdrop';
-import {PICKER_CONTAINER_DEFAULT_ENTERING, PICKER_CONTAINER_DEFAULT_EXITING} from './PickerContainer';
 import {YearMonth} from './YearMonth';
 import {YearMonthPickerProps} from './YearMonthPicker';
 import {YearMonthUtil} from './YearMonthUtil';
-
-const DEFAULT_DURATION = 500;
 
 export const useYearMonthPickerUseCase = ({
   selectedValue,
@@ -20,8 +16,6 @@ export const useYearMonthPickerUseCase = ({
   onDelete,
   onCancel,
   onDone,
-  pickerBackdropProps: {entering: backdropEntering, exiting: backdropExiting} = {},
-  pickerContainerProps: {entering: containerEntering, exiting: containerExiting} = {},
   itemColor,
   itemFontFamily,
 }: YearMonthPickerProps) => {
@@ -30,22 +24,6 @@ export const useYearMonthPickerUseCase = ({
   }
   const [isVisible, setIsVisible] = useState(false);
   const close = useCallback(() => setIsVisible(false), []);
-  const pickerBackdropEntering = useMemo(
-    () => backdropEntering ?? PICKER_BACKDROP_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
-    [backdropEntering],
-  );
-  const pickerBackdropExiting = useMemo(
-    () => backdropExiting ?? PICKER_BACKDROP_DEFAULT_EXITING.duration(DEFAULT_DURATION),
-    [backdropExiting],
-  );
-  const pickerContainerEntering = useMemo(
-    () => containerEntering ?? PICKER_CONTAINER_DEFAULT_ENTERING.duration(DEFAULT_DURATION),
-    [containerEntering],
-  );
-  const pickerContainerExiting = useMemo(
-    () => containerExiting ?? PICKER_CONTAINER_DEFAULT_EXITING.duration(DEFAULT_DURATION),
-    [containerExiting],
-  );
 
   const yearItems = useMemo(() => {
     const maximumYear = maximumYearMonth.year;
@@ -154,10 +132,6 @@ export const useYearMonthPickerUseCase = ({
     getSelectedYearMonth,
     onValueChangeYear,
     onValueChangeMonth,
-    pickerBackdropEntering,
-    pickerBackdropExiting,
-    pickerContainerEntering,
-    pickerContainerExiting,
     open,
     handleBackdropPress,
     handleDelete,

--- a/example-app/SantokuApp/src/framework/utilities/useVisibility.ts
+++ b/example-app/SantokuApp/src/framework/utilities/useVisibility.ts
@@ -1,5 +1,7 @@
 import {useCallback, useState} from 'react';
 
+import {useIsMounted} from './useIsMounted';
+
 /**
  * This React hook provides the boolean state (representing visibility) and functions that change state.
  *
@@ -7,12 +9,13 @@ import {useCallback, useState} from 'react';
  */
 export const useVisibility = (initialVisibility: boolean = false) => {
   const [isVisible, setIsVisible] = useState(initialVisibility);
+  const isMounted = useIsMounted();
 
-  const toggleVisibility = useCallback(() => setIsVisible(v => !v), []);
+  const toggleVisibility = useCallback(() => isMounted() && setIsVisible(v => !v), [isMounted]);
 
-  const setVisible = useCallback(() => setIsVisible(true), []);
+  const setVisible = useCallback(() => isMounted() && setIsVisible(true), [isMounted]);
 
-  const setInvisible = useCallback(() => setIsVisible(false), []);
+  const setInvisible = useCallback(() => isMounted() && setIsVisible(false), [isMounted]);
 
   return {isVisible, toggleVisibility, setVisible, setInvisible};
 };


### PR DESCRIPTION
## ✅ What's done

以下のReact Native Animatedのissueに記載されている通り、Layout Animationsを使用した場合に、ページコンテンツがナビゲーションヘッダに隠れてしまう事象が発生しました。
[React Navigation (Native-stack) header hide screen after reanimated layout animation run [only in Android] ](https://github.com/software-mansion/react-native-reanimated/issues/2906)
本PRはその対応になります。

- [x] Layout Animationsを使用しないで、`PickerBackdrop`、`PickerContainer`のアニメーションを実装

---

## Tests

- [ ] 実施した動作確認の内容をチェック付きの箇条書きで記載してください
- [ ] 作業着手前に列挙して TODO リストのようにも使用できます
- [ ] やり終わったらチェックを付けてください

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 13/iOS 15)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 4a/Android 12)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
