### PR TITLE
🚨: Fix react-native-firebase-messaging mock

### DIFF
--- a/example-app/SantokuApp/jest/__mocks__/@react-native-firebase/messaging.ts
+++ b/example-app/SantokuApp/jest/__mocks__/@react-native-firebase/messaging.ts
@@ -31,7 +31,8 @@ const mock: Omit<
   subscribeToTopic: jest.fn(),
   unsubscribeFromTopic: jest.fn(),
   getDidOpenSettingsForNotification: jest.fn(),
-  setOpenSettingsForNotificationsHandler: jest.fn,
+  setOpenSettingsForNotificationsHandler: jest.fn(),
+  setDeliveryMetricsExportToBigQuery: jest.fn(),
 };
 
 // 複数のファイルでmessagingをimportしていた場合に、redefineされないようにモックが存在するか確認


### PR DESCRIPTION

## ✅ What's done

- [x] #874 implementation omission
  - Mock `setDeliberatelyMetricsExportToBigQuery` added to `@react-native-firebase/messaging`

## Other (messages to reviewers, concerns, etc.)

none
