### PR TITLE
🐛: Fix a bug that errorCode of Runtime(Application)Error is not set.

### DIFF
--- a/example-app/SantokuApp/src/bases/core/errors/ApplicationError.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/ApplicationError.ts
@@ -7,13 +7,20 @@ export class ApplicationError extends ErrorWrapper {
   constructor(cause: unknown, errorCode?: string);
   constructor(message: string, errorCode?: string);
   constructor(message: string, cause: unknown, errorCode?: string);
-  constructor(messageOrCause?: unknown, cause?: unknown, errorCode?: string) {
+  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
     if (typeof messageOrCause === 'string') {
-      super(messageOrCause, cause);
-      this._errorCode = errorCode;
+      if (typeof causeOrErrorCode === 'string' && !errorCode) {
+        super(messageOrCause);
+        this._errorCode = causeOrErrorCode;
+      } else {
+        super(messageOrCause, causeOrErrorCode);
+        this._errorCode = errorCode;
+      }
     } else {
       super(messageOrCause);
-      this._errorCode = errorCode;
+      if (typeof causeOrErrorCode === 'string') {
+        this._errorCode = causeOrErrorCode;
+      }
     }
   }
 

--- a/example-app/SantokuApp/src/bases/core/errors/RuntimeError.test.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/RuntimeError.test.ts
@@ -1,13 +1,13 @@
-import {ApplicationError, isApplicationError} from './ApplicationError';
+import {RuntimeError, isRuntimeError} from './RuntimeError';
 
-class ApplicationErrorSubClass extends ApplicationError {}
-const cause = new ApplicationErrorSubClass('root cause');
-const nested = new ApplicationErrorSubClass('nested cause', cause);
+class RuntimeErrorSubClass extends RuntimeError {}
+const cause = new RuntimeErrorSubClass('root cause');
+const nested = new RuntimeErrorSubClass('nested cause', cause);
 
 // eslint-disable-next-line jest/unbound-method
 const captureStackTrace = Error.captureStackTrace;
 describe.each([false, true])(
-  'new ApplicationError() when captureStackTrace availability is %p',
+  'new RuntimeError() when captureStackTrace availability is %p',
   captureStackTraceAvailable => {
     beforeAll(() => {
       if (!captureStackTraceAvailable) {
@@ -23,80 +23,80 @@ describe.each([false, true])(
 
     it('given a message', () => {
       const message = 'error message';
-      const sut = new ApplicationError(message);
+      const sut = new RuntimeError(message);
 
-      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.name).toEqual('RuntimeError');
       expect(sut.message).toEqual(message);
       expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^ApplicationError: error message$/m);
+      expect(sut.stack).toMatch(/^RuntimeError: error message$/m);
       expect(sut.errorCode).toEqual(undefined);
     });
 
     it('given an Error', () => {
-      const sut = new ApplicationError(cause);
+      const sut = new RuntimeError(cause);
 
-      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.name).toEqual('RuntimeError');
       expect(sut.message).toEqual('');
       expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: $.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.stack).toMatch(/^RuntimeError: $.+^RuntimeErrorSubClass: root cause/ms);
       expect(sut.errorCode).toEqual(undefined);
     });
 
     it('given a message and errorCode', () => {
       const message = 'error message';
       const errorCode = 'error code';
-      const sut = new ApplicationError(message, errorCode);
+      const sut = new RuntimeError(message, errorCode);
 
-      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.name).toEqual('RuntimeError');
       expect(sut.message).toEqual(message);
       expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^ApplicationError: error message$/m);
+      expect(sut.stack).toMatch(/^RuntimeError: error message$/m);
       expect(sut.errorCode).toEqual(errorCode);
     });
 
     it('given an Error and errorCode', () => {
       const errorCode = 'error code';
-      const sut = new ApplicationError(cause, errorCode);
+      const sut = new RuntimeError(cause, errorCode);
 
-      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.name).toEqual('RuntimeError');
       expect(sut.message).toEqual('');
       expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: $.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.stack).toMatch(/^RuntimeError: $.+^RuntimeErrorSubClass: root cause/ms);
       expect(sut.errorCode).toEqual(errorCode);
     });
 
     it('given a message and Error', () => {
       const message = 'when the error occurred';
-      const sut = new ApplicationError(message, cause);
+      const sut = new RuntimeError(message, cause);
 
-      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.name).toEqual('RuntimeError');
       expect(sut.message).toEqual(message);
       expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: when the error occurred$.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.stack).toMatch(/^RuntimeError: when the error occurred$.+^RuntimeErrorSubClass: root cause/ms);
       expect(sut.errorCode).toEqual(undefined);
     });
 
     it('given a message and Error and errorCode', () => {
       const message = 'when the error occurred';
       const errorCode = 'error code';
-      const sut = new ApplicationError(message, cause, errorCode);
+      const sut = new RuntimeError(message, cause, errorCode);
 
-      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.name).toEqual('RuntimeError');
       expect(sut.message).toEqual(message);
       expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: when the error occurred$.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.stack).toMatch(/^RuntimeError: when the error occurred$.+^RuntimeErrorSubClass: root cause/ms);
       expect(sut.errorCode).toEqual(errorCode);
     });
 
     it('given a message and nested Error', () => {
       const message = 'when the error occurred';
-      const sut = new ApplicationError(message, nested);
+      const sut = new RuntimeError(message, nested);
 
       expect(sut.message).toEqual(message);
       expect(sut.cause).toEqual(nested);
       expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
       expect(sut.stack).toMatch(
-        /^ApplicationError: when the error occurred.+^ApplicationErrorSubClass: nested cause.+^ApplicationErrorSubClass: root cause/ms,
+        /^RuntimeError: when the error occurred.+^RuntimeErrorSubClass: nested cause.+^RuntimeErrorSubClass: root cause/ms,
       );
       expect(sut.errorCode).toEqual(undefined);
     });
