### PR TITLE
🐛: MSWで、CSRFトークンの取得APIのレスポンスに誤りがあったので修正

### DIFF
--- a/example-app/SantokuApp/src/fixtures/msw/handlers/system/getSystemCsrfToken.ts
+++ b/example-app/SantokuApp/src/fixtures/msw/handlers/system/getSystemCsrfToken.ts
@@ -9,8 +9,8 @@ export const getSystemCsrfToken = rest.get(`${backendUrl}/system/csrf-token`, (r
   return delayedResponse(
     ctx.json<CsrfTokenResponse>({
       csrfTokenValue: generateToken(32),
-      csrfTokenParameterName: 'X-CSRF-TOKEN',
-      csrfTokenHeaderName: 'csrf-token',
+      csrfTokenHeaderName: 'X-CSRF-TOKEN',
+      csrfTokenParameterName: 'csrf-token',
     }),
     ctx.delay(100),
   );


### PR DESCRIPTION
## ✅ What's done

CSRFトークンの取得APIのレスポンスで、以下を返却するように修正
- [x] `csrfTokenHeaderName`: `X-CSRF-TOKEN`
- [x] `csrfTokenParameterName`: 'csrf-token'

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [ ] 実施した動作確認の内容をチェック付きの箇条書きで記載してください
- [ ] 作業着手前に列挙して TODO リストのようにも使用できます
- [ ] やり終わったらチェックを付けてください

以下のコマンドをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。

- /azp run deploy-all

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 14Pro/iOS 16)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

### 参考

- https://github.com/nablarch/nablarch-fw-web/blob/1.9.0/src/main/java/nablarch/common/web/WebConfig.java#L27-L30
