### PR TITLE
🐛: [iOS] Fixed an issue where animations were not executed in the Picker component.

### DIFF
--- a/example-app/SantokuApp/patches/README.md
+++ b/example-app/SantokuApp/patches/README.md
@@ -30,7 +30,7 @@ React Native Elementsの3系ではこの変更に追従できていなかった�
 * `ListItem.XXX`のPropsから`tvParallaxProperties`を削除
 * `Input`のPropsの`autoCompleteType`を`autoComplete`に変更
 
-## React Native Reanimatedのアニメーションが発生しない事象に対処するパッチ
+## React Native ReanimatedのuseAnimatedStyleを利用した際に、アニメーションが発生しない事象に対処するパッチ
 
 `useAnimatedStyle`を利用した際に、アニメーションが実行されない事象が発生しました。
 

--- a/example-app/SantokuApp/patches/README.md
+++ b/example-app/SantokuApp/patches/README.md
@@ -29,3 +29,13 @@ React Native Elementsの3系ではこの変更に追従できていなかった�
 * `ListItem`のPropsから`tvParallaxProperties`、`hasTVPreferredFocus`を削除
 * `ListItem.XXX`のPropsから`tvParallaxProperties`を削除
 * `Input`のPropsの`autoCompleteType`を`autoComplete`に変更
+
+## React Native Reanimatedのアニメーションが発生しない事象に対処するパッチ
+
+`useAnimatedStyle`を利用した際に、アニメーションが実行されない事象が発生しました。
+
+関連issueは↓です。
+https://github.com/software-mansion/react-native-reanimated/issues/3296
+
+issueに対応するPRが挙がっていたので、その変更をパッチとして当てています。
+https://github.com/software-mansion/react-native-reanimated/pull/3302

--- a/example-app/SantokuApp/patches/react-native-reanimated+2.8.0.patch
+++ b/example-app/SantokuApp/patches/react-native-reanimated+2.8.0.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/react-native-reanimated/ios/REANodesManager.m b/node_modules/react-native-reanimated/ios/REANodesManager.m
+index f40467d..1a88db6 100644
+--- a/node_modules/react-native-reanimated/ios/REANodesManager.m
++++ b/node_modules/react-native-reanimated/ios/REANodesManager.m
+@@ -537,12 +537,17 @@ - (void)updateProps:(nonnull NSDictionary *)props
+       propsSnapshot.viewName = viewName;
+       _componentUpdateBuffer[viewTag] = propsSnapshot;
+       atomic_store(&_shouldFlushUpdateBuffer, true);
++      return;
+     } else {
+       NSMutableDictionary *lastProps = lastSnapshot.props;
+       for (NSString *key in props) {
+         [lastProps setValue:props[key] forKey:key];
+       }
+     }
++  }
++  if (lastSnapshot != nil) {
++    [_componentUpdateBuffer removeObjectForKey:viewTag];
++    [self updateProps:lastSnapshot.props ofViewWithTag:viewTag withName:viewName];
+     return;
+   }
+ 

--- a/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
+++ b/example-app/SantokuApp/src/components/picker/DateTimePicker.ios.tsx
@@ -15,7 +15,7 @@ export type DateTimePickerIOSProps = Omit<DateTimePickerProps, 'displayAndroid' 
   >;
 };
 
-const DEFAULT_DURATION = 500;
+const DEFAULT_DURATION = 300;
 
 /**
  * 日時を表示するPickerとしてReact Native DateTimePickerを使用しています。

--- a/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
@@ -23,8 +23,6 @@ type ContainerAnimationConfig = {
   slideOutConfig?: WithTimingConfig;
 };
 
-const nop = () => {};
-
 export const usePickerContainerUseCase = ({
   isVisible,
   afterSlideIn,
@@ -64,7 +62,9 @@ export const usePickerContainerUseCase = ({
         duration: slideInDuration,
         ...slideInConfig,
       },
-      afterSlideIn && (finished => runOnJS(afterSlideIn)(finished)),
+      finished => {
+        afterSlideIn && runOnJS(afterSlideIn)(finished);
+      },
     );
   }, [afterSlideIn, clock, setPickerIsVisible, slideInConfig, slideInDuration]);
 
@@ -86,12 +86,7 @@ export const usePickerContainerUseCase = ({
     );
   }, [afterSlideOut, clock, setPickerIsNotVisible, slideOutConfig, slideOutDuration]);
 
-  const transform = useAnimatedStyle(() => {
-    // WORKAROUND: [iOS] Animations don't always run on component initialization
-    // https://github.com/software-mansion/react-native-reanimated/issues/3296
-    nop();
-    return {transform: [{translateY: yOffset.value}]};
-  });
+  const transform = useAnimatedStyle(() => ({transform: [{translateY: yOffset.value}]}));
 
   useEffect(() => {
     if (isVisible && !isVisiblePrevious) {

--- a/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
@@ -23,6 +23,8 @@ type ContainerAnimationConfig = {
   slideOutConfig?: WithTimingConfig;
 };
 
+const nop = () => {};
+
 export const usePickerContainerUseCase = ({
   isVisible,
   afterSlideIn,
@@ -84,7 +86,12 @@ export const usePickerContainerUseCase = ({
     );
   }, [afterSlideOut, clock, setPickerIsNotVisible, slideOutConfig, slideOutDuration]);
 
-  const transform = useAnimatedStyle(() => ({transform: [{translateY: yOffset.value}]}));
+  const transform = useAnimatedStyle(() => {
+    // WORKAROUND: [iOS] Animations don't always run on component initialization
+    // https://github.com/software-mansion/react-native-reanimated/issues/3296
+    nop();
+    return {transform: [{translateY: yOffset.value}]};
+  });
 
   useEffect(() => {
     if (isVisible && !isVisiblePrevious) {

--- a/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
@@ -89,7 +89,6 @@ export const usePickerContainerUseCase = ({
   const transform = useAnimatedStyle(() => {
     // WORKAROUND: [iOS] Animations don't always run on component initialization
     // https://github.com/software-mansion/react-native-reanimated/issues/3296
-    console.log('workaround log in picker container.');
     nop();
     return {transform: [{translateY: yOffset.value}]};
   });

--- a/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
+++ b/example-app/SantokuApp/src/components/picker/usePickerContainerUseCase.ts
@@ -89,6 +89,7 @@ export const usePickerContainerUseCase = ({
   const transform = useAnimatedStyle(() => {
     // WORKAROUND: [iOS] Animations don't always run on component initialization
     // https://github.com/software-mansion/react-native-reanimated/issues/3296
+    console.log('workaround log in picker container.');
     nop();
     return {transform: [{translateY: yOffset.value}]};
   });


### PR DESCRIPTION
## ✅ What's done

- [x] Added patch for problem where animation is not performed on picker parts
  - related issue/pr
    - https://github.com/software-mansion/react-native-reanimated/issues/3296
    - https://github.com/software-mansion/react-native-reanimated/pull/3302
- [x] Change DateTimePicker animation duration to  the same value(300msc) as SelectPicker

---

## Tests

- [x] Keystroke on demo screen

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 13/iOS 15)
  - [x] 実機 (iPhone 13 mini/iOS 15)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

none
