### PR TITLE
📌: Exclude expo-build-properties from renovate management

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,7 @@
         '@types/react-native',
         'babel-preset-expo',
         'expo',
+        'expo-build-properties',
         'expo-crypto',
         'expo-keep-awake',
         'expo-local-authentication',


### PR DESCRIPTION
## ✅ What's done

- [x] `expo-build-properties` is managed by Expo, so it is excluded from renovate management.

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## 関連
- close #1033
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1024
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/996
    - https://github.com/ws-4020/mobile-app-crib-notes/commit/f88238faf75a7d54d4896c18a9420bd21d51ff4d `Add proguard settings`


## Other (messages to reviewers, concerns, etc.)

none
