### PR TITLE
🧑‍💻: GitHub Action の check 名が website と SantokuApp どちらのものか分かりづらい問題に対処

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   lint-and-test:
-    name: Lints, Tests
+    name: (${{ github.workflow }}) Lints, Tests
     # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md
     runs-on: macos-12
     env:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   lint:
-    name: Lints
+    name: (${{ github.workflow }}) Lints
     # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md
     runs-on: macos-12
     env:
@@ -97,7 +97,7 @@ jobs:
           cd website && npm run -s lint:css | reviewdog -tee -fail-on-error -reporter=github-check -filter-mode=nofilter -f=stylelint -name="stylelint (GitHub Pages)"
 
   build:
-    name: Build
+    name: (${{ github.workflow }}) Build
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
## ✅ What's done

- GITHUB_WORKFLOW 環境変数を prefix につける

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->


## Other (messages to reviewers, concerns, etc.)
`GITHUB_WORKFLOW` 環境変数は `name` を参照する

### 参考
- [Variables - GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
- `git grep -h -E "^(    )?name" .github/`
```
name: SantokuApp
    name: (${{ github.workflow }}) Lints, Tests
name: DeleteDeployGateDistributionPages
    name: Delete DeployGate distribution pages
name: Deploy
    name: Deploy Pages
name: GitHub Pages
    name: (${{ github.workflow }}) Lints
    name: (${{ github.workflow }}) Build
name: Report
    name: Report
name: Triage
```

### 関連
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1105

<img width="811" alt="スクリーンショット 2023-04-14 18 17 41" src="https://user-images.githubusercontent.com/13145001/232002645-8fc60d4c-0a6c-4e9e-97f1-9dcf28d6cb38.png">

### 備考
merge されるまでは 冗長な表示になるみたい

<img width="860" alt="スクリーンショット 2023-04-14 18 18 26" src="https://user-images.githubusercontent.com/13145001/232002824-2f6bfffe-16fd-4298-8ec0-f505e7e478bf.png">