@@ -105,9 +105,9 @@ describe.each([false, true])(
       const mock = jest.spyOn(console, 'warn').mockImplementation();
       try {
         // @ts-ignore
-        const sut = new ApplicationError(['array', {key: 'value'}]);
+        const sut = new RuntimeError(['array', {key: 'value'}]);
 
-        expect(sut.name).toEqual('ApplicationError');
+        expect(sut.name).toEqual('RuntimeError');
         expect(sut.message).toEqual('');
         expect(sut.cause).toEqual(undefined);
         expect(sut.errorCode).toEqual(undefined);
@@ -120,7 +120,7 @@ describe.each([false, true])(
       const message = 'when the error occurred';
       const cause = {key: 'value'};
       // @ts-ignore
-      const sut = new ApplicationError(message, cause);
+      const sut = new RuntimeError(message, cause);
 
       expect(sut.message).toEqual(message);
       expect(sut.cause).toEqual(undefined);
@@ -129,30 +129,30 @@ describe.each([false, true])(
   },
 );
 
-describe('ApplicationError', () => {
-  it('sub class should be instance of ApplicationError', () => {
-    const sut = new ApplicationErrorSubClass();
+describe('RuntimeError', () => {
+  it('sub class should be instance of RuntimeError', () => {
+    const sut = new RuntimeErrorSubClass();
     // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof ApplicationErrorSubClass).toBe(true);
+    expect(sut instanceof RuntimeErrorSubClass).toBe(true);
     // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof ApplicationError).toBe(true);
+    expect(sut instanceof RuntimeError).toBe(true);
   });
 });
 
-describe('isApplicationError', () => {
+describe('isRuntimeError', () => {
   it('should return false if null', () => {
-    expect(isApplicationError(null)).toBe(false);
+    expect(isRuntimeError(null)).toBe(false);
   });
   it('should return false if undefined', () => {
-    expect(isApplicationError(undefined)).toBe(false);
+    expect(isRuntimeError(undefined)).toBe(false);
   });
-  it('should return false if object but not instance of ApplicationError', () => {
-    expect(isApplicationError({})).toBe(false);
+  it('should return false if object but not instance of RuntimeError', () => {
+    expect(isRuntimeError({})).toBe(false);
   });
-  it('should return true if ApplicationError', () => {
-    expect(isApplicationError(new ApplicationError())).toBe(true);
+  it('should return true if RuntimeError', () => {
+    expect(isRuntimeError(new RuntimeError())).toBe(true);
   });
-  it('should return true if sub class of ApplicationError', () => {
-    expect(isApplicationError(new ApplicationErrorSubClass())).toBe(true);
+  it('should return true if sub class of RuntimeError', () => {
+    expect(isRuntimeError(new RuntimeErrorSubClass())).toBe(true);
   });
 });

--- a/example-app/SantokuApp/src/bases/core/errors/RuntimeError.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/RuntimeError.ts
@@ -7,13 +7,20 @@ export class RuntimeError extends ErrorWrapper {
   constructor(cause: unknown, errorCode?: string);
   constructor(message: string, errorCode?: string);
   constructor(message: string, cause: unknown, errorCode?: string);
-  constructor(messageOrCause?: unknown, cause?: unknown, errorCode?: string) {
+  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
     if (typeof messageOrCause === 'string') {
-      super(messageOrCause, cause);
-      this._errorCode = errorCode;
+      if (typeof causeOrErrorCode === 'string' && !errorCode) {
+        super(messageOrCause);
+        this._errorCode = causeOrErrorCode;
+      } else {
+        super(messageOrCause, causeOrErrorCode);
+        this._errorCode = errorCode;
+      }
     } else {
       super(messageOrCause);
-      this._errorCode = errorCode;
+      if (typeof causeOrErrorCode === 'string') {
+        this._errorCode = causeOrErrorCode;
+      }
     }
   }
 


### PR DESCRIPTION
## ✅ What's done

- [x] Fix errorCode are set correctly in all constructors

---

## Tests

- [x] Add test with jest

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

none
