### PR TITLE
🐛: home画面_スクロール時に質問ラベル行が固定表示されるように修正

### DIFF
--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -7,7 +7,6 @@
     "web": "expo start --web",
     "start": "expo start --dev-client",
     "test": "jest --detectOpenHandles --runInBand",
-    "test2": "jest --updateSnapshot",
     "prebuild": "run-s build:plugin && cross-env ENVIRONMENT=local expo prebuild --clean --no-install",
     "prebuild:stg": "run-s build:plugin && cross-env ENVIRONMENT=stg expo prebuild --clean --no-install",
     "prebuild:prod": "run-s build:plugin && cross-env ENVIRONMENT=prod expo prebuild --clean --no-install",

--- a/example-app/SantokuApp/package.json
+++ b/example-app/SantokuApp/package.json
@@ -7,6 +7,7 @@
     "web": "expo start --web",
     "start": "expo start --dev-client",
     "test": "jest --detectOpenHandles --runInBand",
+    "test2": "jest --updateSnapshot",
     "prebuild": "run-s build:plugin && cross-env ENVIRONMENT=local expo prebuild --clean --no-install",
     "prebuild:stg": "run-s build:plugin && cross-env ENVIRONMENT=stg expo prebuild --clean --no-install",
     "prebuild:prod": "run-s build:plugin && cross-env ENVIRONMENT=prod expo prebuild --clean --no-install",

--- a/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
+++ b/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
@@ -896,14 +896,48 @@ XXRが全くわからない方
                                                                   ]
                                                                 }
                                                               />
