### PR TITLE
📌: Exclude react-native-svg from renovate management

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,7 @@
         'react-native-reanimated',
         'react-native-safe-area-context',
         'react-native-screens',
+        'react-native-svg',
         'react-native-web',
         'react-native-webview',
         'typescript'


### PR DESCRIPTION
## ✅ What's done

- [x] Exclude react-native-svg from Renovate management as it will be upgraded with Expo.

---

## Other (messages to reviewers, concerns, etc.)

none
