### PR TITLE
📝: Update learn doc

### DIFF
--- a/website/docs/react-native/learn/getting-started/create-project.md
+++ b/website/docs/react-native/learn/getting-started/create-project.md
@@ -72,5 +72,4 @@ npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
 
 1. `cd <YourAppName>`（`<YourAppName>`は実際に作成したときの値に変更してください）
 2. `npm install --legacy-peer-deps`
-3. （macOSの場合のみ）`npm run pod-install`
 :::

--- a/website/docs/react-native/learn/getting-started/launch-created-app.mdx
+++ b/website/docs/react-native/learn/getting-started/launch-created-app.mdx
@@ -32,9 +32,15 @@ React Nativeアプリの実行方法と仕組みをかんたんに説明しま�
 ![Image](expo-build.png)
 
 Expo Goを利用する場合、ストア公開されているExpo Goアプリを端末にインストールして使用するため、アプリのビルドは不要です。
-Expo Goは、Expoで作られたアプリをビルドすることなく簡単に実機で動かすことができるアプリです。Expo SDKに含まれないネイティブモジュールを利用していなければ、[Bare Workflow](https://docs.expo.io/introduction/managed-vs-bare/#bare-workflow)のアプリでも実行できます。[App Store](https://apps.apple.com/jp/app/expo-go/id982107779), [Google Play](https://play.google.com/store/apps/details?id=host.exp.exponent)からインストールしてください。
+Expo Goは、Expoで作られたアプリをビルドすることなく簡単に実機で動かすことができるアプリです。Expo SDKに含まれないネイティブモジュールを利用していなければ、アプリを実行できます。[App Store](https://apps.apple.com/jp/app/expo-go/id982107779), [Google Play](https://play.google.com/store/apps/details?id=host.exp.exponent)からインストールしてください。
 
-Expo Goをインストールしたら、プロジェクトでExpoの開発サーバを起動します。
+Expo Goをインストールしたら、Expoの標準では提供されていないConfig Pluginをビルドします。
+
+```bash
+npm run build:plugin
+```
+
+Expoの開発サーバを起動します。
 
 ```bash
 npx expo start
@@ -78,7 +84,18 @@ Expo DevTools is running at http://localhost:19003
 
 ![Image](react-native-android-build.png)
 
-`npm run android` と実行するとMetro Bundlerが起動した後、アプリのビルドが始まります。
+はじめに、ネイティブプロジェクトを生成します。（iPhoneシミュレータの手順で既に生成している場合は不要です。）
+
+```bash
+npm run prebuild
+```
+
+Metro Bundlerの起動と、アプリのビルドをします。
+
+```bash
+npm run android
+```
+
 Androidアプリがビルドされ、エミュレータにインストールされます。
 
 その後、インストールされたアプリがMetro Bundlerを通してJava Scriptのソースを読み込み、実行します。
@@ -88,7 +105,37 @@ Androidアプリがビルドされ、エミュレータにインストールさ�
 
 ![Image](react-native-ios-build.png)
 
-`npm run ios` と実行するとMetro Bundlerが起動した後、アプリのビルドが始まります。
+はじめに、ネイティブプロジェクトを生成します。（Androidエミュレータの手順で既に生成している場合は不要です。）
+
+```bash
+npm run prebuild
+```
+
+:::info
+`npm run prebuild`を実行すると以下のような警告ログが出力されてしまいます。起動に影響はないので無視してください。
+
+```console
+Failed to copy PersonalAccount.xcconfig because PersonalAccount.xcconfig does not exist. Error: ENOENT: no such file or directory, stat '[PJのパス]/config/plugin/template/ios/[PJ名]/PersonalAccount.xcconfig'
+    at Object.statSync (node:fs:1583:3)
+〜〜 以下略 〜〜
+```
+
+ログの最後に「Config synced」が出力されていれば、問題ありません。
+
+:::
+
+Podsをインストールします。
+
+```bash
+npm run pod-install
+```
+
+Metro Bundlerの起動と、アプリのビルドをします。
+
+```bash
+npm run ios
+```
+
 iOSアプリがビルドされ、シミュレータにインストールされます。
 
 その後、インストールされたアプリがMetro Bundlerを通してJava Scriptのソースを読み込み、実行します。

--- a/website/docs/react-native/learn/getting-started/launch-created-app.mdx
+++ b/website/docs/react-native/learn/getting-started/launch-created-app.mdx
@@ -84,7 +84,7 @@ Expo DevTools is running at http://localhost:19003
 
 ![Image](react-native-android-build.png)
 
-はじめに、ネイティブプロジェクトを生成します。（iPhoneシミュレータの手順で既に生成している場合は不要です。）
+はじめに、ネイティブプロジェクトを生成します（iPhoneシミュレータの手順で既に生成している場合は不要です）。
 
 ```bash
 npm run prebuild
@@ -105,7 +105,7 @@ Androidアプリがビルドされ、エミュレータにインストールさ�
 
 ![Image](react-native-ios-build.png)
 
-はじめに、ネイティブプロジェクトを生成します。（Androidエミュレータの手順で既に生成している場合は不要です。）
+はじめに、ネイティブプロジェクトを生成します（Androidエミュレータの手順で既に生成している場合は不要です）。
 
 ```bash
 npm run prebuild

--- a/website/docs/react-native/learn/qa-app/app-project-desc.md
+++ b/website/docs/react-native/learn/qa-app/app-project-desc.md
@@ -14,6 +14,14 @@ hide_table_of_contents: true
 
 [プロジェクトの作成](/react-native/learn/getting-started/create-project)を参照し、新たに初期プロジェクトを作成してください。
 
+### ネイティブプロジェクトの生成
+
+次のコマンドを実行して、ネイティブプロジェクトを生成してください。
+
+```bash
+npm run prebuild
+```
+
 ### 使用ライブラリのインストール
 
 Q&Aアプリの作成には、次のライブラリを使用します。他に使用したいライブラリがあれば、適宜追加してください。


### PR DESCRIPTION
## ✅ What's done

- [x] [rn-spoilerのConfig Plugin対応](https://github.com/ws-4020/rn-spoiler/pull/125)に伴う学習コンテンツの修正

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] ドキュメントの内容に沿って環境構築（ToDoアプリが起動できるところまで）

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
