### PR TITLE
🩹: Jestでテスト実施前のモッククリア方法を修正

### DIFF
--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -11,4 +11,6 @@ module.exports = {
     '<rootDir>/jest/setup/react-query.js',
     '<rootDir>/jest/setup/useFocusEffect.js',
   ],
+  // https://jestjs.io/ja/docs/configuration#clearmocks-boolean
+  clearMocks: true,
 };

--- a/example-app/SantokuApp/jest/__mocks__/@notifee/react-native.ts
+++ b/example-app/SantokuApp/jest/__mocks__/@notifee/react-native.ts
@@ -57,13 +57,4 @@ if (!__mocks.notifee) {
   Object.defineProperty(__mocks, 'notifee', {value: mock});
 }
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 export default mock;

--- a/example-app/SantokuApp/jest/__mocks__/@react-native-firebase/crashlytics.ts
+++ b/example-app/SantokuApp/jest/__mocks__/@react-native-firebase/crashlytics.ts
@@ -27,13 +27,4 @@ if (!__mocks.crashlytics) {
   Object.defineProperty(__mocks, 'crashlytics', {value: mock});
 }
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 export default () => mock;

--- a/example-app/SantokuApp/jest/__mocks__/@react-native-firebase/messaging.ts
+++ b/example-app/SantokuApp/jest/__mocks__/@react-native-firebase/messaging.ts
@@ -40,13 +40,4 @@ if (!__mocks.crashlytics) {
   Object.defineProperty(__mocks, 'messaging', {value: mock});
 }
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 export default () => mock;

