### PR TITLE
📝: 商標追加: React, React Native, Firestore, fastlane, Google Maps, Mapbox

### DIFF
--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -13,7 +13,9 @@ title: 商標について
 - 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPad」「iPadOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」「Dynamic Island」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
-- 「Google Chrome」「Android」「Flutter」「Firebase」「Google Play」「Pixel」は、 Google LLCの登録商標です。
+<!-- textlint-disable ja-technical-writing/sentence-length-->
+- 「Google Chrome」「Google Maps」「Android」「fastlane」「Flutter」「Firebase」「Firestore」「Google Play」「Pixel」は、 Google LLCの登録商標です。
+<!-- textlint-enable ja-technical-writing/sentence-length-->
 - Androidロボットは、Googleが作成および提供している作品から複製または変更したものであり、[クリエイティブ・コモンズ表示](https://creativecommons.org/licenses/by/3.0/) 3.0ライセンスに記載された条件に従って使用しています。
 - 「Amazon Cognito」「Amazon Pinpoint」は、米国および/またはその他の諸国における、Amazon.com, Inc. またはその関連会社の商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -9,6 +9,7 @@ title: 商標について
 ### 各社の商標または登録商標
 
 <!-- textlint-disable -->
+- 「React」、「React Native」は、Meta Platforms, Inc.の登録商標です。
 - 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPad」「iPadOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」「Dynamic Island」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -35,6 +35,7 @@ title: 商標について
 - 「QRコード」は、株式会社デンソーウェーブの商標または登録商標です。
 - 「1Password」は、米国およびその他の諸国における、AgileBits, Inc. の商標または登録商標です。
 <!-- textlint-disable jtf-style/1.2.1.句点(。)と読点(、)-->
+- 「Mapbox」は、Mapbox Inc.の米国およびその他の国における商標または登録商標です。
 - 「Figma」は、FIGMA, INC.の商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 


### PR DESCRIPTION
## ✅ What's done

- [x] 商標追加
  - Meta
    - [x] React
    - [x] React Native
  - Google
    - [x] Firestore
    - [x] fastlane
    - [x] Google Maps
  - Mapbox
    - [x] Mapbox

※ 元々含まれていたが商標リストから漏れていたものを含む

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->


## Other (messages to reviewers, concerns, etc.)
### 参考
- [商標について | Fintan](https://fintan.jp/page/1622/)
- [商標 | Meta | Brand Resource Center](https://about.meta.com/ja/brand/resources/meta/our-trademarks/)
- [Brand Resource Center | Trademark list](https://about.google/brand-resource-center/trademark-list/)
- [MAPBOX Trademark of MAPBOX, INC. - Registration Number 3962620 - Serial Number 77836269 :: Justia Trademarks](https://trademarks.justia.com/778/36/mapbox-77836269.html)

### Outputページ
- [商標について | Fintan » Mobile App Development](https://ws-4020.github.io/mobile-app-crib-notes/trademark/)

### 関連
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1139
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1054
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1166