### PR TITLE
📌: Exclude ruby and cocoapods from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,18 @@
   ],
   packageRules: [
     {
+      // 開発ツールはexpo upgrade時に更新するためRenovateの対象外とします
+      groupName: 'Development tools',
+      enabled: false,
+      matchPackageNames: [
+        'node',
+        'java',
+        'ruby',
+        'cocoapods',
+        'fastlane',
+      ],
+    },
+    {
       // expo upgradeで更新されるパッケージはRenovateの対象外とします
       groupName: 'Expo upgrade',
       enabled: false,
@@ -73,8 +85,6 @@
         'de.undercouch:gradle-download-task',
         // @testing-library/react-native -> jest
         '@testing-library/react-native',
-        'ruby',
-        'cocoapods',
       ],
       matchPackagePrefixes: [
         'com.facebook.flipper',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,8 @@
         'de.undercouch:gradle-download-task',
         // @testing-library/react-native -> jest
         '@testing-library/react-native',
+        'ruby',
+        'cocoapods',
       ],
       matchPackagePrefixes: [
         'com.facebook.flipper',


### PR DESCRIPTION
## ✅ What's done

- [x] `ruby`と`cocoapods`はExpoアップグレード時にvupするので、Renovateの対象外とする

---

## Other (messages to reviewers, concerns, etc.)

参考までに、Expo SDK 48が使用しているバージョンを記載します。

* ruby: `2.7.2`
* cocoapods: `~> 1.11.2`

- https://github.com/expo/expo/blob/sdk-48/.ruby-version
- https://github.com/expo/expo/blob/sdk-48/Gemfile
