### PR TITLE
🐛: デバイストークン登録後にアカウントデータがリフレッシュされていなかった事象の対応

### DIFF
--- a/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
+++ b/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
@@ -1,5 +1,5 @@
 import {AccountData} from 'features/account/types/AccountData';
-import {postAccountsMeTerms} from 'features/backend/apis/account/account';
+import {postAccountsMeDeviceToken, postAccountsMeTerms} from 'features/backend/apis/account/account';
 import {TermsOfServiceAgreementStatus} from 'features/backend/apis/model';
 import {useMutation, useQueryClient} from 'react-query';
 
@@ -14,6 +14,12 @@ export const useAccountCommands = () => {
     },
   });
 
+  const updateDeviceTokenMutation = useMutation(postAccountsMeDeviceToken, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['account', 'accountData']);
+    },
+  });
+
   /**
    * サービス利用規約に同意します。
    */
@@ -24,6 +30,7 @@ export const useAccountCommands = () => {
 
   return {
     loadAccountData: loadAccountDataMutation.mutateAsync,
+    updateDeviceToken: updateDeviceTokenMutation.mutateAsync,
     agreeTerms: agreeTermsMutation.mutateAsync,
     isLoadingAccountData: agreeTermsMutation.isLoading,
     isAgreeingTerms: agreeTermsMutation.isLoading,

--- a/example-app/SantokuApp/src/features/qa-home/services/useRequestPermissionAndRegisterToken.ts
+++ b/example-app/SantokuApp/src/features/qa-home/services/useRequestPermissionAndRegisterToken.ts
@@ -1,12 +1,13 @@
 import messaging from '@react-native-firebase/messaging';
 import {getFcmToken} from 'bases/firebase/messaging/getFcmToken';
 import {requestPushPermission} from 'bases/firebase/messaging/requestPushPermission';
+import {useAccountCommands} from 'features/account/services/account/useAccountCommands';
 import {useAccountData} from 'features/account/services/account/useAccountData';
-import {postAccountsMeDeviceToken} from 'features/backend/apis/account/account';
 import {useCallback} from 'react';
 
 export const useRequestPermissionAndRegisterToken = () => {
   const {accountData} = useAccountData();
+  const {updateDeviceToken} = useAccountCommands();
   const requestPermissionAndRegisterToken = useCallback(async () => {
     const authStatus = await requestPushPermission();
     if (authStatus === messaging.AuthorizationStatus.AUTHORIZED) {
@@ -14,9 +15,9 @@ export const useRequestPermissionAndRegisterToken = () => {
       // ログイン後は必ずアカウント情報が存在している
       // アカウント情報にFCM登録トークンが含まれていない場合は、FCM登録トークンを登録する
       if (fcmToken && !accountData!.account.deviceTokens.includes(fcmToken)) {
-        await postAccountsMeDeviceToken({newDeviceToken: fcmToken});
+        await updateDeviceToken({newDeviceToken: fcmToken});
       }
     }
-  }, [accountData]);
+  }, [accountData, updateDeviceToken]);
   return {requestPermissionAndRegisterToken};
 };


### PR DESCRIPTION
## ✅ What's done

- [x] デバイストークン登録後に、アカウントデータ（`queryKey`が`['account', 'accountData']`）をリフレッシュ（`queryClient.invalidateQueries`）するように修正

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [ ] 実施した動作確認の内容をチェック付きの箇条書きで記載してください
- [ ] 作業着手前に列挙して TODO リストのようにも使用できます
- [ ] やり終わったらチェックを付けてください

以下のコマンドをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。

- /azp run deploy-all

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
