### PR TITLE
Revert "🧑‍💻: Git LFS 有効化(pptx)"

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -105,7 +105,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          lfs: true
 
       # Cache '.npm' to speed up clean-install when package-lock.json is updated.
       # Loosened up the restore-keys a bit, as it doesn't have to match the contents of package-lock.json exactly.

--- a/website/.gitattributes
+++ b/website/.gitattributes
@@ -1,2 +1,0 @@
-# LFS
-*.pptx filter=lfs diff=lfs merge=lfs -text

--- a/website/README.md
+++ b/website/README.md
@@ -52,25 +52,6 @@ NGINX_PORT=3001 docker run -v $(pwd)/nginx:/etc/nginx/templates -v $(pwd)/build:
 npm run serve
 ```
 
-## Git Large File Storage (LFS)
-
-サイズの大きいバイナリファイルはGit LFSを使ってcommitしています。
-
-ローカルで以下対象ファイルを閲覧したり、追加する場合は以下の事前準備を実施してください。
-
-### 現在の対象ファイル
-
-- `pptx`
-
-### 事前準備
-
-1. [git-lfs](https://git-lfs.com/) のインストール
-1. ローカルリポジトリでのlfs有効化
-
-    ```sh
-    git lfs install
-    ```
-
 ## Lint
 
 ### 文章校正


### PR DESCRIPTION
fork されたリポジトリでは git LFS は使えませんでした

Reverts ws-4020/mobile-app-crib-notes#1097