### PR TITLE
📌: Docusaurus関連のパッケージバージョン範囲をパッチに変更

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,7 @@
         "prism-react-renderer": "^1.3.3",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "redocusaurus": "~1.0.1"
+        "redocusaurus": "~1.6.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "~2.4.0",
@@ -3155,11 +3155,11 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.0.0-beta.97",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.97.tgz",
-      "integrity": "sha512-3WW9/6flosJuRtU3GI0Vw39OYFZqqXMDCp5TLa3EjXOb7Nm6AZTWRb3Y+I/+UdNJ/NTszVJkQczoa1t476ekiQ==",
+      "version": "1.0.0-beta.123",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.123.tgz",
+      "integrity": "sha512-W6MbUWpb/VaV+Kf0c3jmMIJw3WwwF7iK5nAfcOS+ZwrlbxtIl37+1hEydFlJ209vCR9HL12PaMwdh2Vpihj6Jw==",
       "dependencies": {
-        "@redocly/ajv": "^8.6.4",
+        "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -6972,36 +6972,38 @@
       }
     },
     "node_modules/docusaurus-plugin-redoc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.0.3.tgz",
-      "integrity": "sha512-pLYBkyqRIdDsUx6Q9gTKlNkHZpVXYxXptDwTIK+FwMfW7chfdRTLLjlZ1oSqCVjNlb0L/CT1rpSh78pNKE95KQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.6.0.tgz",
+      "integrity": "sha512-bvOmVcJ9Lo6ymyaHCoXTjN6Ck7/Dog1KRsJgZilB6ukHQ7d6nJrAwAEoDF1rXto8tOvIUqVb6Zzy7qDPvBQA1Q==",
       "dependencies": {
-        "@docusaurus/types": "^2.0.0-beta.20",
-        "@docusaurus/utils": "^2.0.0-beta.20",
-        "@redocly/openapi-core": "1.0.0-beta.97",
-        "joi": "^17.5.0",
-        "redoc": "2.0.0-rc.69"
+        "@redocly/openapi-core": "1.0.0-beta.123",
+        "redoc": "2.0.0"
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@docusaurus/utils": "^2.0.0"
       }
     },
     "node_modules/docusaurus-theme-redoc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.0.4.tgz",
-      "integrity": "sha512-RGMAMtaSgyxpF/+KyhABzaHYeCsVUC4p8wrpDeAK461u54xZlt7oVXsYeXeX6i6w0kSoFwczekoyb+C8mm0uZw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.6.2.tgz",
+      "integrity": "sha512-TECxcj6hUoE1aei21i6kTJHRcF7gdVwKyjZuaEMAPGvYhPO9gPvBXKeFQ0ZrZgQHrQSUMuS9tx+EZiTssNqJeA==",
       "dependencies": {
-        "@docusaurus/theme-common": "^2.0.0-beta.20",
-        "@docusaurus/types": "^2.0.0-beta.20",
-        "clsx": "^1.1.1",
+        "@redocly/openapi-core": "1.0.0-beta.123",
+        "clsx": "^1.2.1",
         "copyfiles": "^2.4.1",
         "lodash": "^4.17.21",
-        "mobx": "^6.5.0",
-        "redoc": "2.0.0-rc.69",
-        "styled-components": "^5.3.5"
+        "mobx": "^6.8.0",
+        "redoc": "2.0.0",
+        "styled-components": "^5.3.6"
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2.0.0"
       }
     },
     "node_modules/dom-converter": {
@@ -14081,11 +14083,11 @@
       }
     },
     "node_modules/redoc": {
-      "version": "2.0.0-rc.69",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.69.tgz",
-      "integrity": "sha512-AFedbb9h0I98z0lBF2hkkn3M09CsF/zXfRCd07vGL0fZg72/VFPAmHN7CyFRGg/whVEstZ2iUhN2jbN6MmTTDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0.tgz",
+      "integrity": "sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==",
       "dependencies": {
-        "@redocly/openapi-core": "^1.0.0-beta.97",
+        "@redocly/openapi-core": "^1.0.0-beta.104",
         "classnames": "^2.3.1",
         "decko": "^1.2.0",
         "dompurify": "^2.2.8",
@@ -14095,9 +14097,9 @@
         "mark.js": "^8.11.1",
         "marked": "^4.0.15",
         "mobx-react": "^7.2.0",
-        "openapi-sampler": "^1.2.3",
+        "openapi-sampler": "^1.3.0",
         "path-browserify": "^1.0.1",
-        "perfect-scrollbar": "^1.5.1",
+        "perfect-scrollbar": "^1.5.5",
         "polished": "^4.1.3",
         "prismjs": "^1.27.0",
         "prop-types": "^15.7.2",
@@ -14121,16 +14123,19 @@
       }
     },
     "node_modules/redocusaurus": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.0.4.tgz",
