### PR TITLE
🐛: 質問詳細画面_戻るボタンがデザインと異なる不具合を改善

### DIFF
--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -4,11 +4,11 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {useTheme} from '@shopify/restyle';
 import {AppInitialData} from 'apps/app/types/AppInitialData';
 import {m} from 'bases/message/Message';
+import {Text} from 'bases/ui/common';
 import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
 import React, {useMemo, useCallback} from 'react';
 import {Platform} from 'react-native';
-import {Box, StyledTouchableOpacity, Text} from 'bases/ui/common';
 
 import {useMainTabNav} from './MainTabNav';
 import {QuestionAndEventPostStackNav} from './QuestionAndEventPostStackNav';
@@ -54,7 +54,9 @@ const Component: React.FC<Props> = ({initialData}) => {
               <>
                 <Ionicons name="arrow-back" size={24} color={theme.colors.white} onPress={goBack} />
                 <StyledSpace width="p32" />
-                <Text color='white' fontSize={20} fontWeight="500">{m('質問詳細')}</Text>
+                <Text color="white" fontSize={20} fontWeight="500">
+                  {m('質問詳細')}
+                </Text>
               </>
             ),
           }}

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -39,45 +39,30 @@ const Component: React.FC<Props> = ({initialData}) => {
           headerShown: false,
         }}
       />
-      {Platform.OS === 'ios' ? (
-        <nav.Screen
-          component={QuestionDetailScreen}
-          name="QuestionDetail"
-          options={({navigation}: {navigation: NativeStackNavigationProp<AuthenticatedStackParamList>}) => ({
-            title: '',
-            headerStyle: {backgroundColor: theme.colors.orange1},
-            contentStyle: {backgroundColor: theme.colors.orange2},
-            headerBackTitleVisible: false,
-            headerLeft: () => (
-              <>
-                <StyledColumn>
-                  <StyledSpace height="p4" />
-                  <StyledTouchableOpacity onPress={navigation.goBack}>
-                    <GoBackIllustration />
-                  </StyledTouchableOpacity>
-                </StyledColumn>
-                <StyledSpace width="p32" />
-                <Text color="white" fontSize={20} fontWeight="500">
-                  {m('質問詳細')}
-                </Text>
-              </>
-            ),
-          })}
-        />
-      ) : (
-        <nav.Screen
-          component={QuestionDetailScreen}
-          name="QuestionDetail"
-          options={{
-            title: m('質問詳細'),
-            headerStyle: {backgroundColor: theme.colors.orange1},
-            contentStyle: {backgroundColor: theme.colors.orange2},
-            headerTitleStyle: {fontSize: 20, fontWeight: '500'},
-            headerTintColor: theme.colors.white,
-            headerBackTitleVisible: false,
-          }}
-        />
-      )}
+      <nav.Screen
+        component={QuestionDetailScreen}
+        name="QuestionDetail"
+        options={({navigation}: {navigation: NativeStackNavigationProp<AuthenticatedStackParamList>}) => ({
+          title: '',
+          headerStyle: {backgroundColor: theme.colors.orange1},
+          contentStyle: {backgroundColor: theme.colors.orange2},
+          headerBackTitleVisible: false,
+          headerLeft: () => (
+            <>
+              <StyledColumn>
+                <StyledSpace height="p4" />
+                <StyledTouchableOpacity onPress={navigation.goBack}>
+                  <GoBackIllustration />
+                </StyledTouchableOpacity>
+              </StyledColumn>
+              <StyledSpace width="p32" />
+              <Text color="white" fontSize={20} fontWeight="500">
+                {m('質問詳細')}
+              </Text>
+            </>
+          ),
+        })}
+      />
       <nav.Screen
         name="QuestionAndEventStackNav"
         component={QuestionAndEventPostStackNav}

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -7,7 +7,7 @@ import {StyledColumn} from 'bases/ui/common/StyledColumn';
 import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {GoBackIllustration} from 'bases/ui/illustration/GoBackIllustration';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
