### PR TITLE
🐛: 質問詳細画面_ニックネームが長い場合、コメントの経過時間が画面に収まるように修正

### DIFF
--- a/example-app/SantokuApp/src/features/qa-question/components/CommentCard.tsx
+++ b/example-app/SantokuApp/src/features/qa-question/components/CommentCard.tsx
@@ -23,7 +23,7 @@ export const CommentCard: FC<CommentCardProps> = ({content, likes, profile, date
         <Text variant="font13Regular" lineHeight={19} letterSpacing={0.25}>
           {content}
         </Text>
-        <StyledRow flex={1} justifyContent="space-between">
+        <StyledRow flex={1} justifyContent="space-between" flexWrap="wrap">
           <Text variant="font13Regular" lineHeight={24} letterSpacing={0.15} textDecorationLine="underline">
             {profile?.nickname}
           </Text>


### PR DESCRIPTION
## ✅ What's done

- [x] nicknameと経過時間を囲むStyledRowにflexWrap属性を追加

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 16.2)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 6/Android 13)
  - [ ] 実機 (Pixel 3a/Android 11)

## Tests

- [x] `npm run test`コマンドの実行
- [x] スタイルが崩れていないことを打鍵で確認

## Other (messages to reviewers, concerns, etc.)

### ニックネームが長い場合

| 修正前 (Pixel 6/Android 13) | 修正後 (Pixel 6/Android 13) |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/223914562-f1a35e9f-bf8a-4cb3-952f-ea2ac1122335.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/223914585-26ecd4c9-d361-4729-a02a-00a7364dcf47.png" width="50%" /> |

### ニックネームが長くない（修正前でもスタイルが崩れるような長さでない）場合

| 修正前 (Pixel 6/Android 13) | 修正後 (Pixel 6/Android 13) |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/223914777-b57ef0c1-f7ae-4ed6-be87-c82cc357873d.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/223914788-b170f60a-0a88-4f53-991e-3e86728d5b59.png" width="50%" /> |