-      "integrity": "sha512-cF/UiOZUZjfvIpgC1RnzwePac4bmUA2JZzfgTw8Bn6i0AdYRe0+03c8RfgGMNCLtuJIvG97G9dB+vhnx8lA+iQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.6.2.tgz",
+      "integrity": "sha512-kAE2OTLvE8fz+tLCTpVDpI+rZIzx4XsP+zRf0q4UKN0f89zLptPogD2ps8zOnQOjvJW6sWFIQEM8JoJBOtnekw==",
       "dependencies": {
-        "@docusaurus/types": "^2.0.0-beta.20",
-        "docusaurus-plugin-redoc": "1.0.3",
-        "docusaurus-theme-redoc": "1.0.4"
+        "docusaurus-plugin-redoc": "1.6.0",
+        "docusaurus-theme-redoc": "1.6.2"
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2.0.0",
+        "@docusaurus/utils": "^2.0.0"
       }
     },
     "node_modules/reftools": {
@@ -21339,11 +21344,11 @@
       }
     },
     "@redocly/openapi-core": {
-      "version": "1.0.0-beta.97",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.97.tgz",
-      "integrity": "sha512-3WW9/6flosJuRtU3GI0Vw39OYFZqqXMDCp5TLa3EjXOb7Nm6AZTWRb3Y+I/+UdNJ/NTszVJkQczoa1t476ekiQ==",
+      "version": "1.0.0-beta.123",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.123.tgz",
+      "integrity": "sha512-W6MbUWpb/VaV+Kf0c3jmMIJw3WwwF7iK5nAfcOS+ZwrlbxtIl37+1hEydFlJ209vCR9HL12PaMwdh2Vpihj6Jw==",
       "requires": {
-        "@redocly/ajv": "^8.6.4",
+        "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -24263,30 +24268,26 @@
       }
     },
     "docusaurus-plugin-redoc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.0.3.tgz",
-      "integrity": "sha512-pLYBkyqRIdDsUx6Q9gTKlNkHZpVXYxXptDwTIK+FwMfW7chfdRTLLjlZ1oSqCVjNlb0L/CT1rpSh78pNKE95KQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.6.0.tgz",
+      "integrity": "sha512-bvOmVcJ9Lo6ymyaHCoXTjN6Ck7/Dog1KRsJgZilB6ukHQ7d6nJrAwAEoDF1rXto8tOvIUqVb6Zzy7qDPvBQA1Q==",
       "requires": {
-        "@docusaurus/types": "^2.0.0-beta.20",
-        "@docusaurus/utils": "^2.0.0-beta.20",
-        "@redocly/openapi-core": "1.0.0-beta.97",
-        "joi": "^17.5.0",
-        "redoc": "2.0.0-rc.69"
+        "@redocly/openapi-core": "1.0.0-beta.123",
+        "redoc": "2.0.0"
       }
     },
     "docusaurus-theme-redoc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.0.4.tgz",
