### PR TITLE
🧑‍💻: jestのcoverage測定対象から自動生成コード・画面を除外

### DIFF
--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -18,9 +18,9 @@ module.exports = {
     '<rootDir>/src/features/backend/apis',
     '<rootDir>/src/features/sandbox/apis',
     '<rootDir>/src/apps/app/screens/demo-',
-    '<rootDir>/src/features/demo-',
+    '<rootDir>/src/features/demo-[^/]+/pages/',
     '<rootDir>/src/apps/app/screens/qa-',
-    '<rootDir>/src/features/qa-',
+    '<rootDir>/src/features/qa-[^/]+/pages/',
   ],
   moduleNameMapper: {
     // Barcode.tsxでESMのコードを直接importしているため、以下のエラーが発生する

--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -14,7 +14,12 @@ module.exports = {
   ],
   // https://jestjs.io/ja/docs/configuration#clearmocks-boolean
   clearMocks: true,
-  coveragePathIgnorePatterns: ['<rootDir>/src/features/backend/apis', '<rootDir>/src/features/sandbox/apis'],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/src/features/backend/apis',
+    '<rootDir>/src/features/sandbox/apis',
+    '<rootDir>/src/apps/app/screens/demo-',
+    '<rootDir>/src/features/demo-',
+  ],
   moduleNameMapper: {
     // Barcode.tsxでESMのコードを直接importしているため、以下のエラーが発生する
     // SyntaxError: Cannot use import statement outside a module

--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -18,9 +18,8 @@ module.exports = {
     '<rootDir>/src/features/backend/apis',
     '<rootDir>/src/features/sandbox/apis',
     '<rootDir>/src/apps/app/screens/demo-',
-    '<rootDir>/src/features/demo-[^/]+/pages/',
     '<rootDir>/src/apps/app/screens/qa-',
-    '<rootDir>/src/features/qa-[^/]+/pages/',
+    '<rootDir>/src/features/[^/]+/pages/',
   ],
   moduleNameMapper: {
     // Barcode.tsxでESMのコードを直接importしているため、以下のエラーが発生する

--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -17,8 +17,7 @@ module.exports = {
   coveragePathIgnorePatterns: [
     '<rootDir>/src/features/backend/apis',
     '<rootDir>/src/features/sandbox/apis',
-    '<rootDir>/src/apps/app/screens/demo-',
-    '<rootDir>/src/apps/app/screens/qa-',
+    '<rootDir>/src/apps/app/screens/',
     '<rootDir>/src/features/[^/]+/pages/',
   ],
   moduleNameMapper: {

--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
   // https://jestjs.io/ja/docs/configuration#clearmocks-boolean
   clearMocks: true,
   coveragePathIgnorePatterns: [
-    '<rootDir>/src/features/backend/apis',
-    '<rootDir>/src/features/sandbox/apis',
+    '<rootDir>/src/features/backend/apis/',
+    '<rootDir>/src/features/sandbox/apis/',
     '<rootDir>/src/apps/app/screens/',
     '<rootDir>/src/features/[^/]+/pages/',
   ],

--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -19,6 +19,8 @@ module.exports = {
     '<rootDir>/src/features/sandbox/apis',
     '<rootDir>/src/apps/app/screens/demo-',
     '<rootDir>/src/features/demo-',
+    '<rootDir>/src/apps/app/screens/qa-',
+    '<rootDir>/src/features/qa-',
   ],
   moduleNameMapper: {
     // Barcode.tsxでESMのコードを直接importしているため、以下のエラーが発生する

--- a/example-app/SantokuApp/jest.config.js
+++ b/example-app/SantokuApp/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   ],
   // https://jestjs.io/ja/docs/configuration#clearmocks-boolean
   clearMocks: true,
+  coveragePathIgnorePatterns: ['<rootDir>/src/features/backend/apis', '<rootDir>/src/features/sandbox/apis'],
   moduleNameMapper: {
     // Barcode.tsxでESMのコードを直接importしているため、以下のエラーが発生する
     // SyntaxError: Cannot use import statement outside a module


### PR DESCRIPTION
## ✅ What's done
jestのcoverage測定対象から以下を除外。
カバレッジ測定の度に手動で `coveragePathIgnorePatterns` を追加するのは手間なのでリポジトリに含める。

- 自動生成コード
- 画面


### 自動生成コード(Web APIへのアクセスコード)
- src/features/backend/apis
- src/features/sandbox/apis

### 画面
- src/apps/app/screens/
- src/features/*/pages/

※ デモ機能, QAアプリに限らない


---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] `npm run test:report` でカバレッジが変更すること
  - `53.87% Statements 2519/4676` → `62.66% Statements 2132/3402`


## Other (messages to reviewers, concerns, etc.)
- 元々は自動生成コードのみを除外する予定だったのでブランチ名が不正確となっている
- 現時点で除外対象のテストコードはとても少ない（全111テストファイル中）
  - 自動生成コード: 0ファイル
  - 画面: 3ファイル
    - src/features/account/pages/LoginPage.test.tsx
    - src/features/account/pages/ProfileRegistrationPage.test.tsx
    - src/features/qa-home/pages/HomePage.test.tsx
- eslint の `ignorePatterns` には以下が記載されていたが、 API定義以外はテスト対象ではなかった（レポートに存在しなかった）ので、`coveragePathIgnorePatterns` には追加していない。

```
  ignorePatterns: [
    'src/features/backend/apis/**/*.ts',
    'src/features/sandbox/apis/**/*.ts',
    'src/features/acknowledgements/constants/ThirdPartyDependencies.ts',
    'config/plugin/build/**',
  ],
```