+                                                              <StyledRow
+                                                                alignItems="center"
+                                                                justifyContent="space-between"
+                                                                px="p24"
+                                                                py="p32"
+                                                              >
+                                                                <ForwardRef
+                                                                  letterSpacing={0.18}
+                                                                  lineHeight={24}
+                                                                  variant="font20Bold"
+                                                                >
+                                                                  質問
+                                                                </ForwardRef>
+                                                                <StyledRow
+                                                                  alignItems="center"
+                                                                  space="p32"
+                                                                >
+                                                                  <ForwardRef
+                                                                    onPress={[Function]}
+                                                                  >
+                                                                    <SortIllustration
+                                                                      color="black"
+                                                                    />
+                                                                  </ForwardRef>
+                                                                  <ForwardRef
+                                                                    onPress={[Function]}
+                                                                  >
+                                                                    <FilterAltIllustration />
+                                                                  </ForwardRef>
+                                                                  <ForwardRef
+                                                                    onPress={[Function]}
+                                                                  >
+                                                                    <LocalOfferIllustration
+                                                                      color="black"
+                                                                    />
+                                                                  </ForwardRef>
+                                                                </StyledRow>
+                                                              </StyledRow>
                                                             </React.Fragment>
                                                           }
                                                           data={
                                                             Array [
-                                                              Object {
-                                                                "navigateToQuestionDetail": [Function],
-                                                                "question": Object {},
-                                                              },
                                                               Object {
                                                                 "navigateToQuestionDetail": [Function],
                                                                 "question": Object {
@@ -1186,11 +1220,7 @@ React Native 0.66
                                                           renderItem={[Function]}
                                                           scrollEventThrottle={50}
                                                           showsVerticalScrollIndicator={false}
-                                                          stickyHeaderIndices={
-                                                            Array [
-                                                              1,
-                                                            ]
-                                                          }
+                                                          stickyHeaderIndices={Array []}
                                                           style={
                                                             Array [
                                                               Object {},
@@ -1905,22 +1935,15 @@ React Native 0.66
                                                                   />
                                                                 </View>
                                                               </RCTScrollView>
-                                                            </View>
-                                                            <View
-                                                              onLayout={[Function]}
-                                                              style={null}
-                                                            >
                                                               <View
                                                                 style={
                                                                   Array [
                                                                     Object {
                                                                       "alignItems": "center",
-                                                                      "backgroundColor": "#FFF5E4",
                                                                       "flexDirection": "row",
                                                                       "justifyContent": "space-between",
-                                                                      "paddingBottom": 16,
                                                                       "paddingHorizontal": 24,
-                                                                      "paddingTop": 32,
+                                                                      "paddingVertical": 32,
                                                                     },
                                                                   ]
                                                                 }
@@ -2183,15 +2206,6 @@ React Native 0.66
                                                                   </View>
                                                                 </View>
                                                               </View>
-                                                              <View
-                                                                style={
-                                                                  Array [
-                                                                    Object {
-                                                                      "paddingTop": 16,
-                                                                    },
-                                                                  ]
-                                                                }
-                                                              />
                                                             </View>
                                                             <View
                                                               onLayout={[Function]}

--- a/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
+++ b/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
@@ -896,48 +896,14 @@ XXRが全くわからない方
                                                                   ]
                                                                 }
                                                               />
-                                                              <StyledRow
-                                                                alignItems="center"
-                                                                justifyContent="space-between"
-                                                                px="p24"
-                                                                py="p32"
-                                                              >
-                                                                <ForwardRef
-                                                                  letterSpacing={0.18}
-                                                                  lineHeight={24}
-                                                                  variant="font20Bold"
-                                                                >
-                                                                  質問
-                                                                </ForwardRef>
-                                                                <StyledRow
-                                                                  alignItems="center"
-                                                                  space="p32"
-                                                                >
-                                                                  <ForwardRef
-                                                                    onPress={[Function]}
-                                                                  >
-                                                                    <SortIllustration
-                                                                      color="black"
-                                                                    />
-                                                                  </ForwardRef>
-                                                                  <ForwardRef
-                                                                    onPress={[Function]}
-                                                                  >
-                                                                    <FilterAltIllustration />
-                                                                  </ForwardRef>
-                                                                  <ForwardRef
-                                                                    onPress={[Function]}
-                                                                  >
-                                                                    <LocalOfferIllustration
-                                                                      color="black"
-                                                                    />
-                                                                  </ForwardRef>
-                                                                </StyledRow>
-                                                              </StyledRow>
                                                             </React.Fragment>
                                                           }
                                                           data={
                                                             Array [
+                                                              Object {
+                                                                "navigateToQuestionDetail": [Function],
+                                                                "question": Object {},
+                                                              },
                                                               Object {
                                                                 "navigateToQuestionDetail": [Function],
                                                                 "question": Object {
@@ -1220,7 +1186,11 @@ React Native 0.66
                                                           renderItem={[Function]}
                                                           scrollEventThrottle={50}
                                                           showsVerticalScrollIndicator={false}
-                                                          stickyHeaderIndices={Array []}
+                                                          stickyHeaderIndices={
+                                                            Array [
+                                                              1,
+                                                            ]
+                                                          }
                                                           style={
                                                             Array [
                                                               Object {},
@@ -1935,15 +1905,22 @@ React Native 0.66
                                                                   />
                                                                 </View>
                                                               </RCTScrollView>
+                                                            </View>
+                                                            <View
+                                                              onLayout={[Function]}
+                                                              style={null}
+                                                            >
                                                               <View
                                                                 style={
                                                                   Array [
                                                                     Object {
                                                                       "alignItems": "center",
+                                                                      "backgroundColor": "#FFF5E4",
                                                                       "flexDirection": "row",
                                                                       "justifyContent": "space-between",
+                                                                      "paddingBottom": 16,
                                                                       "paddingHorizontal": 24,
-                                                                      "paddingVertical": 32,
+                                                                      "paddingTop": 32,
                                                                     },
                                                                   ]
                                                                 }
@@ -2206,6 +2183,15 @@ React Native 0.66
                                                                   </View>
                                                                 </View>
                                                               </View>
+                                                              <View
+                                                                style={
+                                                                  Array [
+                                                                    Object {
+                                                                      "paddingTop": 16,
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              />
                                                             </View>
                                                             <View
                                                               onLayout={[Function]}

--- a/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
+++ b/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
@@ -160,10 +160,10 @@ export const HomePage: React.FC<HomePageProps> = ({
   const flatListRef = useRef<FlatList>(null);
   const scrollToTop = useCallback(() => flatListRef.current?.scrollToOffset({offset: 0, animated: true}), []);
 
-  const questionItems = useMemo(
-    () => questions?.map(addOnPressHandlerToQuestions(navigateToQuestionDetail)),
-    [questions, navigateToQuestionDetail],
-  );
+  // 質問一覧先頭にラベルを表示するためにのダミーオブジェクトを挿入する
+  const questionItems = useMemo(() => {
+    return [...[{} as Question], ...(questions ?? [])].map(addOnPressHandlerToQuestions(navigateToQuestionDetail));
+  }, [questions, navigateToQuestionDetail]);
 
   return (
     <Box flex={1} testID="HomePage">
@@ -172,6 +172,7 @@ export const HomePage: React.FC<HomePageProps> = ({
         showsVerticalScrollIndicator={false}
         refreshing={isPullToRefreshing}
         onRefresh={pullToRefresh}
+        stickyHeaderIndices={[1]}
         ListHeaderComponent={
           <>
             <Box px="p24" py="p32">
@@ -180,26 +181,32 @@ export const HomePage: React.FC<HomePageProps> = ({
               </Text>
             </Box>
             {!isEventsLoading && <EventList data={events} />}
-            <StyledRow px="p24" py="p32" justifyContent="space-between" alignItems="center">
-              <Text variant="font20Bold" lineHeight={24} letterSpacing={0.18}>
-                {m('質問')}
-              </Text>
-              <StyledRow space="p32" alignItems="center">
-                <StyledTouchableOpacity onPress={setVisibleSortSheet}>
-                  <SortIllustration color={sortIconColor} />
-                </StyledTouchableOpacity>
-                <StyledTouchableOpacity onPress={showUnderDevelopment}>
-                  <FilterAltIllustration />
-                </StyledTouchableOpacity>
-                <StyledTouchableOpacity onPress={setVisibleTagSheet}>
-                  <LocalOfferIllustration color={tagIconColor} />
-                </StyledTouchableOpacity>
-              </StyledRow>
-            </StyledRow>
           </>
         }
         data={questionItems}
-        renderItem={QuestionListCard}
+        renderItem={listRenderItemInfo => {
+          if (listRenderItemInfo.item === questionItems[0]) {
+            return (
+              <StyledRow px="p24" py="p32" justifyContent="space-between" alignItems="center" backgroundColor="orange2">
+                <Text variant="font20Bold" lineHeight={24} letterSpacing={0.18}>
+                  {m('質問')}
+                </Text>
+                <StyledRow space="p32" alignItems="center">
+                  <StyledTouchableOpacity onPress={setVisibleSortSheet}>
+                    <SortIllustration color={sortIconColor} />
+                  </StyledTouchableOpacity>
+                  <StyledTouchableOpacity onPress={showUnderDevelopment}>
+                    <FilterAltIllustration />
+                  </StyledTouchableOpacity>
+                  <StyledTouchableOpacity onPress={setVisibleTagSheet}>
+                    <LocalOfferIllustration color={tagIconColor} />
+                  </StyledTouchableOpacity>
+                </StyledRow>
+              </StyledRow>
+            );
+          }
+          return QuestionListCard(listRenderItemInfo);
+        }}
         ItemSeparatorComponent={ListSeparator}
       />
       <Box position="absolute" right={8} bottom={32} flexDirection="column" justifyContent="center" alignItems="center">

--- a/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
+++ b/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
@@ -7,27 +7,24 @@ import {m} from 'bases/message/Message';
 import {Box, StyledTouchableOpacity, Text} from 'bases/ui/common';
 import {StyledActivityIndicator} from 'bases/ui/common/StyledActivityIndicator';
 import {StyledFlatList} from 'bases/ui/common/StyledFlatList';
-import {StyledRow} from 'bases/ui/common/StyledRow';
 import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {Fab} from 'bases/ui/fab/Fab';
 import {AddIllustration} from 'bases/ui/illustration/AddIllustration';
 import {ExpandLessIllustration} from 'bases/ui/illustration/ExpandLessIllustration';
-import {FilterAltIllustration} from 'bases/ui/illustration/FilterAltIllustration';
-import {LocalOfferIllustration} from 'bases/ui/illustration/LocalOfferIllustration';
 import {NotificationsIllustration} from 'bases/ui/illustration/NotificationsIllustration';
 import {SearchIllustration} from 'bases/ui/illustration/SearchIllustration';
 import {SettingsIllustration} from 'bases/ui/illustration/SettingsIllustration';
-import {SortIllustration} from 'bases/ui/illustration/SortIllustration';
 import {Snackbar} from 'bases/ui/snackbar/Snackbar';
 import {GetListQuestionsSort, Question} from 'features/backend/apis/model';
 import {EventList} from 'features/qa-event/components/EventList';
 import {QuestionListCard} from 'features/qa-question/components/QuestionListCard';
+import {QuestionListHeader} from 'features/qa-question/components/QuestionListHeader';
 import {SingleSelectableSortSheet} from 'features/qa-question/components/SingleSelectableSortSheet';
 import {SingleSelectableTagSheet} from 'features/qa-question/components/SingleSelectableTagSheet';
 import {useTags} from 'features/qa-question/services/useTags';
 import {useShowTermsAgreementOverlay} from 'features/terms/use-cases/useShowTermsAgreementOverlay';
 import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
-import {FlatList, Platform} from 'react-native';
+import {FlatList, ListRenderItemInfo, Platform} from 'react-native';
 
 import {useEventsAndQuestions} from '../services/useEventsAndQuestions';
 import {useRequestPermissionAndRegisterToken} from '../services/useRequestPermissionAndRegisterToken';
@@ -184,35 +181,28 @@ export const HomePage: React.FC<HomePageProps> = ({
           </>
         }
         data={questionItems}
-        renderItem={listRenderItemInfo => {
-          if (listRenderItemInfo.index === 0) {
-            return (
-              <StyledRow
-                px="p24"
-                pt="p32"
-                pb="p16"
-                justifyContent="space-between"
-                alignItems="center"
-                backgroundColor="orange2">
-                <Text variant="font20Bold" lineHeight={24} letterSpacing={0.18}>
-                  {m('質問')}
-                </Text>
-                <StyledRow space="p32" alignItems="center">
-                  <StyledTouchableOpacity onPress={setVisibleSortSheet}>
-                    <SortIllustration color={sortIconColor} />
-                  </StyledTouchableOpacity>
-                  <StyledTouchableOpacity onPress={showUnderDevelopment}>
-                    <FilterAltIllustration />
-                  </StyledTouchableOpacity>
-                  <StyledTouchableOpacity onPress={setVisibleTagSheet}>
-                    <LocalOfferIllustration color={tagIconColor} />
-                  </StyledTouchableOpacity>
-                </StyledRow>
-              </StyledRow>
-            );
-          }
-          return QuestionListCard(listRenderItemInfo);
-        }}
+        renderItem={useCallback(
+          (
+            listRenderItemInfo: ListRenderItemInfo<{
+              question: Question;
+              navigateToQuestionDetail: () => void;
+            }>,
+          ) => {
+            if (listRenderItemInfo.index === 0) {
+              return (
+                <QuestionListHeader
+                  setVisibleSortSheet={setVisibleSortSheet}
+                  sortIconColor={sortIconColor}
+                  setVisibleTagSheet={setVisibleTagSheet}
+                  tagIconColor={tagIconColor}
+                  showUnderDevelopment={showUnderDevelopment}
+                />
+              );
+            }
+            return <QuestionListCard {...listRenderItemInfo} />;
+          },
+          [setVisibleSortSheet, setVisibleTagSheet, sortIconColor, tagIconColor],
+        )}
         ItemSeparatorComponent={ListSeparator}
       />
       <Box position="absolute" right={8} bottom={32} flexDirection="column" justifyContent="center" alignItems="center">

--- a/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
+++ b/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
@@ -160,7 +160,7 @@ export const HomePage: React.FC<HomePageProps> = ({
   const flatListRef = useRef<FlatList>(null);
   const scrollToTop = useCallback(() => flatListRef.current?.scrollToOffset({offset: 0, animated: true}), []);
 
-  // 質問一覧先頭にラベルを表示するためにのダミーオブジェクトを挿入する
+  // 質問一覧先頭にラベルを表示するためのダミーオブジェクトを挿入する
   const questionItems = useMemo(() => {
     return [...[{} as Question], ...(questions ?? [])].map(addOnPressHandlerToQuestions(navigateToQuestionDetail));
   }, [questions, navigateToQuestionDetail]);

--- a/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
+++ b/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
@@ -187,7 +187,13 @@ export const HomePage: React.FC<HomePageProps> = ({
         renderItem={listRenderItemInfo => {
           if (listRenderItemInfo.item === questionItems[0]) {
             return (
-              <StyledRow px="p24" py="p32" justifyContent="space-between" alignItems="center" backgroundColor="orange2">
+              <StyledRow
+                px="p24"
+                pt="p32"
+                pb="p16"
+                justifyContent="space-between"
+                alignItems="center"
+                backgroundColor="orange2">
                 <Text variant="font20Bold" lineHeight={24} letterSpacing={0.18}>
                   {m('質問')}
                 </Text>

--- a/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
+++ b/example-app/SantokuApp/src/features/qa-home/pages/HomePage.tsx
@@ -185,7 +185,7 @@ export const HomePage: React.FC<HomePageProps> = ({
         }
         data={questionItems}
         renderItem={listRenderItemInfo => {
-          if (listRenderItemInfo.item === questionItems[0]) {
+          if (listRenderItemInfo.index === 0) {
             return (
               <StyledRow
                 px="p24"

--- a/example-app/SantokuApp/src/features/qa-home/pages/__snapshots__/HomePage.test.tsx.snap
+++ b/example-app/SantokuApp/src/features/qa-home/pages/__snapshots__/HomePage.test.tsx.snap
@@ -28,15 +28,45 @@ Array [
               募集中のイベント
             </ForwardRef>
           </ForwardRef>
+          <StyledRow
+            alignItems="center"
+            justifyContent="space-between"
+            px="p24"
+            py="p32"
+          >
+            <ForwardRef
+              letterSpacing={0.18}
+              lineHeight={24}
+              variant="font20Bold"
+            >
+              質問
+            </ForwardRef>
+            <StyledRow
+              alignItems="center"
+              space="p32"
+            >
+              <ForwardRef
+                onPress={[Function]}
+              >
+                <SortIllustration
+                  color="black"
+                />
+              </ForwardRef>
+              <ForwardRef
+                onPress={[Function]}
+              >
+                <FilterAltIllustration />
+              </ForwardRef>
+              <ForwardRef
+                onPress={[Function]}
+              >
+                <LocalOfferIllustration
+                  color="black"
+                />
+              </ForwardRef>
+            </StyledRow>
+          </StyledRow>
         </React.Fragment>
-      }
-      data={
-        Array [
-          Object {
-            "navigateToQuestionDetail": [Function],
-            "question": Object {},
-          },
-        ]
       }
       getItem={[Function]}
       getItemCount={[Function]}
@@ -60,11 +90,7 @@ Array [
       renderItem={[Function]}
       scrollEventThrottle={50}
       showsVerticalScrollIndicator={false}
-      stickyHeaderIndices={
-        Array [
-          1,
-        ]
-      }
+      stickyHeaderIndices={Array []}
       style={
         Array [
           Object {},
@@ -103,22 +129,15 @@ Array [
               募集中のイベント
             </Text>
           </View>
-        </View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
           <View
             style={
               Array [
                 Object {
                   "alignItems": "center",
-                  "backgroundColor": "#FFF5E4",
                   "flexDirection": "row",
                   "justifyContent": "space-between",
-                  "paddingBottom": 16,
                   "paddingHorizontal": 24,
-                  "paddingTop": 32,
+                  "paddingVertical": 32,
                 },
               ]
             }

--- a/example-app/SantokuApp/src/features/qa-home/pages/__snapshots__/HomePage.test.tsx.snap
+++ b/example-app/SantokuApp/src/features/qa-home/pages/__snapshots__/HomePage.test.tsx.snap
@@ -28,45 +28,15 @@ Array [
               募集中のイベント
             </ForwardRef>
           </ForwardRef>
-          <StyledRow
-            alignItems="center"
-            justifyContent="space-between"
-            px="p24"
-            py="p32"
-          >
-            <ForwardRef
-              letterSpacing={0.18}
-              lineHeight={24}
-              variant="font20Bold"
-            >
-              質問
-            </ForwardRef>
-            <StyledRow
-              alignItems="center"
-              space="p32"
-            >
-              <ForwardRef
-                onPress={[Function]}
-              >
-                <SortIllustration
-                  color="black"
-                />
-              </ForwardRef>
-              <ForwardRef
-                onPress={[Function]}
-              >
-                <FilterAltIllustration />
-              </ForwardRef>
-              <ForwardRef
-                onPress={[Function]}
-              >
-                <LocalOfferIllustration
-                  color="black"
-                />
-              </ForwardRef>
-            </StyledRow>
-          </StyledRow>
         </React.Fragment>
+      }
+      data={
+        Array [
+          Object {
+            "navigateToQuestionDetail": [Function],
+            "question": Object {},
+          },
+        ]
       }
       getItem={[Function]}
       getItemCount={[Function]}
@@ -90,7 +60,11 @@ Array [
       renderItem={[Function]}
       scrollEventThrottle={50}
       showsVerticalScrollIndicator={false}
-      stickyHeaderIndices={Array []}
+      stickyHeaderIndices={
+        Array [
+          1,
+        ]
+      }
       style={
         Array [
           Object {},
@@ -129,15 +103,22 @@ Array [
               募集中のイベント
             </Text>
           </View>
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
           <View
             style={
               Array [
                 Object {
                   "alignItems": "center",
+                  "backgroundColor": "#FFF5E4",
                   "flexDirection": "row",
                   "justifyContent": "space-between",
+                  "paddingBottom": 16,
                   "paddingHorizontal": 24,
-                  "paddingVertical": 32,
+                  "paddingTop": 32,
                 },
               ]
             }

--- a/example-app/SantokuApp/src/features/qa-question/components/QuestionListCard.tsx
+++ b/example-app/SantokuApp/src/features/qa-question/components/QuestionListCard.tsx
@@ -24,7 +24,7 @@ export type QuestionListCardProps = {
   };
 };
 
-export const QuestionListCard: FC<QuestionListCardProps> = ({
+const QuestionListCardComponent: FC<QuestionListCardProps> = ({
   item: {
     question: {title, content, likes, views, beginner, datetime, profile},
     navigateToQuestionDetail,
@@ -94,3 +94,5 @@ export const QuestionListCard: FC<QuestionListCardProps> = ({
     </Box>
   );
 };
+
+export const QuestionListCard = React.memo(QuestionListCardComponent);

--- a/example-app/SantokuApp/src/features/qa-question/components/QuestionListHeader.tsx
+++ b/example-app/SantokuApp/src/features/qa-question/components/QuestionListHeader.tsx
@@ -1,0 +1,44 @@
+import {m} from 'bases/message/Message';
+import {StyledTouchableOpacity, Text} from 'bases/ui/common';
+import {StyledRow} from 'bases/ui/common/StyledRow';
+import {FilterAltIllustration} from 'bases/ui/illustration/FilterAltIllustration';
+import {LocalOfferIllustration} from 'bases/ui/illustration/LocalOfferIllustration';
+import {SortIllustration} from 'bases/ui/illustration/SortIllustration';
+import React from 'react';
+
+type QuestionListHeaderProps = {
+  setVisibleSortSheet: () => false | void;
+  sortIconColor?: 'black' | 'blue';
+  setVisibleTagSheet?: () => false | void;
+  tagIconColor?: 'black' | 'blue';
+  showUnderDevelopment: () => void;
+};
+
+const QuestionListHeaderComponent: React.FC<QuestionListHeaderProps> = ({
+  setVisibleSortSheet,
+  sortIconColor,
+  setVisibleTagSheet,
+  tagIconColor,
+  showUnderDevelopment,
+}) => {
+  return (
+    <StyledRow px="p24" pt="p32" pb="p16" justifyContent="space-between" alignItems="center" backgroundColor="orange2">
+      <Text variant="font20Bold" lineHeight={24} letterSpacing={0.18}>
+        {m('質問')}
+      </Text>
+      <StyledRow space="p32" alignItems="center">
+        <StyledTouchableOpacity onPress={setVisibleSortSheet}>
+          <SortIllustration color={sortIconColor} />
+        </StyledTouchableOpacity>
+        <StyledTouchableOpacity onPress={showUnderDevelopment}>
+          <FilterAltIllustration />
+        </StyledTouchableOpacity>
+        <StyledTouchableOpacity onPress={setVisibleTagSheet}>
+          <LocalOfferIllustration color={tagIconColor} />
+        </StyledTouchableOpacity>
+      </StyledRow>
+    </StyledRow>
+  );
+};
+
+export const QuestionListHeader = React.memo(QuestionListHeaderComponent);


### PR DESCRIPTION
## ✅ What's done

- [x] 質問ラベルをFlatListのrenderItem内で表示して、スクロール時に固定されるように修正
- [x] スナップショットファイルの更新

## Tests

- [x] `npm run test`コマンドの実行
- [x] 固定表示されることを打鍵で確認

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 16.2)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 6/Android 13)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

### スクロール時 (修正後に質問ラベルが固定されている)

| 修正前 (Pixel 6/Android 13) | 修正後 (Pixel 6/Android 13) |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/224254740-32ee2797-cfc3-49e9-817a-1828c2630bb7.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/224254790-20847dec-d46a-4963-aa97-d1c75a60b4a3.png" width="50%" /> |

### 初期表示時 (スタイルにずれがない)

| 修正前 (Pixel 6/Android 13) | 修正後 (Pixel 6/Android 13) |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/224254839-18af5785-622d-4e76-b418-11f18e1bc1e6.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/224255060-a0c9e35a-1cd5-4cf0-a845-6bd997ffff68.png" width="50%" /> |



