### PR TITLE
🐛: @types/fs-extra の version 指定ミス修正

### DIFF
--- a/example-app/SantokuApp/package-lock.json
+++ b/example-app/SantokuApp/package-lock.json
@@ -58,7 +58,7 @@
         "@babel/core": "^7.18.6",
         "@testing-library/jest-native": "^5.0.0",
         "@testing-library/react-native": "^10.0.0",
-        "@types/fs-extra": "~8.1",
+        "@types/fs-extra": "^8.1.2",
         "@types/jest": "<27.0.0",
         "@types/react": "~18.0.0",
         "@types/react-native": "~0.69.1",

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -90,7 +90,7 @@
     "@babel/core": "^7.18.6",
     "@testing-library/jest-native": "^5.0.0",
     "@testing-library/react-native": "^10.0.0",
-    "@types/fs-extra": "~8.1",
+    "@types/fs-extra": "^8.1.2",
     "@types/jest": "<27.0.0",
     "@types/react": "~18.0.0",
     "@types/react-native": "~0.69.1",


### PR DESCRIPTION
fs-extraのversion指定と^/~ は揃えておかないと Lock file maintenance by renovate でずれる可能性があった

## ✅ What's done

- [x] `npm install --save-dev @types/fs-extra@^8.1`

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

```
$ git grep 'fs-extra"' package.json
package.json:    "@types/fs-extra": "^8.1.2",
package.json:    "fs-extra": "^8.1.0",
```

### 関連PR
- きっかけ: https://github.com/ws-4020/mobile-app-crib-notes/pull/1043#discussion_r1119765874
- 後続のPR: https://github.com/ws-4020/mobile-app-crib-notes/pull/1045
  - このPR (1048) が merge された後に 1045 を rebase 推奨