### PR TITLE
📝 rn-spoilerがExpo SDK 47にアップグレードしたので、学習コンテンツのプロキシに関する注意事項を削除

### DIFF
--- a/website/docs/react-native/learn/getting-started/create-project.md
+++ b/website/docs/react-native/learn/getting-started/create-project.md
@@ -10,17 +10,6 @@ title: プロジェクトの作成
 
 次のコマンドを実行して、新規プロジェクトを作成してください。（`<YourAppName>`の部分は、好みのプロジェクト名に変更してください。このプロジェクトは後ほど[ToDoアプリの実装](../todo-app.md)で使用します）
 
-:::danger
-**この学習コンテンツはプロキシ環境下に対応していません。**
-
-おそらく次のPull Requestに関連する不具合と推測しております。
-
-- feat(cli): add proxy support（[https://github.com/expo/expo/pull/19592](https://github.com/expo/expo/pull/19592)）
-
-このPull RequestはExpo SDK 47で取り込まれております。Expo SDK 47以降においては、プロキシ環境下でも動作することを確認出来ております。
-しかし、現時点での[RN Spoiler](https://github.com/ws-4020/rn-spoiler)のExpo SDK対応バージョンは46のため、プロキシ環境下に対応出来ていません。
-:::
-
 :::note
 プロジェクト名には、ごく一部を除いて記号は利用できません。アルファベットから始まり、英数字のみで構成されたプロジェクト名とすることをおすすめします。
 :::


### PR DESCRIPTION
## ✅ What's done

- [x] Learn > Getting Started > プロジェクトの作成 に記載されているプロキシに関する注事項を削除

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

### 関連PR

- https://github.com/ws-4020/rn-spoiler/pull/132
