### PR TITLE
📝: GitHub PR template から古いビルドバリアントについての記述を削除

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,16 +34,10 @@
 - [ ] 作業着手前に列挙して TODO リストのようにも使用できます
 - [ ] やり終わったらチェックを付けてください
 
-以下のコマンドのいずれかをこのプルリクエストのコメントとして投稿すると、
+以下のコマンドをこのプルリクエストのコメントとして投稿すると、
 Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。
-4種全てのビルドバリアントを対象にする場合はdeploy-all、
-特定のビルドバリアントだけを対象にする場合はdeploy-ビルドバリアント名のコマンドを利用してください。
 
 - /azp run deploy-all
-- /azp run deploy-devSantokuAppDebugAdvanced
-- /azp run deploy-devSantokuAppReleaseInHouse
-- /azp run deploy-santokuAppDebugAdvanced
-- /azp run deploy-santokuAppReleaseInHouse
 
 <!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
 ## Devices


### PR DESCRIPTION
## ✅ What's done

- Azure Pipeline の起動コマンドの説明にビルドバリアントが含まれているが、もう使用していないので削除

## ⏸ What's not done

- `example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js` の更新

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 関連PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1024

### `What's not done` の script grep
```
$ git grep SantokuAppDebug
example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js:  'bundleDevSantokuAppDebug',
example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js:  'bundleDevSantokuAppDebugAdvanced',
example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js:  'bundleSantokuAppDebug',
example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js:  'bundleSantokuAppDebugAdvanced',
example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js:  ['devSantokuAppDebug', 'dev.debug'],
example-app/SantokuApp/.script/jobs/build-and-run-all-variants-macos.js:  ['devSantokuAppDebugAdvanced', 'dev.debugAdvanced'],
```