-      "integrity": "sha512-RGMAMtaSgyxpF/+KyhABzaHYeCsVUC4p8wrpDeAK461u54xZlt7oVXsYeXeX6i6w0kSoFwczekoyb+C8mm0uZw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.6.2.tgz",
+      "integrity": "sha512-TECxcj6hUoE1aei21i6kTJHRcF7gdVwKyjZuaEMAPGvYhPO9gPvBXKeFQ0ZrZgQHrQSUMuS9tx+EZiTssNqJeA==",
       "requires": {
-        "@docusaurus/theme-common": "^2.0.0-beta.20",
-        "@docusaurus/types": "^2.0.0-beta.20",
-        "clsx": "^1.1.1",
+        "@redocly/openapi-core": "1.0.0-beta.123",
+        "clsx": "^1.2.1",
         "copyfiles": "^2.4.1",
         "lodash": "^4.17.21",
-        "mobx": "^6.5.0",
-        "redoc": "2.0.0-rc.69",
-        "styled-components": "^5.3.5"
+        "mobx": "^6.8.0",
+        "redoc": "2.0.0",
+        "styled-components": "^5.3.6"
       }
     },
     "dom-converter": {
@@ -29444,11 +29445,11 @@
       }
     },
     "redoc": {
-      "version": "2.0.0-rc.69",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.69.tgz",
-      "integrity": "sha512-AFedbb9h0I98z0lBF2hkkn3M09CsF/zXfRCd07vGL0fZg72/VFPAmHN7CyFRGg/whVEstZ2iUhN2jbN6MmTTDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0.tgz",
+      "integrity": "sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==",
       "requires": {
-        "@redocly/openapi-core": "^1.0.0-beta.97",
+        "@redocly/openapi-core": "^1.0.0-beta.104",
         "classnames": "^2.3.1",
         "decko": "^1.2.0",
         "dompurify": "^2.2.8",
@@ -29458,9 +29459,9 @@
         "mark.js": "^8.11.1",
         "marked": "^4.0.15",
         "mobx-react": "^7.2.0",
-        "openapi-sampler": "^1.2.3",
+        "openapi-sampler": "^1.3.0",
         "path-browserify": "^1.0.1",
-        "perfect-scrollbar": "^1.5.1",
+        "perfect-scrollbar": "^1.5.5",
         "polished": "^4.1.3",
         "prismjs": "^1.27.0",
         "prop-types": "^15.7.2",
@@ -29473,13 +29474,12 @@
       }
     },
     "redocusaurus": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.0.4.tgz",
-      "integrity": "sha512-cF/UiOZUZjfvIpgC1RnzwePac4bmUA2JZzfgTw8Bn6i0AdYRe0+03c8RfgGMNCLtuJIvG97G9dB+vhnx8lA+iQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.6.2.tgz",
+      "integrity": "sha512-kAE2OTLvE8fz+tLCTpVDpI+rZIzx4XsP+zRf0q4UKN0f89zLptPogD2ps8zOnQOjvJW6sWFIQEM8JoJBOtnekw==",
       "requires": {
-        "@docusaurus/types": "^2.0.0-beta.20",
-        "docusaurus-plugin-redoc": "1.0.3",
-        "docusaurus-theme-redoc": "1.0.4"
+        "docusaurus-plugin-redoc": "1.6.0",
+        "docusaurus-theme-redoc": "1.6.2"
       }
     },
     "reftools": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/plugin-client-redirects": "2.4.0",
-        "@docusaurus/preset-classic": "2.4.0",
+        "@docusaurus/core": "~2.4.0",
+        "@docusaurus/plugin-client-redirects": "~2.4.0",
+        "@docusaurus/preset-classic": "~2.4.0",
         "@mdx-js/react": "^1.6.21",
         "clsx": "^1.1.1",
         "medium-zoom": "^1.0.6",
         "prism-react-renderer": "^1.3.3",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "redocusaurus": "^1.0.1"
+        "redocusaurus": "~1.0.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/module-type-aliases": "~2.4.0",
         "@tsconfig/docusaurus": "^1.0.2",
         "@types/react": "^17.0.1",
         "@types/react-helmet": "^6.1.0",
@@ -2714,17 +2714,17 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -2796,9 +2796,9 @@
       }
     },
     "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
