### PR TITLE
📝: withAddPersonalAccountConfig -> withIosAddPersonalAccountConfig

### DIFF
--- a/website/docs/react-native/santoku/development/build-configuration/development-account-for-ios.mdx
+++ b/website/docs/react-native/santoku/development/build-configuration/development-account-for-ios.mdx
@@ -13,7 +13,7 @@ AppleはADP・ADEPライセンス利用に関して以下のようなルール�
 
 ## 開発者アカウントの設定
 
-Expoが標準で用意しているConfig Pluginsには、開発者アカウントを設定するための機能がありません。そのため、このアプリでは[withAddPersonalAccountConfig](./apply-plugins#アプリで独自に作成したconfig-plugins)というプラグインを作成しています。
+Expoが標準で用意しているConfig Pluginsには、開発者アカウントを設定するための機能がありません。そのため、このアプリでは[withIosAddPersonalAccountConfig](./apply-plugins#アプリで独自に作成したconfig-plugins)というプラグインを作成しています。
 
 開発者アカウントを設定する手順は以下になります。
 


### PR DESCRIPTION
## ✅ What's done

- plugin名のOS追加漏れに対応 (withAddPersonalAccountConfig)

## Other (messages to reviewers, concerns, etc.)
* 関連PR
  * https://github.com/ws-4020/mobile-app-crib-notes/pull/1028
  * https://github.com/ws-4020/mobile-app-crib-notes/pull/1072
* 他に `withAddPersonalAccountConfig` は残ってない

```
$ git grep withAddPersonalAccountConfig | wc
       0       0       0
```
```
$ git grep withAddPersonalAccountConfig origin/master 
origin/master:website/docs/react-native/santoku/development/build-configuration/development-account-for-ios.mdx:Expoが標準で用意しているConfig Pluginsには、開発者アカウントを設定するための機能がありません。そのため、このアプリでは[withAddPersonalAccountConfig](./apply-plugins#アプリで独自に作成したconfig-plugins)というプラグインを作成しています。
```
