### PR TITLE
📌: Exclude dependencies used in firebase from renovate management

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,9 +95,16 @@
       // React Native Firebaseの関連パッケージはまとめて更新するようにします
       groupName: 'React Native Firebase',
       matchPackagePrefixes: [
-        '@react-native-firebase/',
+        '@react-native-firebase/'
+      ],
+    },
+    {
+      // React Native FirebaseのConfig Pluginに依存するパッケージは、React Native Firebaseアップグレード後のPrebuildで更新するため対象外とします
+      groupName: 'Depends on Config Plugin of React Native Firebase',
+      enabled: false,
+      matchPackageNames: [
         'com.google.firebase:firebase-crashlytics-gradle',
-        'com.google.gms:google-services'
+        'com.google.gms:google-services',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,7 +95,9 @@
       // React Native Firebaseの関連パッケージはまとめて更新するようにします
       groupName: 'React Native Firebase',
       matchPackagePrefixes: [
-        '@react-native-firebase/'
+        '@react-native-firebase/',
+        'com.google.firebase:firebase-crashlytics-gradle',
+        'com.google.gms:google-services'
       ],
     },
     {


### PR DESCRIPTION
## ✅ What's done

- [x] The following libraries are managed by React Native Firebase's ConfigPlugin, so change to upgrade them at the same time as React Native Firebase.
  - `com.google.firebase:firebase-crashlytics-gradle`
  - `com.google.gms:google-services`

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## 関連
- close #1017

## Other (messages to reviewers, concerns, etc.)

none
