### PR TITLE
📌: redocusaurusはDocusaurus関連のパッケージとまとめてvupするように変更

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -119,6 +119,9 @@
       matchPackagePrefixes: [
         '@docusaurus'
       ],
+      matchPackageNames: [
+        'redocusaurus',
+      ],
       allowedVersions: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-[\\w]+(\\.[0-9]{1,5})?)?$/"
     },
     {


### PR DESCRIPTION
## ✅ What's done

`redocusaurus`の依存パッケージには`@docusaurus/xxx`が含まれており、Docusaurus関連のパッケージと同時にvupしないと、正常にビルドができない場合があります。

そのため、Docusaurus関連のパッケージとまとめてvupするように変更します。

- [x] `renovate.json5`に`redocusaurus`を追加

---

## Other (messages to reviewers, concerns, etc.)

なし