--- a/example-app/SantokuApp/jest/__mocks__/@react-navigation/native.ts
+++ b/example-app/SantokuApp/jest/__mocks__/@react-navigation/native.ts
@@ -19,15 +19,6 @@ const mock: jest.Mocked<NavigationProp<ParamListBase>> = {
 
 Object.defineProperty(__mocks, 'navigation', {value: mock});
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 // @react-navigation/nativeのすべてのNamed Exportを列挙するのは大変なので、
 // ES6のexport/import形式ではなく、module.exportsを使ってexportする。
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/example-app/SantokuApp/jest/__mocks__/expo-splash-screen.ts
+++ b/example-app/SantokuApp/jest/__mocks__/expo-splash-screen.ts
@@ -14,13 +14,4 @@ const mock: jest.Mocked<typeof SplashScreen> = {
 
 Object.defineProperty(__mocks, 'expoSplashScreen', {value: mock});
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 export default mock;

--- a/example-app/SantokuApp/src/bases/logging/Logger.test.ts
+++ b/example-app/SantokuApp/src/bases/logging/Logger.test.ts
@@ -33,10 +33,6 @@ describe('Logger isLevelEnabled', () => {
   const mockWarn = jest.spyOn(transport, 'warn').mockImplementation();
   const mockError = jest.spyOn(transport, 'error').mockImplementation();
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   test('ログレベルをtraceにした場合の検証', () => {
     const log = new Logger({level: 'trace', transports: [transport]});
     logAllMethod(log);
@@ -123,10 +119,6 @@ describe('Logger transport message and errorCode', () => {
   const consoleTransport = new ConsoleTransport();
   const firebaseCrashlyticsTransport = new FirebaseCrashlyticsTransport();
   const mockFormat = jest.spyOn(formatter, 'format');
-
-  beforeAll(() => {
-    jest.clearAllMocks();
-  });
 
   test('traceレベルの場合にTransportにフォーマットされたメッセージを正しく渡しているかの検証', () => {
     const mockConsoleTrace = jest.spyOn(consoleTransport, 'trace').mockImplementation();

--- a/example-app/SantokuApp/src/features/account/services/auth/autoLogin.test.tsx
+++ b/example-app/SantokuApp/src/features/account/services/auth/autoLogin.test.tsx
@@ -27,13 +27,6 @@ describe('autoLogin', () => {
   const spySecureStorageAdapterLoadActiveAccountId = jest.spyOn(loadActiveAccountId, 'loadActiveAccountId');
   const spySecureStorageAdapterLoadPassword = jest.spyOn(loadPassword, 'loadPassword');
 
-  beforeEach(() => {
-    spyLoginApi.mockClear();
-    spyRefreshCsrfToken.mockClear();
-    spySecureStorageAdapterLoadActiveAccountId.mockClear();
-    spySecureStorageAdapterLoadPassword.mockClear();
-  });
-
   test('セキュアストレージからクレデンシャルを取得してログインAPIを呼び出しているかの検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue('password123');

--- a/example-app/SantokuApp/src/features/account/services/auth/canAutoLogin.test.ts
+++ b/example-app/SantokuApp/src/features/account/services/auth/canAutoLogin.test.ts
@@ -7,11 +7,6 @@ describe('canAutoLogin', () => {
   const spySecureStorageAdapterLoadActiveAccountId = jest.spyOn(loadActiveAccountId, 'loadActiveAccountId');
   const spySecureStorageAdapterLoadPassword = jest.spyOn(loadPassword, 'loadPassword');
 
-  beforeEach(() => {
-    spySecureStorageAdapterLoadActiveAccountId.mockClear();
-    spySecureStorageAdapterLoadPassword.mockClear();
-  });
-
   test('セキュアストレージからクレデンシャルを取得できる場合の検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     spySecureStorageAdapterLoadPassword.mockResolvedValue('password123');

--- a/example-app/SantokuApp/src/features/account/services/auth/changeAccount.test.tsx
+++ b/example-app/SantokuApp/src/features/account/services/auth/changeAccount.test.tsx
@@ -16,11 +16,6 @@ describe('changeAccount', () => {
   });
   const spyRefreshCsrfToken = jest.spyOn(csrfToken, 'refreshCsrfToken').mockImplementation();
 
-  beforeEach(() => {
-    spyLoginApi.mockClear();
-    spyRefreshCsrfToken.mockClear();
-  });
-
   test('セキュアストレージからパスワードを取得してログインAPIを呼び出しているかの検証', async () => {
     const spySecureStorageAdapter = jest.spyOn(loadPassword, 'loadPassword').mockResolvedValue('password123');
     const res = await changeAccount('123456789');

--- a/example-app/SantokuApp/src/features/account/services/auth/logout.test.tsx
+++ b/example-app/SantokuApp/src/features/account/services/auth/logout.test.tsx
@@ -20,13 +20,6 @@ describe('AuthenticationService logout', () => {
   const spySecureStorageAdapterDeleteActiveAccountId = jest.spyOn(deleteActiveAccountId, 'deleteActiveAccountId');
   const spySecureStorageAdapterDeletePassword = jest.spyOn(deletePassword, 'deletePassword');
 
-  beforeEach(() => {
-    spyLogoutApi.mockClear();
-    spyRefreshCsrfToken.mockClear();
-    spySecureStorageAdapterLoadActiveAccountId.mockClear();
-    spySecureStorageAdapterDeleteActiveAccountId.mockClear();
-    spySecureStorageAdapterDeletePassword.mockClear();
-  });
   test('ログアウトAPIを呼び出して、セキュアストレージからアクティブアカウントを削除しているかの検証', async () => {
     spySecureStorageAdapterLoadActiveAccountId.mockResolvedValue('123456789');
     // const {result} = renderHook(() => useLogout(), {wrapper});


### PR DESCRIPTION
## ✅ What's done

Expo SDK 48アップグレードの対応で、`App.test.tsx`を実行すると以下のエラーが発生

> Error: Hooks cannot be defined inside tests. Hook of type "beforeEach" is nested within

`jest/__mocks__`配下のモックファイルは、モックしているライブラリなどが`import`、`require`されたときに読み込まれます。
テスト対象のコンポーネントの内部で、条件によって`require`するライブラリを切り替えている箇所があり、それが原因でこのエラーが発生したと思われます。

そのため、`jest/__mocks__`配下のモックファイルでモックをクリアするのをやめて、`jest.config.js`の[clearMocks](https://jestjs.io/ja/docs/configuration#clearmocks-boolean)を有効化する方法で、テスト実施前にモックをクリアします。

- [x] `jest.config.js`の`clearMocks`を`true`に設定
- [x] テスト実施前に`beforeEach`や`beforeAll`でモックをクリアしていた箇所を削除
  - 対象は以下で確認
  - [x] `git grep mockClear`
  - [x] `git grep clearAllMocks`

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

### 関連

- https://github.com/ws-4020/mobile-app-crib-notes/pull/1118
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1118#discussion_r1175939353
