### PR TITLE
✅: App.tsxのテスト実行時に、日付を固定する

### DIFF
--- a/example-app/SantokuApp/src/apps/app/App.test.tsx
+++ b/example-app/SantokuApp/src/apps/app/App.test.tsx
@@ -28,6 +28,8 @@ beforeEach(() => {
   // テストは成功するものの、エラーログが出力されてしまう。
   // タイマーを使わないようにして、アニメーションを動かさないことで回避しているつもり。
   jest.useFakeTimers();
+  // テスト時は2023/6/1で日付を固定する
+  jest.setSystemTime(new Date(2023, 5, 1, 0, 0, 0, 0));
 });
 
 jest.mock('expo-application', () => {


### PR DESCRIPTION
## ✅ What's done

`App.tsx`のテスト実行時に日付を固定していないため、テストが落ちていました。
例えば、以下のデータが取得できなくなり、スナップショットが変更されてしまってテストエラーになっていました。
- https://github.com/ws-4020/mobile-app-crib-notes/blob/v2023.03/example-app/SantokuApp/src/fixtures/msw/datas/eventData.ts#L95

そのため、現在のスナップショットに変更が入らない日付で固定します。

- [x] [jest.setSystemTime](https://jestjs.io/ja/docs/jest-object)で、`2023/6/1`に日付を固定

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

なし
