### PR TITLE
🧑‍💻: [SantokuApp] fs-extra ライブラリの型定義改善

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -109,6 +109,14 @@
       ],
     },
     {
+      // fs-extra: 型定義と一緒に更新するようにします
+      groupName: 'fs-extra',
+      matchPackageNames: [
+        '@types/fs-extra',
+        'fs-extra',
+      ],
+    },
+    {
       // Docusaurusの関連パッケージはまとめて更新するようにします
       groupName: 'Docusaurus',
       matchPackagePrefixes: [

--- a/example-app/SantokuApp/package-lock.json
+++ b/example-app/SantokuApp/package-lock.json
@@ -58,7 +58,7 @@
         "@babel/core": "^7.18.6",
         "@testing-library/jest-native": "^5.0.0",
         "@testing-library/react-native": "^10.0.0",
-        "@types/fs-extra": "^9.0.13",
+        "@types/fs-extra": "~8.1",
         "@types/jest": "<27.0.0",
         "@types/react": "~18.0.0",
         "@types/react-native": "~0.69.1",
@@ -7891,9 +7891,9 @@
       "dev": true
     },
     "node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
+      "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -37526,9 +37526,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
+      "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/example-app/SantokuApp/package-lock.json
+++ b/example-app/SantokuApp/package-lock.json
@@ -75,6 +75,7 @@
         "eslint-plugin-jest": "^27.0.0",
         "eslint-plugin-strict-dependencies": "^1.0.1",
         "expo-module-scripts": "^3.0.4",
+        "fs-extra": "^8.1.0",
         "jest": "^26.6.3",
         "jest-expo": "^46.0.0",
         "jest-junit": "^15.0.0",

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-jest": "^27.0.0",
     "eslint-plugin-strict-dependencies": "^1.0.1",
     "expo-module-scripts": "^3.0.4",
+    "fs-extra": "^8.1.0",
     "jest": "^26.6.3",
     "jest-expo": "^46.0.0",
     "jest-junit": "^15.0.0",

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -90,7 +90,7 @@
     "@babel/core": "^7.18.6",
     "@testing-library/jest-native": "^5.0.0",
     "@testing-library/react-native": "^10.0.0",
-    "@types/fs-extra": "^9.0.13",
+    "@types/fs-extra": "~8.1",
     "@types/jest": "<27.0.0",
     "@types/react": "~18.0.0",
     "@types/react-native": "~0.69.1",


### PR DESCRIPTION
## ✅ What's done
- `fs-extra` 依存を明示 (devDependencies)
- `@types/fs-extra` version を `fs-extra` version に揃える
- renovate では `fs-extra` を型定義と一緒に更新するようにグループ化

## ⏸ What's not done

- fs-extra の バージョンアップ

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests
`./example-app/SantokuApp` にて 
- [x] `npm run lint` を実行して正常終了
- [x] `npm run prebuild` 実行で `prebuild/` フォルダが更新(copy)される

## Other (messages to reviewers, concerns, etc.)

### 関連（詳細）
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1039#discussion_r1119524377



close https://github.com/ws-4020/mobile-app-crib-notes/pull/1039