-import React, {useCallback, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import {Platform} from 'react-native';
 
 import {useMainTabNav} from './MainTabNav';

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -1,13 +1,12 @@
 import {Ionicons} from '@expo/vector-icons';
-import {useNavigation} from '@react-navigation/native';
-import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {createNativeStackNavigator, NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useTheme} from '@shopify/restyle';
 import {AppInitialData} from 'apps/app/types/AppInitialData';
 import {m} from 'bases/message/Message';
 import {Text} from 'bases/ui/common';
 import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
-import React, {useMemo, useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {Platform} from 'react-native';
 
 import {useMainTabNav} from './MainTabNav';
@@ -26,8 +25,10 @@ type Props = {
   initialData: AppInitialData;
 };
 const Component: React.FC<Props> = ({initialData}) => {
-  const navigation = useNavigation();
-  const goBack = useCallback(() => navigation.goBack(), [navigation]);
+  const goBack = useCallback(
+    (navigation: NativeStackNavigationProp<AuthenticatedStackParamList>) => navigation.goBack(),
+    [],
+  );
   const initialRouteName = useMemo(() => getInitialRouteName(initialData), [initialData]);
   const mainTabNav = useMainTabNav(initialData);
   const theme = useTheme<RestyleTheme>();
@@ -45,21 +46,21 @@ const Component: React.FC<Props> = ({initialData}) => {
         <nav.Screen
           component={QuestionDetailScreen}
           name="QuestionDetail"
-          options={{
+          options={({navigation}: {navigation: NativeStackNavigationProp<AuthenticatedStackParamList>}) => ({
             title: '',
             headerStyle: {backgroundColor: theme.colors.orange1},
             contentStyle: {backgroundColor: theme.colors.orange2},
             headerBackTitleVisible: false,
             headerLeft: () => (
               <>
-                <Ionicons name="arrow-back" size={24} color={theme.colors.white} onPress={goBack} />
+                <Ionicons name="arrow-back" size={24} color={theme.colors.white} onPress={() => goBack(navigation)} />
                 <StyledSpace width="p32" />
                 <Text color="white" fontSize={20} fontWeight="500">
                   {m('質問詳細')}
                 </Text>
               </>
             ),
-          }}
+          })}
         />
       ) : (
         <nav.Screen

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -8,7 +8,6 @@ import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {GoBackIllustration} from 'bases/ui/illustration/GoBackIllustration';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
 import React, {useMemo} from 'react';
-import {Platform} from 'react-native';
 
 import {useMainTabNav} from './MainTabNav';
 import {QuestionAndEventPostStackNav} from './QuestionAndEventPostStackNav';

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -6,7 +6,7 @@ import {AppInitialData} from 'apps/app/types/AppInitialData';
 import {m} from 'bases/message/Message';
 import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
-import React, {useMemo} from 'react';
+import React, {useMemo, useCallback} from 'react';
 import {Platform} from 'react-native';
 
 import {useMainTabNav} from './MainTabNav';
@@ -26,6 +26,7 @@ type Props = {
 };
 const Component: React.FC<Props> = ({initialData}) => {
   const navigation = useNavigation();
+  const goBack = useCallback(() => navigation.goBack(), [navigation]);
   const initialRouteName = useMemo(() => getInitialRouteName(initialData), [initialData]);
   const mainTabNav = useMainTabNav(initialData);
   const theme = useTheme<RestyleTheme>();
@@ -52,14 +53,7 @@ const Component: React.FC<Props> = ({initialData}) => {
             headerBackTitleVisible: false,
             headerLeft: () => (
               <>
-                <Ionicons
-                  name="arrow-back"
-                  size={24}
-                  color={theme.colors.white}
-                  onPress={() => {
-                    navigation.goBack();
-                  }}
-                />
+                <Ionicons name="arrow-back" size={24} color={theme.colors.white} onPress={goBack} />
                 <StyledSpace width="p32" />
               </>
             ),

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -26,10 +26,6 @@ type Props = {
   initialData: AppInitialData;
 };
 const Component: React.FC<Props> = ({initialData}) => {
-  const goBack = useCallback(
-    (navigation: NativeStackNavigationProp<AuthenticatedStackParamList>) => navigation.goBack(),
-    [],
-  );
   const initialRouteName = useMemo(() => getInitialRouteName(initialData), [initialData]);
   const mainTabNav = useMainTabNav(initialData);
   const theme = useTheme<RestyleTheme>();
@@ -56,7 +52,7 @@ const Component: React.FC<Props> = ({initialData}) => {
               <>
                 <StyledColumn>
                   <StyledSpace height="p4" />
-                  <StyledTouchableOpacity onPress={() => goBack(navigation)}>
+                  <StyledTouchableOpacity onPress={navigation.goBack}>
                     <GoBackIllustration />
                   </StyledTouchableOpacity>
                 </StyledColumn>

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -1,10 +1,11 @@
-import {Ionicons} from '@expo/vector-icons';
 import {createNativeStackNavigator, NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useTheme} from '@shopify/restyle';
 import {AppInitialData} from 'apps/app/types/AppInitialData';
 import {m} from 'bases/message/Message';
-import {Text} from 'bases/ui/common';
+import {StyledTouchableOpacity, Text} from 'bases/ui/common';
+import {StyledColumn} from 'bases/ui/common/StyledColumn';
 import {StyledSpace} from 'bases/ui/common/StyledSpace';
+import {GoBackIllustration} from 'bases/ui/illustration/GoBackIllustration';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
 import React, {useCallback, useMemo} from 'react';
 import {Platform} from 'react-native';
@@ -53,7 +54,12 @@ const Component: React.FC<Props> = ({initialData}) => {
             headerBackTitleVisible: false,
             headerLeft: () => (
               <>
-                <Ionicons name="arrow-back" size={24} color={theme.colors.white} onPress={() => goBack(navigation)} />
+                <StyledColumn>
+                  <StyledSpace height="p4" />
+                  <StyledTouchableOpacity onPress={() => goBack(navigation)}>
+                    <GoBackIllustration />
+                  </StyledTouchableOpacity>
+                </StyledColumn>
                 <StyledSpace width="p32" />
                 <Text color="white" fontSize={20} fontWeight="500">
                   {m('質問詳細')}

--- a/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
+++ b/example-app/SantokuApp/src/apps/app/navigators/AuthenticatedStackNav.tsx
@@ -1,9 +1,13 @@
+import {Ionicons} from '@expo/vector-icons';
+import {useNavigation} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {useTheme} from '@shopify/restyle';
 import {AppInitialData} from 'apps/app/types/AppInitialData';
 import {m} from 'bases/message/Message';
+import {StyledSpace} from 'bases/ui/common/StyledSpace';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
 import React, {useMemo} from 'react';
+import {Platform} from 'react-native';
 
 import {useMainTabNav} from './MainTabNav';
 import {QuestionAndEventPostStackNav} from './QuestionAndEventPostStackNav';
@@ -21,6 +25,7 @@ type Props = {
   initialData: AppInitialData;
 };
 const Component: React.FC<Props> = ({initialData}) => {
+  const navigation = useNavigation();
   const initialRouteName = useMemo(() => getInitialRouteName(initialData), [initialData]);
   const mainTabNav = useMainTabNav(initialData);
   const theme = useTheme<RestyleTheme>();
@@ -34,18 +39,46 @@ const Component: React.FC<Props> = ({initialData}) => {
           headerShown: false,
         }}
       />
-      <nav.Screen
-        component={QuestionDetailScreen}
-        name="QuestionDetail"
-        options={{
-          title: m('質問詳細'),
-          headerStyle: {backgroundColor: theme.colors.orange1},
-          contentStyle: {backgroundColor: theme.colors.orange2},
-          headerTitleStyle: {fontSize: 20, fontWeight: '500'},
-          headerTintColor: theme.colors.white,
-          headerBackTitleVisible: false,
-        }}
-      />
+      {Platform.OS === 'ios' ? (
+        <nav.Screen
+          component={QuestionDetailScreen}
+          name="QuestionDetail"
+          options={{
+            title: m('質問詳細'),
+            headerStyle: {backgroundColor: theme.colors.orange1},
+            contentStyle: {backgroundColor: theme.colors.orange2},
+            headerTitleStyle: {fontSize: 20, fontWeight: '500'},
+            headerTintColor: theme.colors.white,
+            headerBackTitleVisible: false,
+            headerLeft: () => (
+              <>
+                <Ionicons
+                  name="arrow-back"
+                  size={24}
+                  color={theme.colors.white}
+                  onPress={() => {
+                    navigation.goBack();
+                  }}
+                />
+                <StyledSpace width="p32" />
+              </>
+            ),
+          }}
+        />
+      ) : (
+        <nav.Screen
+          component={QuestionDetailScreen}
+          name="QuestionDetail"
+          options={{
+            title: m('質問詳細'),
+            headerStyle: {backgroundColor: theme.colors.orange1},
+            contentStyle: {backgroundColor: theme.colors.orange2},
+            headerTitleStyle: {fontSize: 20, fontWeight: '500'},
+            headerTintColor: theme.colors.white,
+            headerBackTitleVisible: false,
+          }}
+        />
+      )}
       <nav.Screen
         name="QuestionAndEventStackNav"
         component={QuestionAndEventPostStackNav}

--- a/example-app/SantokuApp/src/bases/ui/illustration/GoBackIllustration.tsx
+++ b/example-app/SantokuApp/src/bases/ui/illustration/GoBackIllustration.tsx
@@ -1,0 +1,19 @@
+import {ColorProps, useResponsiveProp, useTheme} from '@shopify/restyle';
+import React from 'react';
+import {Path} from 'react-native-svg';
+
+import {StyledSvgIconBase, StyledSvgIconBaseProps} from '../common/StyledSvgIconBase';
+import {RestyleTheme} from '../theme/restyleTheme';
+
+export type GoBackIllustrationProps = StyledSvgIconBaseProps & ColorProps<RestyleTheme>;
+
+export const GoBackIllustration = ({color = 'white', size = 'p20', ...rest}: GoBackIllustrationProps) => {
+  const theme = useTheme<RestyleTheme>();
+  const responsiveColor = useResponsiveProp(color);
+  const fillColor = theme.colors[responsiveColor ?? 'white'];
+  return (
+    <StyledSvgIconBase size={size} viewBox="0 0 20 20" {...rest}>
+      <Path d="M7 14L8.41 12.59L3.83 8H20V6H3.83L8.42 1.41L7 0L0 7L7 14Z" fill={fillColor} />
+    </StyledSvgIconBase>
+  );
+};

--- a/example-app/SantokuApp/src/bases/ui/theme/restyleTheme.ts
+++ b/example-app/SantokuApp/src/bases/ui/theme/restyleTheme.ts
@@ -57,6 +57,10 @@ export const restyleTheme = createTheme({
       width: 18,
       height: 18,
     },
+    p20: {
+      width: 20,
+      height: 20,
+    },
     p24: {
       width: 24,
       height: 24,


### PR DESCRIPTION
## ✅ What's done

- [x] 戻るボタンのアイコンを変更
- [x] タイトルの表示位置を修正 

## Tests

- [x] `npm run test`コマンドの実行
- [x] 戻るボタンのデザインが同じであることを打鍵で確認

## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 16.2)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 6/Android 13)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

| 修正前 (iPhone 12/iOS 16.2) | 修正後 (iPhone 12/iOS 16.2)  |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/224966678-51c0e137-ca5d-4fa4-b179-cce5cd8045f2.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/227157346-b9ab41c2-1736-4af1-a8f2-18860b32cda3.png" width="50%" /> |


修正前後でスタイルが変わっていない
| 修正前 (Pixel 6/Android 13) | 修正後 (Pixel 6/Android 13)  |
|:-----------------------------:|:------------------------------:|
| <img src="https://user-images.githubusercontent.com/38860388/224965760-a5a56216-2ab4-4957-974e-e29fbb90900d.png" width="50%" /> | <img src="https://user-images.githubusercontent.com/38860388/224965814-b63a88d4-1cb1-4467-9076-f9e1130f972b.png" width="50%" /> |