### PR TITLE
🐛: 不具合_home画面_2枚目以降のイベントカセットが見切れていない

### DIFF
--- a/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
+++ b/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
@@ -1265,6 +1265,7 @@ React Native 0.66
                                                                 horizontal={true}
                                                                 pagingEnabled={true}
                                                                 showsHorizontalScrollIndicator={false}
+                                                                snapToAlignment="center"
                                                                 style={
                                                                   Array [
                                                                     Object {},
@@ -1272,6 +1273,15 @@ React Native 0.66
                                                                 }
                                                               >
                                                                 <View>
+                                                                  <View
+                                                                    style={
+                                                                      Array [
+                                                                        Object {
+                                                                          "paddingLeft": 16,
+                                                                        },
+                                                                      ]
+                                                                    }
+                                                                  />
                                                                   <View
                                                                     style={
                                                                       Array [
@@ -1285,7 +1295,7 @@ React Native 0.66
                                                                       style={
                                                                         Array [
                                                                           Object {
-                                                                            "paddingLeft": 24,
+                                                                            "paddingLeft": 8,
                                                                           },
                                                                         ]
                                                                       }
@@ -1566,7 +1576,7 @@ React Native 0.66
                                                                       style={
                                                                         Array [
                                                                           Object {
-                                                                            "paddingLeft": 24,
+                                                                            "paddingLeft": 8,
                                                                           },
                                                                         ]
                                                                       }
@@ -1585,7 +1595,7 @@ React Native 0.66
                                                                       style={
                                                                         Array [
                                                                           Object {
-                                                                            "paddingLeft": 24,
+                                                                            "paddingLeft": 8,
                                                                           },
                                                                         ]
                                                                       }
@@ -1866,7 +1876,7 @@ React Native 0.66
                                                                       style={
                                                                         Array [
                                                                           Object {
-                                                                            "paddingLeft": 24,
+                                                                            "paddingLeft": 8,
                                                                           },
                                                                         ]
                                                                       }
@@ -1876,7 +1886,7 @@ React Native 0.66
                                                                     style={
                                                                       Array [
                                                                         Object {
-                                                                          "paddingLeft": 24,
+                                                                          "paddingLeft": 8,
                                                                         },
                                                                       ]
                                                                     }
@@ -1930,7 +1940,7 @@ React Native 0.66
                                                                     style={
                                                                       Array [
                                                                         Object {
-                                                                          "paddingLeft": 24,
+                                                                          "paddingLeft": 8,
                                                                         },
                                                                       ]
                                                                     }

--- a/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
+++ b/example-app/SantokuApp/src/apps/app/__snapshots__/App.test.tsx.snap
@@ -1265,7 +1265,7 @@ React Native 0.66
                                                                 horizontal={true}
                                                                 pagingEnabled={true}
                                                                 showsHorizontalScrollIndicator={false}
-                                                                snapToAlignment="center"
+                                                                snapToInterval={288}
                                                                 style={
                                                                   Array [
                                                                     Object {},

--- a/example-app/SantokuApp/src/features/qa-event/components/EventList.tsx
+++ b/example-app/SantokuApp/src/features/qa-event/components/EventList.tsx
@@ -20,15 +20,16 @@ export const EventList: React.FC<EventListProps> = ({data}) => {
   const theme = useTheme<RestyleTheme>();
   const {width: windowWidth} = useSafeAreaFrame();
   return (
-    <StyledScrollView horizontal showsHorizontalScrollIndicator={false} pagingEnabled>
+    <StyledScrollView horizontal showsHorizontalScrollIndicator={false} snapToAlignment="center" pagingEnabled>
+      <StyledSpace width="p16" />
       {data?.map(item => (
         <StyledRow key={item.eventId}>
-          <StyledSpace width="p24" />
+          <StyledSpace width="p8" />
           <EventListCard event={item} />
-          <StyledSpace width="p24" />
+          <StyledSpace width="p8" />
         </StyledRow>
       ))}
-      <StyledSpace width="p24" />
+      <StyledSpace width="p8" />
       <Box width={windowWidth - theme.spacing.p24 * 2} justifyContent="center" alignItems="center">
         <StyledTouchableOpacity onPress={showUnderDevelopment}>
           <Text variant="font14Bold" lineHeight={20} letterSpacing={0.25} color="blue">
@@ -36,7 +37,7 @@ export const EventList: React.FC<EventListProps> = ({data}) => {
           </Text>
         </StyledTouchableOpacity>
       </Box>
-      <StyledSpace width="p24" />
+      <StyledSpace width="p8" />
     </StyledScrollView>
   );
 };

--- a/example-app/SantokuApp/src/features/qa-event/components/EventList.tsx
+++ b/example-app/SantokuApp/src/features/qa-event/components/EventList.tsx
@@ -7,6 +7,7 @@ import {Snackbar} from 'bases/ui/snackbar/Snackbar';
 import {RestyleTheme} from 'bases/ui/theme/restyleTheme';
 import {Event} from 'features/backend/apis/model';
 import React from 'react';
+import {Platform} from 'react-native';
 import {useSafeAreaFrame} from 'react-native-safe-area-context';
 
 import {EventListCard} from './EventListCard';
@@ -19,8 +20,14 @@ export type EventListProps = {
 export const EventList: React.FC<EventListProps> = ({data}) => {
   const theme = useTheme<RestyleTheme>();
   const {width: windowWidth} = useSafeAreaFrame();
+
   return (
-    <StyledScrollView horizontal showsHorizontalScrollIndicator={false} snapToAlignment="center" pagingEnabled>
+    <StyledScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      snapToInterval={Platform.select({ios: windowWidth - 32})}
+      snapToAlignment={Platform.select({android: 'center'})}
+      pagingEnabled>
       <StyledSpace width="p16" />
       {data?.map(item => (
         <StyledRow key={item.eventId}>


### PR DESCRIPTION
## ✅ What's done

- [x] イベントカードの位置調整

## Tests

- [x] `npm run test`コマンドの実行
- [x] イベントカセットが見切れていることを打鍵テストで確認
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 12/iOS 16.2)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 6/Android 13)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)
**方針**
常にイベントカセットが見切れるようにするため、初期表示時にイベントカセットが見切れるような`カセット幅`と`余白`を設定した上で、スナップ幅に`カセットの幅+左右の余白`を設定しようと考えました。

**やったこと**
方針に従い、snapToIntervalに`カセットの幅+左右の余白(windowWidth-32)`を設定したところiosでは、想定通りの表示がされました。
ただし、Androidでは連続してスワイプすると徐々にイベントカセットの表示位置にずれが生じてきました。
そこでAndroidでは、snapToAlignmentにcenterを設定して試したところ、スワイプしてもずれが生じなくなったため、snapToAlignmentにcenterを設定するようにしています。

**不明点**
- Androidでは連続してスワイプすると徐々にイベントカセットの表示位置にずれが生じてきたことの原因
    

画像は後ほど差し替え
| 修正前 (iPhone 12/iOS 16.2) | 修正後 (iPhone 12/iOS 16.2)  |
|:-----------------------------:|:------------------------------:|
| <img src="" width="50%" /> | <img src="" width="50%" /> |


