### PR TITLE
🐛: 質問詳細画面_最下部スクロール時にコメントアイコンを押下できない不具合を改善

### DIFF
--- a/example-app/SantokuApp/src/bases/ui/theme/restyleTheme.ts
+++ b/example-app/SantokuApp/src/bases/ui/theme/restyleTheme.ts
@@ -43,6 +43,7 @@ export const restyleTheme = createTheme({
     p32: 32,
     p48: 48,
     p64: 64,
+    p168: 168,
   },
   breakpoints: {
     // phone: 0,

--- a/example-app/SantokuApp/src/features/qa-question/pages/QuestionDetailPage.tsx
+++ b/example-app/SantokuApp/src/features/qa-question/pages/QuestionDetailPage.tsx
@@ -70,7 +70,7 @@ export const QuestionDetailPage: React.FC<QuestionDetailPageProps> = ({questionI
             );
           })}
         </StyledColumn>
-        <StyledSpace height="p64" />
+        <StyledSpace height="p168" />
       </StyledScrollView>
       <Box position="absolute" right={8} bottom={32} flexDirection="column" justifyContent="center" alignItems="center">
         {Platform.OS === 'android' && (


### PR DESCRIPTION
## ✅ What's done

- [x] 質問詳細画面下部にある余白のサイズを変更

## Tests

- [x] `npm run test`コマンドの実行
- [x] コメントアイコンを押下できることを打鍵で確認

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 16.2)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 6/Android 13)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)


| 修正前 (Pixel 6/Android 13) | 修正後 (Pixel 6/Android 13)  |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/224961603-86c16456-3ad3-4d1b-aed6-6928795efa93.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/224961808-55c4cb84-64f6-4f9b-a8a6-d1a6fe9f17c5.png" width="50%" /> |



