### PR TITLE
🧑‍💻: Git LFS 有効化(pptx)

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -105,6 +105,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          lfs: true
 
       # Cache '.npm' to speed up clean-install when package-lock.json is updated.
       # Loosened up the restore-keys a bit, as it doesn't have to match the contents of package-lock.json exactly.

--- a/website/.gitattributes
+++ b/website/.gitattributes
@@ -1,0 +1,2 @@
+# LFS
+*.pptx filter=lfs diff=lfs merge=lfs -text

--- a/website/README.md
+++ b/website/README.md
@@ -52,6 +52,25 @@ NGINX_PORT=3001 docker run -v $(pwd)/nginx:/etc/nginx/templates -v $(pwd)/build:
 npm run serve
 ```
 
+## Git Large File Storage (LFS)
+
+サイズの大きいバイナリファイルはGit LFSを使ってcommitしています。
+
+ローカルで以下対象ファイルを閲覧したり、追加する場合は以下の事前準備を実施してください。
+
+### 現在の対象ファイル
+
+- `pptx`
+
+### 事前準備
+
+1. [git-lfs](https://git-lfs.com/) のインストール
+1. ローカルリポジトリでのlfs有効化
+
+    ```sh
+    git lfs install
+    ```
+
 ## Lint
 
 ### 文章校正


### PR DESCRIPTION
## ✅ What's done
- [x] `pptx` ファイルを git LFS で管理するように変更
- [x] website の build 時に LFS を有効化

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
- `git diff` を `--binary` オプションありで実行しても lfs ファイルは `version https://git-lfs.github.com/spec/v1` から始まるtext差分を出します。これを apply patchできる形にするには `git lfs uninstall` が手軽です
- `actions/checkout` のドキュメント [actions/checkout: Action for checking out a repo](https://github.com/actions/checkout#usage)

>     # Whether to download Git-LFS files  
>     # Default: false  
>     lfs: ''  