### PR TITLE
⬆️: Upgrade Ruby to 3.1.4とCIのトリガー変更

### DIFF
--- a/.azure-pipelines/deploy-all.yaml
+++ b/.azure-pipelines/deploy-all.yaml
@@ -4,6 +4,7 @@ trigger:
       - 'master'
   paths:
     include:
+      - '.azure-pipelines/**'
       - 'example-app/SantokuApp'
     exclude:
       - 'example-app/SantokuApp/README.md'

--- a/.azure-pipelines/deploy-all.yaml
+++ b/.azure-pipelines/deploy-all.yaml
@@ -4,6 +4,7 @@ trigger:
       - 'master'
   paths:
     include:
+      - '.tool-versions'
       - '.azure-pipelines/**'
       - 'example-app/SantokuApp'
     exclude:

--- a/.azure-pipelines/deploy-all.yaml
+++ b/.azure-pipelines/deploy-all.yaml
@@ -16,6 +16,8 @@ pr:
       - '*'
   paths:
     include:
+      - '.tool-versions'
+      - '.azure-pipelines/**'
       - 'example-app/SantokuApp'
     exclude:
       - 'example-app/SantokuApp/README.md'

--- a/.azure-pipelines/deploy-stg.yaml
+++ b/.azure-pipelines/deploy-stg.yaml
@@ -6,6 +6,7 @@ pr:
       - '*'
   paths:
     include:
+      - '.azure-pipelines/**'
       - 'example-app/SantokuApp'
     exclude:
       - 'example-app/SantokuApp/README.md'

--- a/.azure-pipelines/deploy-stg.yaml
+++ b/.azure-pipelines/deploy-stg.yaml
@@ -6,6 +6,7 @@ pr:
       - '*'
   paths:
     include:
+      - '.tool-versions'
       - '.azure-pipelines/**'
       - 'example-app/SantokuApp'
     exclude:

--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -36,7 +36,7 @@ stages:
       steps:
       - task: UseRubyVersion@0
         inputs:
-          versionSpec: '3.1.3'
+          versionSpec: '3.1.4'
           addToPath: true
       - task: NodeTool@0
         displayName: 'Use Node.js 18.15.0'
@@ -133,7 +133,7 @@ stages:
       steps:
       - task: UseRubyVersion@0
         inputs:
-          versionSpec: '3.1.3'
+          versionSpec: '3.1.4'
           addToPath: true
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{environment.name}}'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 18.15.0
 java zulu-11.62.17
-ruby 3.1.3
+ruby 3.1.4


### PR DESCRIPTION
## ✅ What's done

- [x] CIで使用している[macOS](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)にインストールされているRubyが`3.1.3`から`3.1.4`に変更されたので、それに合わせてSantokuで使用するRubyのバージョンをアップグレード
- [x] `.azure-pipelines`内のファイルと`.tool-versions`が変更されてもCIが起動しなかった問題に対応

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `rm -rf .bundle/vendor/ && bundle install && npm run pod-install`

以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
4種全てのビルドバリアントを対象にする場合はdeploy-all、
特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。

- /azp run deploy-all
- /azp run deploy-devSantokuAppDebugAdvanced
- /azp run deploy-devSantokuAppReleaseInHouse
- /azp run deploy-santokuAppDebugAdvanced
- /azp run deploy-santokuAppReleaseInHouse

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

- `git grep -F "3.1.3" -- ":!**/package-lock.json" ":!**/santoku-app-backend/**" ":!*.svg" ":!*.png" .`を実行して該当箇所がないことを確認

