### PR TITLE
🧑‍💻: renovate対象外を追加

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,7 @@
         'react-dom',
         'react-native',
         'react-native-gesture-handler',
+        'react-native-maps',
         'react-native-reanimated',
         'react-native-safe-area-context',
         'react-native-screens',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,7 @@
         'expo-splash-screen',
         'expo-status-bar',
         'jest',
+        'jest-expo',
         'react',
         'react-dom',
         'react-native',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,7 @@
         'expo-local-authentication',
         'expo-secure-store',
         'expo-splash-screen',
+        'expo-status-bar',
         'jest',
         'react',
         'react-dom',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,6 +87,8 @@
         'de.undercouch:gradle-download-task',
         // @testing-library/react-native -> jest
         '@testing-library/react-native',
+        // prebuild
+        'androidx.swiperefreshlayout:swiperefreshlayout',
       ],
       matchPackagePrefixes: [
         'com.facebook.flipper',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,6 +74,8 @@
       groupName: 'Depends on Expo version',
       enabled: false,
       matchPackageNames: [
+        // expo -> @expo/cli
+        '@expo/config-plugins',
         // jest-expo -> jest
         '@types/jest',
         // react, jest-expo -> react-test-renderer


### PR DESCRIPTION
## ✅ What's done
expoによる管理対象であるため以下をrenovate対象外に指定

- react-native-maps
- expo-status-bar
- androidx.swiperefreshlayout:swiperefreshlayout
  - prebuildで生成される部分
- jest-expo
- @expo/config-plugins


---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### jest-expoについて
過去に`.github/renovate.json5`から消したが、含まれているのが自然＆大きな問題も無いと思われるため戻す

- https://github.com/ws-4020/mobile-app-crib-notes/pull/1118/commits/e0d01763d42ae8102c05d7b15528c34d6da49ff0
- https://github.com/ws-4020/rn-spoiler/pull/133#discussion_r1188040581

### 関連PR

- https://github.com/ws-4020/mobile-app-crib-notes/pull/1165#pullrequestreview-1478494515
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1186#pullrequestreview-1534045748
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1167#pullrequestreview-1534024230
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1189#pullrequestreview-1534187696
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1189#pullrequestreview-1534201355