-      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.1.tgz",
+      "integrity": "sha512-PQdbF8dGd4LnbwBlcc4ML8RKYdplm+e9sUeWBTr4zgF13/Shiuov9XznvM4T8cb1CfyKK21yTUkuAIIh/DAH/g=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -3155,11 +3155,11 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.0.0-beta.123",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.123.tgz",
-      "integrity": "sha512-W6MbUWpb/VaV+Kf0c3jmMIJw3WwwF7iK5nAfcOS+ZwrlbxtIl37+1hEydFlJ209vCR9HL12PaMwdh2Vpihj6Jw==",
+      "version": "1.0.0-beta.97",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.97.tgz",
+      "integrity": "sha512-3WW9/6flosJuRtU3GI0Vw39OYFZqqXMDCp5TLa3EjXOb7Nm6AZTWRb3Y+I/+UdNJ/NTszVJkQczoa1t476ekiQ==",
       "dependencies": {
-        "@redocly/ajv": "^8.11.0",
+        "@redocly/ajv": "^8.6.4",
         "@types/node": "^14.11.8",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -3175,9 +3175,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ=="
+      "version": "14.18.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.46.tgz",
+      "integrity": "sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng=="
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -5183,14 +5183,14 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz",
+      "integrity": "sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "picomatch": "^2.3.0"
       },
       "peerDependencies": {
@@ -6972,38 +6972,36 @@
       }
     },
     "node_modules/docusaurus-plugin-redoc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.6.0.tgz",
-      "integrity": "sha512-bvOmVcJ9Lo6ymyaHCoXTjN6Ck7/Dog1KRsJgZilB6ukHQ7d6nJrAwAEoDF1rXto8tOvIUqVb6Zzy7qDPvBQA1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.0.3.tgz",
+      "integrity": "sha512-pLYBkyqRIdDsUx6Q9gTKlNkHZpVXYxXptDwTIK+FwMfW7chfdRTLLjlZ1oSqCVjNlb0L/CT1rpSh78pNKE95KQ==",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.123",
-        "redoc": "2.0.0"
+        "@docusaurus/types": "^2.0.0-beta.20",
+        "@docusaurus/utils": "^2.0.0-beta.20",
+        "@redocly/openapi-core": "1.0.0-beta.97",
+        "joi": "^17.5.0",
+        "redoc": "2.0.0-rc.69"
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "@docusaurus/utils": "^2.0.0"
       }
     },
     "node_modules/docusaurus-theme-redoc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.6.0.tgz",
-      "integrity": "sha512-YSZruPqVWxR7NFE7P0YwYzlFxaXVuntm7MPxxZg+KJmXG8Oc88x9lR2VhcnKp8VkJY3rM7YNVz+Sp+x9UyUTHw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.0.4.tgz",
+      "integrity": "sha512-RGMAMtaSgyxpF/+KyhABzaHYeCsVUC4p8wrpDeAK461u54xZlt7oVXsYeXeX6i6w0kSoFwczekoyb+C8mm0uZw==",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.123",
-        "clsx": "^1.2.1",
+        "@docusaurus/theme-common": "^2.0.0-beta.20",
+        "@docusaurus/types": "^2.0.0-beta.20",
+        "clsx": "^1.1.1",
         "copyfiles": "^2.4.1",
         "lodash": "^4.17.21",
-        "mobx": "^6.8.0",
-        "redoc": "2.0.0",
-        "styled-components": "^5.3.6"
+        "mobx": "^6.5.0",
+        "redoc": "2.0.0-rc.69",
+        "styled-components": "^5.3.5"
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "@docusaurus/theme-common": "^2.0.0"
       }
     },
     "node_modules/dom-converter": {
@@ -7053,9 +7051,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.4.tgz",
-      "integrity": "sha512-1e2SpqHiRx4DPvmRuXU5J0di3iQACwJM+mFGE2HAkkK7Tbnfk9WcghcAmyWc9CRrjyRRUpmuhPUH6LphQQR3EQ=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
+      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
     },
     "node_modules/domutils": {
       "version": "3.0.1",
@@ -10755,9 +10753,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11458,9 +11456,9 @@
       }
     },
     "node_modules/mobx": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.8.0.tgz",
-      "integrity": "sha512-+o/DrHa4zykFMSKfS8Z+CPSEg5LW9tSNGTuN8o6MF1GKxlfkSHSeJn5UtgxvPkGgaouplnrLXCF+duAsmm6FHQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.9.0.tgz",
+      "integrity": "sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -11491,9 +11489,9 @@
       }
     },
     "node_modules/mobx-react-lite": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
-      "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz",
+      "integrity": "sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -12023,9 +12021,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -14083,11 +14081,11 @@
       }
     },
     "node_modules/redoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0.tgz",
