### PR TITLE
✨: バックエンドに初期データとしてMSWと同じアカウントを登録

### DIFF
--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
@@ -15,6 +15,25 @@ import nablarch.core.log.LoggerManager;
 import nablarch.core.repository.initialization.Initializable;
 import nablarch.core.util.StringUtil;
 
+/**
+ * 以下のアカウントを初期データとして登録します。
+ * <ul>
+ *   <li>santoku</li>
+ *   <li>admin</li>
+ *   <li>partner</li>
+ * </ul>
+ * <p>
+ * 既にアカウントが登録されている場合は、初期データを更新します。
+ * <p>
+ * パスワードは、環境設定ファイル（env.config）、または環境変数で設定可能です。
+ * <ul>
+ *   <li>環境設定ファイル: 「account.password」に設定</li>
+ *   <li>環境変数: 「ACCOUNT_PASSWORD」に設定</li>
+ * </ul>
+ *
+ * @see <a href="https://nablarch.github.io/docs/5u20/doc/application_framework/application_framework/setting_guide/ManagingEnvironmentalConfiguration/index.html">処理方式、環境に依存する設定の管理方法</a>
+ * @see <a href="https://nablarch.github.io/docs/5u20/doc/application_framework/application_framework/libraries/repository.html#os">OS環境変数を使って環境依存値を上書きする</a>
+ */
 public class AccountInitializer implements Initializable {
 
   private static final Logger LOGGER = LoggerManager.get(AccountInitializer.class);

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
@@ -1,0 +1,68 @@
+package jp.fintan.mobile.santokuapp.system.nablarch;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import jp.fintan.mobile.santokuapp.domain.model.account.RawPassword;
+import jp.fintan.mobile.santokuapp.infrastructure.service.PBKDF2PasswordHashingProcessor;
+import nablarch.core.log.Logger;
+import nablarch.core.log.LoggerManager;
+import nablarch.core.repository.initialization.Initializable;
+import nablarch.core.util.StringUtil;
+
+public class AccountInitializer implements Initializable {
+
+  private static final Logger LOGGER = LoggerManager.get(AccountInitializer.class);
+  private DataSource dataSource;
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  private String accountPassword;
+  public String getAccountPassword() {
+    return accountPassword;
+  }
+
+  public void setAccountPassword(String accountPassword) {
+    this.accountPassword = accountPassword;
+  }
+
+  @Override
+  public void initialize() {
+    List<String> accounts = List.of("santoku", "admin", "partner");
+
+    if (StringUtil.isNullOrEmpty(accountPassword)) {
+      LOGGER.logWarn("Initial account data could not be registered because no password was set in environment variable or system properties.");
+      return;
+    }
+    String hashedPassword = new PBKDF2PasswordHashingProcessor().hash(new RawPassword(accountPassword)).value();
+
+    try(
+        Connection connection = dataSource.getConnection();
+        ) {
+      for (String account : accounts) {
+        try(
+            PreparedStatement accountStatement = connection.prepareStatement("insert into account (account_id, nickname) values (?, ?)");
+            PreparedStatement passwordStatement = connection.prepareStatement("insert into password (account_id, password) values (?, ?)");
+            ) {
+          accountStatement.setString(1, account);
+          accountStatement.setString(2, account);
+          passwordStatement.setString(1, account);
+          passwordStatement.setString(2, hashedPassword);
+          accountStatement.execute();
+          passwordStatement.execute();
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
@@ -13,7 +13,6 @@ import jp.fintan.mobile.santokuapp.infrastructure.service.PBKDF2PasswordHashingP
 import nablarch.core.log.Logger;
 import nablarch.core.log.LoggerManager;
 import nablarch.core.repository.initialization.Initializable;
-import nablarch.core.util.StringUtil;
 
 /**
  * 以下のアカウントを初期データとして登録します。
@@ -61,11 +60,15 @@ public class AccountInitializer implements Initializable {
 
   @Override
   public void initialize() {
-    if (StringUtil.isNullOrEmpty(accountPassword)) {
-      LOGGER.logWarn("Initial account data could not be registered because no password was set in environment variable or system properties.");
+    RawPassword rawPassword;
+    try {
+      rawPassword = new RawPassword(accountPassword);
+    } catch (IllegalArgumentException e) {
+      LOGGER.logWarn("Initial account data could not be registered because password was invalid.", e);
       return;
     }
-    String hashedPassword = new PBKDF2PasswordHashingProcessor().hash(new RawPassword(accountPassword)).value();
+
+    String hashedPassword = new PBKDF2PasswordHashingProcessor().hash(rawPassword).value();
 
     try(
         Connection connection = dataSource.getConnection();

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
@@ -56,9 +56,17 @@ public class AccountInitializer implements Initializable {
             // h2のpostgresqlモードでは、on conflict句は使用できない
             // https://github.com/h2database/h2database/issues/3557
             // そのため、merge into句を使用する
-            PreparedStatement accountStatement = connection.prepareStatement("merge into account as a using (values (?, ?)) as i(account_id, nickname) on a.account_id = i.account_id when matched then update set nickname = i.nickname when not matched then insert (account_id, nickname) values (i.account_id, i.nickname)");
-            PreparedStatement passwordStatement = connection.prepareStatement("merge into password as p using (values (?, ?)) as i(account_id, password) on p.account_id = i.account_id when matched then update set password = i.password when not matched then insert (account_id, password) values (i.account_id, i.password)");
-            ) {
+            PreparedStatement accountStatement = connection.prepareStatement(
+                "merge into account as a using (values (?, ?)) as i(account_id, nickname) on a.account_id = i.account_id "
+                    + "when matched then update set nickname = i.nickname "
+                    + "when not matched then insert (account_id, nickname) values (i.account_id, i.nickname)"
+            );
+            PreparedStatement passwordStatement = connection.prepareStatement(
+                "merge into password as p using (values (?, ?)) as i(account_id, password) on p.account_id = i.account_id "
+                    + "when matched then update set password = i.password "
+                    + "when not matched then insert (account_id, password) values (i.account_id, i.password)"
+            )
+          ) {
           accountStatement.setString(1, account.accountId().value());
           accountStatement.setString(2, account.nickname().value());
           passwordStatement.setString(1, account.accountId().value());

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
@@ -96,10 +96,12 @@ public class AccountInitializer implements Initializable {
           accountStatement.execute();
           passwordStatement.execute();
         } catch (SQLException e) {
+          // 例外をthrowするとエラーログが出力されるが、アプリは起動する
           throw new RuntimeException(e);
         }
       }
     } catch (SQLException e) {
+      // 例外をthrowするとエラーログが出力されるが、アプリは起動する
       throw new RuntimeException(e);
     }
   }

--- a/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
+++ b/example-app/santoku-app-backend/src/main/java/jp/fintan/mobile/santokuapp/system/nablarch/AccountInitializer.java
@@ -37,18 +37,12 @@ public class AccountInitializer implements Initializable {
 
   private static final Logger LOGGER = LoggerManager.get(AccountInitializer.class);
   private DataSource dataSource;
-  public DataSource getDataSource() {
-    return dataSource;
-  }
 
   public void setDataSource(DataSource dataSource) {
     this.dataSource = dataSource;
   }
 
   private String accountPassword;
-  public String getAccountPassword() {
-    return accountPassword;
-  }
 
   public void setAccountPassword(String accountPassword) {
     this.accountPassword = accountPassword;

--- a/example-app/santoku-app-backend/src/main/resources/env.config
+++ b/example-app/santoku-app-backend/src/main/resources/env.config
@@ -71,3 +71,6 @@ cors.origins=http://localhost:3000
 
 # 1ページあたりの表示件数
 paging.per.count=100
+
+# 初期データとして投入するアカウントのパスワード
+account.password=Example1234

--- a/example-app/santoku-app-backend/src/main/resources/rest-component-configuration.xml
+++ b/example-app/santoku-app-backend/src/main/resources/rest-component-configuration.xml
@@ -167,6 +167,10 @@
   </component>
 
   <component name="firebaseInitializer" class="jp.fintan.mobile.santokuapp.system.nablarch.FirebaseInitializer"/>
+  <component name="accountInitializer" class="jp.fintan.mobile.santokuapp.system.nablarch.AccountInitializer">
+    <property name="dataSource" ref="dataSource"/>
+    <property name="accountPassword" value="${account.password}"/>
+  </component>
 
   <!-- ハンドラキュー構成 -->
   <component name="webFrontController" class="nablarch.fw.web.servlet.WebFrontController">
@@ -254,6 +258,7 @@
         <component-ref name="dbStore"/>
         <component-ref name="dbExpiration"/>
         <component-ref name="firebaseInitializer"/>
+        <component-ref name="accountInitializer"/>
       </list>
     </property>
   </component>


### PR DESCRIPTION
## ✅ What's done

モバイルのログイン画面から、MSWとバックエンド双方のログインを透過的に実施するため、MSWの初期アカウントと同じアカウントをバックエンドにも作成します。

バックエンドに初期データとして登録するアカウントは以下の3つです。

- santoku
- admin
- partner

パスワードは、環境設定ファイル、または環境変数から設定可能です。

- [x] アプリ起動時にアカウントを登録する`Initializer`の作成
- [x] アカウントのパスワードをハードコードしない設定
- [x] AppServiceへのデプロイ
- [x] AppServiceの環境変数にパスワードを設定

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] Local環境でテスト
  - [x] `ACCOUNT_PASSWORD=[password]  ./mvnw jetty:run`を実行して、環境変数に設定した値がデータベースに登録されていることを確認
  - [x] `./mvnw jetty:run`を実行して、`env.config`に設定されているパスワードがデータベースに登録されていることを確認
  - [x] 初期データが存在しない場合は、アカウントが登録されていることを確認
  - [x] 初期データが存在する場合は、それらのデータが更新されていることを確認
- [x] Stg環境でアカウントが作成されていることを確認

## Other (messages to reviewers, concerns, etc.)

なし
