### PR TITLE
♻️: Use Constants.expoConfig instead of Constants.manifest.

### DIFF
--- a/example-app/SantokuApp/jest/__mocks__/expo-constants.ts
+++ b/example-app/SantokuApp/jest/__mocks__/expo-constants.ts
@@ -2,10 +2,9 @@ import ExpoConstants from 'expo-constants';
 
 export const Constants: typeof ExpoConstants = {
   ...ExpoConstants,
-  manifest: {
+  expoConfig: {
     name: 'SantokuApp',
     slug: 'santokuApp',
-    bundleUrl: 'http://localhost',
     extra: {
       termsUrl: 'https://www.tis.co.jp/termsofuse/',
       santokuAppBackendUrl: 'http://localhost:9080',

--- a/example-app/SantokuApp/src/bases/core/configs/AppConfig.ts
+++ b/example-app/SantokuApp/src/bases/core/configs/AppConfig.ts
@@ -10,42 +10,42 @@ import {Platform} from 'react-native';
  * console.log(AppConfig.appNameHome);
  * ```
  *
- * {@link Constants.manifest.extra}.XXXで取得できる値が、型定義ではanyとなっています。
+ * {@link Constants.expoConfig.extra}.XXXで取得できる値が、型定義ではanyとなっています。
  * しかし、環境設定値はapp.config.xxx.jsに必ず適切な型で設定されている想定のため、type assertionしています。
  *
  * app.config.xxx.jsに環境設定値が設定されていない場合や、適切な型で設定されていない場合は、実行時にエラーとなります。
  */
 export abstract class AppConfig {
   static get termsUrl(): string {
-    return Constants.manifest?.extra?.termsUrl as string;
+    return Constants.expoConfig?.extra?.termsUrl as string;
   }
 
   static get santokuAppBackendUrl(): string {
-    const url = Constants.manifest?.extra?.santokuAppBackendUrl as string;
+    const url = Constants.expoConfig?.extra?.santokuAppBackendUrl as string;
     return Platform.OS === 'android' ? url.replace('localhost', '10.0.2.2') : url;
   }
 
   static get requestTimeout(): number | undefined {
-    const timeout = Constants.manifest?.extra?.requestTimeout as number;
+    const timeout = Constants.expoConfig?.extra?.requestTimeout as number;
     return isNaN(timeout) ? undefined : timeout;
   }
 
   static get storeUrl(): string | undefined {
     return Platform.select({
-      ios: Constants.manifest?.extra?.appStoreAppUrl as string,
-      android: Constants.manifest?.extra?.googlePlayAppUrl as string,
+      ios: Constants.expoConfig?.extra?.appStoreAppUrl as string,
+      android: Constants.expoConfig?.extra?.googlePlayAppUrl as string,
     });
   }
 
   static get mobileAppCribNotesWebsiteUrl(): string {
-    return Constants.manifest?.extra?.mobileAppCribNotesWebsiteUrl as string;
+    return Constants.expoConfig?.extra?.mobileAppCribNotesWebsiteUrl as string;
   }
 
   static get mobileAppCribNotesRepositoryUrl(): string {
-    return Constants.manifest?.extra?.mobileAppCribNotesRepositoryUrl as string;
+    return Constants.expoConfig?.extra?.mobileAppCribNotesRepositoryUrl as string;
   }
 
   static get mswEnabled(): boolean {
-    return Constants.manifest?.extra?.mswEnabled as boolean;
+    return Constants.expoConfig?.extra?.mswEnabled as boolean;
   }
 }

--- a/website/docs/react-native/santoku/development/build-configuration/app-constants.mdx
+++ b/website/docs/react-native/santoku/development/build-configuration/app-constants.mdx
@@ -26,18 +26,18 @@ module.exports = ({config}) => {
 };
 ```
 
-設定した値を取得するには、`expo-constants`をimportして、`Expo.Constants.manifest.extra`から取得します。
+設定した値を取得するには、`expo-constants`をimportして、`Expo.Constants.expoConfig.extra`から取得します。
 
 ```typescript title=AppConfig.ts
 import Constants from 'expo-constants';
 
 export abstract class AppConfig {
   static get termsUrl(): string {
-    return Constants.manifest?.extra?.termsUrl as string;
+    return Constants.expoConfig?.extra?.termsUrl as string;
   }
   
   static get santokuAppBackendUrl(): string {
-    const url = Constants.manifest?.extra?.santokuAppBackendUrl as string;
+    const url = Constants.expoConfig?.extra?.santokuAppBackendUrl as string;
     return Platform.OS === 'android' ? url.replace('localhost', '10.0.2.2') : url;
   }
   


### PR DESCRIPTION
## ✅ What's done

Corrected a bug that caused the manifest to be undefined when OTA updating.

The Expo document states the following.

Use Constants.expoConfig instead of Constants.manifest, which behaves more consistently across EAS Build and Update.
Constants.expoConfig object defined in app.json and app.config.js files. For both classic and modern manifests, whether they are embedded or remote.

see: https://docs.expo.dev/versions/v48.0.0/sdk/constants/#nativeconstants

※ Expo46 documentation does not include a detailed description, so 48 one is used.

- [x] Use Constants.expoConfig instead of Constants.manifest.

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] アプリケーションが正常に起動する
- [x] OTA Updateでアプリが更新された後にアプリケーションが正常に起動する

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [x] 動作確認に利用したデバイスにチェックをつけてください
- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