-      "integrity": "sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==",
+      "version": "2.0.0-rc.69",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.69.tgz",
+      "integrity": "sha512-AFedbb9h0I98z0lBF2hkkn3M09CsF/zXfRCd07vGL0fZg72/VFPAmHN7CyFRGg/whVEstZ2iUhN2jbN6MmTTDQ==",
       "dependencies": {
-        "@redocly/openapi-core": "^1.0.0-beta.104",
+        "@redocly/openapi-core": "^1.0.0-beta.97",
         "classnames": "^2.3.1",
         "decko": "^1.2.0",
         "dompurify": "^2.2.8",
@@ -14097,9 +14095,9 @@
         "mark.js": "^8.11.1",
         "marked": "^4.0.15",
         "mobx-react": "^7.2.0",
-        "openapi-sampler": "^1.3.0",
+        "openapi-sampler": "^1.2.3",
         "path-browserify": "^1.0.1",
-        "perfect-scrollbar": "^1.5.5",
+        "perfect-scrollbar": "^1.5.1",
         "polished": "^4.1.3",
         "prismjs": "^1.27.0",
         "prop-types": "^15.7.2",
@@ -14123,19 +14121,16 @@
       }
     },
     "node_modules/redocusaurus": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.6.0.tgz",
-      "integrity": "sha512-+gfMLzSX/uBi34+/Ng3ufpmSmy/BuUoR9whXIjhAfm/0uQSpmQQOR3zJrbSNGywoRK6RDkZZQKb5yytwrEh4bw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.0.4.tgz",
+      "integrity": "sha512-cF/UiOZUZjfvIpgC1RnzwePac4bmUA2JZzfgTw8Bn6i0AdYRe0+03c8RfgGMNCLtuJIvG97G9dB+vhnx8lA+iQ==",
       "dependencies": {
-        "docusaurus-plugin-redoc": "1.6.0",
-        "docusaurus-theme-redoc": "1.6.0"
+        "@docusaurus/types": "^2.0.0-beta.20",
+        "docusaurus-plugin-redoc": "1.0.3",
+        "docusaurus-theme-redoc": "1.0.4"
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "@docusaurus/theme-common": "^2.0.0",
-        "@docusaurus/utils": "^2.0.0"
       }
     },
     "node_modules/reftools": {
@@ -15805,9 +15800,9 @@
       }
     },
     "node_modules/style-loader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.2.tgz",
+      "integrity": "sha512-RHs/vcrKdQK8wZliteNK4NKzxvLBzpuHMqYmUVWeKa6MkaIQ97ZTOS0b+zapZhy6GcrgWnvWYCMHRirC3FsUmw==",
       "engines": {
         "node": ">= 12.13.0"
       },
@@ -15834,10 +15829,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
-      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
-      "hasInstallScript": true,
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.10.tgz",
+      "integrity": "sha512-3kSzSBN0TiCnGJM04UwO1HklIQQSXW7rCARUk+VyMR7clz8XVlA3jijtf5ypqoDIdNMKx3la4VvaPFR855SFcg==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -16261,9 +16255,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -21012,17 +21006,17 @@
       }
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
@@ -21075,9 +21069,9 @@
       "devOptional": true
     },
     "@exodus/schemasafe": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
-      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.1.tgz",
+      "integrity": "sha512-PQdbF8dGd4LnbwBlcc4ML8RKYdplm+e9sUeWBTr4zgF13/Shiuov9XznvM4T8cb1CfyKK21yTUkuAIIh/DAH/g=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -21345,11 +21339,11 @@
       }
     },
     "@redocly/openapi-core": {
-      "version": "1.0.0-beta.123",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.123.tgz",
-      "integrity": "sha512-W6MbUWpb/VaV+Kf0c3jmMIJw3WwwF7iK5nAfcOS+ZwrlbxtIl37+1hEydFlJ209vCR9HL12PaMwdh2Vpihj6Jw==",
+      "version": "1.0.0-beta.97",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.97.tgz",
+      "integrity": "sha512-3WW9/6flosJuRtU3GI0Vw39OYFZqqXMDCp5TLa3EjXOb7Nm6AZTWRb3Y+I/+UdNJ/NTszVJkQczoa1t476ekiQ==",
       "requires": {
-        "@redocly/ajv": "^8.11.0",
+        "@redocly/ajv": "^8.6.4",
         "@types/node": "^14.11.8",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -21362,9 +21356,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.36",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-          "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ=="
+          "version": "14.18.46",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.46.tgz",
+          "integrity": "sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng=="
         },
         "brace-expansion": {
           "version": "2.0.1",
@@ -22979,14 +22973,14 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz",
+      "integrity": "sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "picomatch": "^2.3.0"
       }
     },
