### PR TITLE
📝: リンク先不正への対応

### DIFF
--- a/website/docs/react-native/santoku/application-architecture/http-api/http-api-error-handling.mdx
+++ b/website/docs/react-native/santoku/application-architecture/http-api/http-api-error-handling.mdx
@@ -84,7 +84,7 @@ SantokuAppのデフォルト動作ではリトライ処理を実施しません�
 
 以下に記載している方法で、各画面毎にユーザがHTTP APIを再試行可能なUI / UXを提供するようにしてください。
 
-- リソースを取得する場合は、[Pull-to-refresh](https://developer.apple.com/design/human-interface-guidelines/ios/controls/refresh-content-controls/)など、ユーザ操作で再取得を試みることができるUIを配置する
+- リソースを取得する場合は、Pull-to-refreshなど、ユーザ操作で再取得を試みることができるUIを配置する
 - リソースの登録や更新、削除を再試行できるように、非活性にしていたボタンなどを活性化させる
 - エラーメッセージを表示するスナックバーに、再試行可能なUIを配置する
 - 入力値をHTTP APIのリクエストとして送信する場合は、エラー発生前の状態を保持する

--- a/website/docs/react-native/santoku/requirements/non-functional/usability.mdx
+++ b/website/docs/react-native/santoku/requirements/non-functional/usability.mdx
@@ -222,7 +222,7 @@ AndroidではOSの設定からフォントサイズを変更した場合、原�
 ただしDynamic Typeに対応し、OSのフォントサイズ設定変更を無効化することはしません。
 またこれらのフォントサイズ設定の変更に対して特別なサポートは行いません。
 
-[dynamic-type]:https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/#dynamic-type-sizes
+[dynamic-type]:https://developer.apple.com/design/human-interface-guidelines/foundations/typography
 
 ### 側面ディスプレイ・折り畳みスマートフォン対応について
 


### PR DESCRIPTION
## ✅ What's done

- [x] Pull-to-refreshのリンクを削除
  - リンク先がなくなっており、リンク先がなくても困らない記事内容のため、リンクを削除しました
- [x] dynamic-typeのリンクを修正
  - [Specifications](https://developer.apple.com/design/human-interface-guidelines/foundations/typography#specifications)よりも[Typography](https://developer.apple.com/design/human-interface-guidelines/foundations/typography)のほうが記事としてわかりやすいため、そちらをリンク先として設定しました

## Tests
- [x] check on local
## Other (messages to reviewers, concerns, etc.)

なし