### PR TITLE
🐛: Fixed a bug that caused two image zooms to be displayed

### DIFF
--- a/website/src/plugins/medium-zoom-docusaurus-plugin/attach-medium-zoom.js
+++ b/website/src/plugins/medium-zoom-docusaurus-plugin/attach-medium-zoom.js
@@ -8,19 +8,8 @@ export default (function () {
   let zoomObject;
   const selector = '.markdown img';
 
-  setTimeout(() => {
-    if (zoomObject) {
-      zoomObject.detach();
-    }
-    zoomObject = mediumZoom(selector);
-  }, 100);
-
   return {
-    onRouteUpdate({location}) {
-      if (location && location.hash && location.hash.length) {
-        return;
-      }
-
+    onRouteUpdate() {
       setTimeout(() => {
         if (zoomObject) {
           zoomObject.detach();

--- a/website/src/plugins/medium-zoom-docusaurus-plugin/attach-medium-zoom.js
+++ b/website/src/plugins/medium-zoom-docusaurus-plugin/attach-medium-zoom.js
@@ -5,10 +5,14 @@ export default (function () {
     return null;
   }
 
+  let zoomObject;
   const selector = '.markdown img';
 
   setTimeout(() => {
-    mediumZoom(selector);
+    if (zoomObject) {
+      zoomObject.detach();
+    }
+    zoomObject = mediumZoom(selector);
   }, 100);
 
   return {
@@ -18,7 +22,10 @@ export default (function () {
       }
 
       setTimeout(() => {
-        mediumZoom(selector);
+        if (zoomObject) {
+          zoomObject.detach();
+        }
+        zoomObject = mediumZoom(selector);
       }, 100);
     },
   };


### PR DESCRIPTION
## ✅ What's done

- [x] Detach zoomObject if already attached.
- [x] I used this code as a reference. Dark mode not supported.
  - https://github.com/gabrielcsapo/docusaurus-plugin-image-zoom
- [x] Support the following onRouteUpdate lifecycle specification changes.
  - https://github.com/facebook/docusaurus/pull/6732
  - Not a public distributed plugin, so it does not support backward compatibility.

---

## Tests

- [x] check on local that two images are not displayed.

| before clicking image | after clicking image |
|--|--|
|<img width="812" alt="image" src="https://user-images.githubusercontent.com/1201990/231079387-f6b164cf-22a7-4d60-ae9e-e451cb5f2e50.png">|<img width="633" alt="image" src="https://user-images.githubusercontent.com/1201990/231079443-ede06c11-b0cb-4315-bac9-e2d748fafdf0.png">|

## Other (messages to reviewers, concerns, etc.)

NaN