@@ -24269,26 +24263,30 @@
       }
     },
     "docusaurus-plugin-redoc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.6.0.tgz",
-      "integrity": "sha512-bvOmVcJ9Lo6ymyaHCoXTjN6Ck7/Dog1KRsJgZilB6ukHQ7d6nJrAwAEoDF1rXto8tOvIUqVb6Zzy7qDPvBQA1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.0.3.tgz",
+      "integrity": "sha512-pLYBkyqRIdDsUx6Q9gTKlNkHZpVXYxXptDwTIK+FwMfW7chfdRTLLjlZ1oSqCVjNlb0L/CT1rpSh78pNKE95KQ==",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.123",
-        "redoc": "2.0.0"
+        "@docusaurus/types": "^2.0.0-beta.20",
+        "@docusaurus/utils": "^2.0.0-beta.20",
+        "@redocly/openapi-core": "1.0.0-beta.97",
+        "joi": "^17.5.0",
+        "redoc": "2.0.0-rc.69"
       }
     },
     "docusaurus-theme-redoc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.6.0.tgz",
-      "integrity": "sha512-YSZruPqVWxR7NFE7P0YwYzlFxaXVuntm7MPxxZg+KJmXG8Oc88x9lR2VhcnKp8VkJY3rM7YNVz+Sp+x9UyUTHw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-1.0.4.tgz",
+      "integrity": "sha512-RGMAMtaSgyxpF/+KyhABzaHYeCsVUC4p8wrpDeAK461u54xZlt7oVXsYeXeX6i6w0kSoFwczekoyb+C8mm0uZw==",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.123",
-        "clsx": "^1.2.1",
+        "@docusaurus/theme-common": "^2.0.0-beta.20",
+        "@docusaurus/types": "^2.0.0-beta.20",
+        "clsx": "^1.1.1",
         "copyfiles": "^2.4.1",
         "lodash": "^4.17.21",
-        "mobx": "^6.8.0",
-        "redoc": "2.0.0",
-        "styled-components": "^5.3.6"
+        "mobx": "^6.5.0",
+        "redoc": "2.0.0-rc.69",
+        "styled-components": "^5.3.5"
       }
     },
     "dom-converter": {
@@ -24323,9 +24321,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.4.tgz",
-      "integrity": "sha512-1e2SpqHiRx4DPvmRuXU5J0di3iQACwJM+mFGE2HAkkK7Tbnfk9WcghcAmyWc9CRrjyRRUpmuhPUH6LphQQR3EQ=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
+      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
     },
     "domutils": {
       "version": "3.0.1",
@@ -27072,9 +27070,9 @@
       "requires": {}
     },
     "marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "match-index": {
       "version": "1.0.3",
@@ -27572,9 +27570,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mobx": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.8.0.tgz",
-      "integrity": "sha512-+o/DrHa4zykFMSKfS8Z+CPSEg5LW9tSNGTuN8o6MF1GKxlfkSHSeJn5UtgxvPkGgaouplnrLXCF+duAsmm6FHQ=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.9.0.tgz",
+      "integrity": "sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ=="
     },
     "mobx-react": {
       "version": "7.6.0",
@@ -27585,9 +27583,9 @@
       }
     },
     "mobx-react-lite": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
-      "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz",
+      "integrity": "sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==",
       "requires": {}
     },
     "moji": {
@@ -27990,9 +27988,9 @@
           }
         },
         "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -29446,11 +29444,11 @@
       }
     },
     "redoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0.tgz",
