### PR TITLE
⬇️: Downgrade @testing-library/react-native to v10

### DIFF
--- a/example-app/SantokuApp/package-lock.json
+++ b/example-app/SantokuApp/package-lock.json
@@ -55,7 +55,7 @@
         "@babel/core": "^7.12.9",
         "@testing-library/jest-native": "^4.0.2",
         "@testing-library/react-hooks": "^8.0.0",
-        "@testing-library/react-native": "^11.0.0",
+        "@testing-library/react-native": "^10.0.0",
         "@types/jest": "<27.0.0",
         "@types/react": "~17.0.21",
         "@types/react-native": "~0.67.6",
@@ -6734,18 +6734,50 @@
       }
     },
     "node_modules/@testing-library/react-native": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-11.0.0.tgz",
-      "integrity": "sha512-2WZF8P8YYXO5Ka1yzj3TZUg4x6noKU5RuCpx4oAhKBkxkVbrRl1pMCvRIozdTPSiru4rNBmAi074ZJjm2OED5g==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-10.1.1.tgz",
+      "integrity": "sha512-tflpI2MTOEe0Gmj0FCTYOQD8OwBYq/YpAre0QFe2IMCcMFr55h/5zvCdwB3+uUsr6Nqve+hs6poVrD3t2wwoLQ==",
       "dev": true,
       "dependencies": {
-        "pretty-format": "^28.1.3"
+        "pretty-format": "^27.0.0"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
         "react-native": ">=0.59",
         "react-test-renderer": ">=16.0.0"
       }
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -30183,12 +30215,37 @@
       }
     },
     "@testing-library/react-native": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-11.0.0.tgz",
-      "integrity": "sha512-2WZF8P8YYXO5Ka1yzj3TZUg4x6noKU5RuCpx4oAhKBkxkVbrRl1pMCvRIozdTPSiru4rNBmAi074ZJjm2OED5g==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-10.1.1.tgz",
+      "integrity": "sha512-tflpI2MTOEe0Gmj0FCTYOQD8OwBYq/YpAre0QFe2IMCcMFr55h/5zvCdwB3+uUsr6Nqve+hs6poVrD3t2wwoLQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "^28.1.3"
+        "pretty-format": "^27.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
       }
     },
     "@tootallnate/once": {

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -79,7 +79,7 @@
     "@babel/core": "^7.12.9",
     "@testing-library/jest-native": "^4.0.2",
     "@testing-library/react-hooks": "^8.0.0",
-    "@testing-library/react-native": "^11.0.0",
+    "@testing-library/react-native": "^10.0.0",
     "@types/jest": "<27.0.0",
     "@types/react": "~17.0.21",
     "@types/react-native": "~0.67.6",


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- Features added in v11 in @testing-library/react-native will no longer be available.(No part of Santoku currently uses v11 features)

## ✅ What's done

The v11 of @testing-library/react-native requires jest 28 or higher, but Santoku (Expo) depends on jest 26.x.
Therefore, downgrade @testing-library/react-native to v10.

- [x] Change `package.json` and `package-lock.json`

---

## Tests

- [x] `npm ci && npm run lint && npm run test`

## Other (messages to reviewers, concerns, etc.)

none