-      "integrity": "sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==",
+      "version": "2.0.0-rc.69",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.69.tgz",
+      "integrity": "sha512-AFedbb9h0I98z0lBF2hkkn3M09CsF/zXfRCd07vGL0fZg72/VFPAmHN7CyFRGg/whVEstZ2iUhN2jbN6MmTTDQ==",
       "requires": {
-        "@redocly/openapi-core": "^1.0.0-beta.104",
+        "@redocly/openapi-core": "^1.0.0-beta.97",
         "classnames": "^2.3.1",
         "decko": "^1.2.0",
         "dompurify": "^2.2.8",
@@ -29460,9 +29458,9 @@
         "mark.js": "^8.11.1",
         "marked": "^4.0.15",
         "mobx-react": "^7.2.0",
-        "openapi-sampler": "^1.3.0",
+        "openapi-sampler": "^1.2.3",
         "path-browserify": "^1.0.1",
-        "perfect-scrollbar": "^1.5.5",
+        "perfect-scrollbar": "^1.5.1",
         "polished": "^4.1.3",
         "prismjs": "^1.27.0",
         "prop-types": "^15.7.2",
@@ -29475,12 +29473,13 @@
       }
     },
     "redocusaurus": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.6.0.tgz",
-      "integrity": "sha512-+gfMLzSX/uBi34+/Ng3ufpmSmy/BuUoR9whXIjhAfm/0uQSpmQQOR3zJrbSNGywoRK6RDkZZQKb5yytwrEh4bw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-1.0.4.tgz",
+      "integrity": "sha512-cF/UiOZUZjfvIpgC1RnzwePac4bmUA2JZzfgTw8Bn6i0AdYRe0+03c8RfgGMNCLtuJIvG97G9dB+vhnx8lA+iQ==",
       "requires": {
-        "docusaurus-plugin-redoc": "1.6.0",
-        "docusaurus-theme-redoc": "1.6.0"
+        "@docusaurus/types": "^2.0.0-beta.20",
+        "docusaurus-plugin-redoc": "1.0.3",
+        "docusaurus-theme-redoc": "1.0.4"
       }
     },
     "reftools": {
@@ -30777,9 +30776,9 @@
       }
     },
     "style-loader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.2.tgz",
+      "integrity": "sha512-RHs/vcrKdQK8wZliteNK4NKzxvLBzpuHMqYmUVWeKa6MkaIQ97ZTOS0b+zapZhy6GcrgWnvWYCMHRirC3FsUmw==",
       "requires": {}
     },
     "style-search": {
@@ -30797,9 +30796,9 @@
       }
     },
     "styled-components": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
-      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.10.tgz",
+      "integrity": "sha512-3kSzSBN0TiCnGJM04UwO1HklIQQSXW7rCARUk+VyMR7clz8XVlA3jijtf5ypqoDIdNMKx3la4VvaPFR855SFcg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -31116,9 +31115,9 @@
           }
         },
         "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",

--- a/website/package.json
+++ b/website/package.json
@@ -23,19 +23,19 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@docusaurus/core": "2.4.0",
-    "@docusaurus/plugin-client-redirects": "2.4.0",
-    "@docusaurus/preset-classic": "2.4.0",
+    "@docusaurus/core": "~2.4.0",
+    "@docusaurus/plugin-client-redirects": "~2.4.0",
+    "@docusaurus/preset-classic": "~2.4.0",
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
     "medium-zoom": "^1.0.6",
     "prism-react-renderer": "^1.3.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "redocusaurus": "^1.0.1"
+    "redocusaurus": "~1.0.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.4.0",
+    "@docusaurus/module-type-aliases": "~2.4.0",
     "@tsconfig/docusaurus": "^1.0.2",
     "@types/react": "^17.0.1",
     "@types/react-helmet": "^6.1.0",

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,7 @@
     "prism-react-renderer": "^1.3.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "redocusaurus": "~1.0.1"
+    "redocusaurus": "~1.6.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "~2.4.0",


### PR DESCRIPTION
## ✅ What's done

Docusaurus関連のパッケージは固定ではなくバージョン範囲指定（パッチ範囲）に変更。
パッチバージョンは一般的にBreaking Changesはなく不具合対応が反映されるため、固定にしないほうが良いと判断。

また、`redocusaurus`はバージョン範囲がマイナーになっていましたが、マイナーには機能追加が含まれる場合があり、Lockfile maintenanceで対応するスコープの対象外にしたいため、バージョン範囲をパッチに変更

対象パッケージは以下

- [x] Prefixに`@docusaurus`が付くpackage
- [x] `redocusaurus`

---

## Other (messages to reviewers, concerns, etc.)

なし
