### PR TITLE
✨ @ts-directiveに関するルールを追加

### DIFF
--- a/example-app/SantokuApp/.eslintrc.js
+++ b/example-app/SantokuApp/.eslintrc.js
@@ -38,6 +38,22 @@ module.exports = {
       },
     },
     {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // Disallow @ts-<directive> comments or require descriptions after directives.
+        // https://typescript-eslint.io/rules/ban-ts-comment/
+        '@typescript-eslint/ban-ts-comment': [
+          'error',
+          {
+            'ts-expect-error': 'allow-with-description',
+            'ts-ignore': true,
+            'ts-nocheck': true,
+            'ts-check': false,
+          },
+        ],
+      },
+    },
+    {
       files: ['*.tsx'],
       rules: {
         // It is too strict to prohibit passing async functions to `onPress`, so disable the rule in JSX.

--- a/example-app/SantokuApp/src/bases/core/errors/ApplicationError.test.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/ApplicationError.test.ts
@@ -104,7 +104,6 @@ describe.each([false, true])(
     it('given an argument other than message or cause', () => {
       const mock = jest.spyOn(console, 'warn').mockImplementation();
       try {
-        // @ts-ignore
         const sut = new ApplicationError(['array', {key: 'value'}]);
 
         expect(sut.name).toEqual('ApplicationError');
@@ -119,7 +118,6 @@ describe.each([false, true])(
     it('given an argument other than Error', () => {
       const message = 'when the error occurred';
       const cause = {key: 'value'};
-      // @ts-ignore
       const sut = new ApplicationError(message, cause);
 
       expect(sut.message).toEqual(message);

--- a/example-app/SantokuApp/src/bases/core/errors/ApplicationError.test.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/ApplicationError.test.ts
@@ -11,7 +11,7 @@ describe.each([false, true])(
   captureStackTraceAvailable => {
     beforeAll(() => {
       if (!captureStackTraceAvailable) {
-        // @ts-ignore
+        // @ts-expect-error -- 検証のためにcaptureStackTraceを削除したいため
         delete Error.captureStackTrace;
       }
     });

--- a/example-app/SantokuApp/src/bases/core/errors/RuntimeError.test.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/RuntimeError.test.ts
@@ -104,7 +104,6 @@ describe.each([false, true])(
     it('given an argument other than message or cause', () => {
       const mock = jest.spyOn(console, 'warn').mockImplementation();
       try {
-        // @ts-ignore
         const sut = new RuntimeError(['array', {key: 'value'}]);
 
         expect(sut.name).toEqual('RuntimeError');
@@ -119,7 +118,6 @@ describe.each([false, true])(
     it('given an argument other than Error', () => {
       const message = 'when the error occurred';
       const cause = {key: 'value'};
-      // @ts-ignore
       const sut = new RuntimeError(message, cause);
 
       expect(sut.message).toEqual(message);

--- a/example-app/SantokuApp/src/bases/core/errors/RuntimeError.test.ts
+++ b/example-app/SantokuApp/src/bases/core/errors/RuntimeError.test.ts
@@ -11,7 +11,7 @@ describe.each([false, true])(
   captureStackTraceAvailable => {
     beforeAll(() => {
       if (!captureStackTraceAvailable) {
-        // @ts-ignore
+        // @ts-expect-error -- 検証のためにcaptureStackTraceを削除したいため
         delete Error.captureStackTrace;
       }
     });

--- a/example-app/SantokuApp/src/bases/local-authentication/LocalAuthentication.test.ts
+++ b/example-app/SantokuApp/src/bases/local-authentication/LocalAuthentication.test.ts
@@ -64,7 +64,7 @@ describe('ExpoLocalAuthentication', () => {
     jest.spyOn(ExpoAuthentication, 'authenticateAsync').mockResolvedValueOnce({success: false, error: 'user_cancel'});
     const no = await LocalAuthentication.authenticate({promptMessage: 'test'});
     expect(no.success).toBeFalsy();
-    // @ts-ignore no.successがfalseの場合のみno.errorが存在するため、そのチェックをするように警告がでるが、expectを条件分岐の中に記載すると今度はその警告が出るのでignoreする
+    // @ts-expect-error no.successがfalseの場合のみno.errorが存在するため、そのチェックをするように警告がでるが、expectを条件分岐の中に記載すると今度はその警告が出るのでignoreする
     expect(no.error).toBe('user_cancel');
   });
 });

--- a/example-app/SantokuApp/src/bases/local-authentication/LocalAuthentication.test.ts
+++ b/example-app/SantokuApp/src/bases/local-authentication/LocalAuthentication.test.ts
@@ -64,7 +64,7 @@ describe('ExpoLocalAuthentication', () => {
     jest.spyOn(ExpoAuthentication, 'authenticateAsync').mockResolvedValueOnce({success: false, error: 'user_cancel'});
     const no = await LocalAuthentication.authenticate({promptMessage: 'test'});
     expect(no.success).toBeFalsy();
-    // @ts-expect-error no.successがfalseの場合のみno.errorが存在するため、そのチェックをするように警告がでるが、expectを条件分岐の中に記載すると今度はその警告が出るのでignoreする
+    // @ts-expect-error -- no.successがfalseの場合のみno.errorが存在するため、そのチェックをするように警告がでるが、expectを条件分岐の中に記載すると今度はその警告が出るのでignoreする
     expect(no.error).toBe('user_cancel');
   });
 });

--- a/example-app/SantokuApp/src/bases/message/Message.test.ts
+++ b/example-app/SantokuApp/src/bases/message/Message.test.ts
@@ -5,19 +5,19 @@ import {RuntimeError} from '../core/errors/RuntimeError';
 
 describe('Message message', () => {
   test('メッセージがロードされていない場合の検証', () => {
-    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
     expect(() => m('msg.error.network')).toThrow(new Error('Messages are not loaded.'));
   });
   test('オプションが存在しないメッセージの取得を検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise(resolve => {
-          // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+          // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'msg.error.network': 'network error.'});
         });
       },
     });
-    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('msg.error.network')).toEqual('network error.');
   });
   test('オプションが存在するメッセージの取得を検証', async () => {
@@ -25,7 +25,7 @@ describe('Message message', () => {
       load: async () => {
         return new Promise(resolve => {
           resolve({
-            // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+            // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
             'validation.required': '{0}を入力してください。',
             // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
             'validation.max': '{0}が長すぎます。{0}は{1}桁以内で入力してください。',
@@ -33,24 +33,24 @@ describe('Message message', () => {
         });
       },
     });
-    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required', 'name')).toEqual('nameを入力してください。');
-    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.max', 'name', 10)).toEqual('nameが長すぎます。nameは10桁以内で入力してください。');
-    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required')).toEqual('{0}を入力してください。');
   });
   test('指定されたメッセージキーに該当するメッセージが存在しない場合の検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise(resolve => {
-          // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+          // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'msg.error.network': 'network error.'});
         });
       },
     });
     const spy = jest.spyOn(error, 'handleError').mockImplementation();
-    // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('dummyKey')).toEqual('dummyKey');
     expect(spy).toHaveBeenCalledWith(
       new RuntimeError('Could not find the message. messageKey=[dummyKey]', 'MessageNotFound'),

--- a/example-app/SantokuApp/src/bases/message/Message.test.ts
+++ b/example-app/SantokuApp/src/bases/message/Message.test.ts
@@ -27,7 +27,6 @@ describe('Message message', () => {
           resolve({
             // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
             'validation.required': '{0}を入力してください。',
-            // @ts-ignore テスト用にMessageKeyには存在しないキーを指定しているため
             'validation.max': '{0}が長すぎます。{0}は{1}桁以内で入力してください。',
           });
         });

--- a/example-app/SantokuApp/src/bases/message/Message.test.ts
+++ b/example-app/SantokuApp/src/bases/message/Message.test.ts
@@ -5,19 +5,19 @@ import {RuntimeError} from '../core/errors/RuntimeError';
 
 describe('Message message', () => {
   test('メッセージがロードされていない場合の検証', () => {
-    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
     expect(() => m('msg.error.network')).toThrow(new Error('Messages are not loaded.'));
   });
   test('オプションが存在しないメッセージの取得を検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise(resolve => {
-          // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+          // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'msg.error.network': 'network error.'});
         });
       },
     });
-    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('msg.error.network')).toEqual('network error.');
   });
   test('オプションが存在するメッセージの取得を検証', async () => {
@@ -25,31 +25,31 @@ describe('Message message', () => {
       load: async () => {
         return new Promise(resolve => {
           resolve({
-            // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+            // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
             'validation.required': '{0}を入力してください。',
             'validation.max': '{0}が長すぎます。{0}は{1}桁以内で入力してください。',
           });
         });
       },
     });
-    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required', 'name')).toEqual('nameを入力してください。');
-    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.max', 'name', 10)).toEqual('nameが長すぎます。nameは10桁以内で入力してください。');
-    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('validation.required')).toEqual('{0}を入力してください。');
   });
   test('指定されたメッセージキーに該当するメッセージが存在しない場合の検証', async () => {
     await loadMessages({
       load: async () => {
         return new Promise(resolve => {
-          // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+          // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
           resolve({'msg.error.network': 'network error.'});
         });
       },
     });
     const spy = jest.spyOn(error, 'handleError').mockImplementation();
-    // @ts-expect-error テスト用にMessageKeyには存在しないキーを指定しているため
+    // @ts-expect-error -- テスト用にMessageKeyには存在しないキーを指定しているため
     expect(m('dummyKey')).toEqual('dummyKey');
     expect(spy).toHaveBeenCalledWith(
       new RuntimeError('Could not find the message. messageKey=[dummyKey]', 'MessageNotFound'),

--- a/example-app/SantokuApp/src/bases/ui/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/bases/ui/picker/DateTimePicker.ios.test.tsx
@@ -152,17 +152,15 @@ describe('DateTimePicker with all props', () => {
     // assert PickerItems
     const pickerItems = screen.getByTestId('pickerItems');
     const pickerItemsProps = pickerItems.props as DateTimePickerItemsIOSProps;
-    // ↓の対応で型定義からdateは削除されましたが、react-native-datetimepickerの内部ではdateを使用しているようなので、selectedValueとdateを比較します
     // https://github.com/react-native-datetimepicker/datetimepicker/pull/671
     // https://github.com/react-native-datetimepicker/datetimepicker/blob/v6.5.2/src/datetimepicker.ios.js#L97
-    // @ts-ignore
+    // @ts-expect-error -- ↑の対応で型定義からdateは削除されましたが、react-native-datetimepickerの内部ではdateを使用しているようなので、selectedValueとdateを比較します
     expect(pickerItemsProps.date).toBe(selectedValue.getTime());
     expect(pickerItemsProps.maximumDate).toBe(maximumDate.getTime());
     expect(pickerItemsProps.minimumDate).toBe(minimumDate.getTime());
     expect(pickerItemsProps.mode).toBe('date');
-    // displayはdisplayIOSというPropでレンダリングされます
     // @ts-ignore
-    // @ts-ignore
+    // @ts-expect-error displayはdisplayIOSというPropでレンダリングされます
     expect(pickerItemsProps.displayIOS).toBe('spinner');
     const pickerItemsStyle = pickerItemsProps.style as ViewStyle;
     const flattenPickerItemsStyle = StyleSheet.flatten(pickerItemsStyle);

--- a/example-app/SantokuApp/src/bases/ui/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/bases/ui/picker/DateTimePicker.ios.test.tsx
@@ -159,7 +159,7 @@ describe('DateTimePicker with all props', () => {
     expect(pickerItemsProps.maximumDate).toBe(maximumDate.getTime());
     expect(pickerItemsProps.minimumDate).toBe(minimumDate.getTime());
     expect(pickerItemsProps.mode).toBe('date');
-    // @ts-expect-error displayはdisplayIOSというPropでレンダリングされます
+    // @ts-expect-error -- displayはdisplayIOSというPropでレンダリングされます
     expect(pickerItemsProps.displayIOS).toBe('spinner');
     const pickerItemsStyle = pickerItemsProps.style as ViewStyle;
     const flattenPickerItemsStyle = StyleSheet.flatten(pickerItemsStyle);

--- a/example-app/SantokuApp/src/bases/ui/picker/DateTimePicker.ios.test.tsx
+++ b/example-app/SantokuApp/src/bases/ui/picker/DateTimePicker.ios.test.tsx
@@ -159,7 +159,6 @@ describe('DateTimePicker with all props', () => {
     expect(pickerItemsProps.maximumDate).toBe(maximumDate.getTime());
     expect(pickerItemsProps.minimumDate).toBe(minimumDate.getTime());
     expect(pickerItemsProps.mode).toBe('date');
-    // @ts-ignore
     // @ts-expect-error displayはdisplayIOSというPropでレンダリングされます
     expect(pickerItemsProps.displayIOS).toBe('spinner');
     const pickerItemsStyle = pickerItemsProps.style as ViewStyle;

--- a/example-app/SantokuApp/src/features/backend/utils/customInstance.ts
+++ b/example-app/SantokuApp/src/features/backend/utils/customInstance.ts
@@ -45,7 +45,9 @@ const customInstance = <T>(
     };
     const promise = axiosInstance(requestConfig);
 
-    // @ts-ignore
+    // @ts-expect-error -- cancelは型定義にはないが存在する
+    // ただし、AbortSignalへの移行を検討した方が良さそう
+    // https://tanstack.com/query/v3/docs/react/guides/query-cancellation#old-cancel-function
     promise.cancel = () => {
       source.cancel('Query was cancelled by React Query');
     };

--- a/example-app/SantokuApp/src/features/backend/utils/customInstance.ts
+++ b/example-app/SantokuApp/src/features/backend/utils/customInstance.ts
@@ -45,7 +45,7 @@ const customInstance = <T>(
     };
     const promise = axiosInstance(requestConfig);
 
-    // @ts-expect-error -- cancelは型定義にはないが存在する
+    // @ts-expect-error -- cancelは型定義にはないが定義するとReact Queryによって呼ばれる
     // ただし、AbortSignalへの移行を検討した方が良さそう
     // https://tanstack.com/query/v3/docs/react/guides/query-cancellation#old-cancel-function
     promise.cancel = () => {


### PR DESCRIPTION
以下の課題を解決するため、[@typescript-eslint/ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment/)を追加しました。

- `@ts-ignore`は、ignoreする必要がない場合に検知できない
- エラーをignoreする場合は、必ず理由を記載したい

## ✅ What's done

- [x] `@typescript-eslint/ban-ts-comment`を`error`で設定
  - [x] `ts-expect-error`に`allow-with-description`を設定
  - [x] `ts-ignore`、`ts-nocheck`は禁止
  - [x] `ts-check`は許可（特に禁止にしたい理由がなかったため）
- [x] Lintエラーの修正

## Other (messages to reviewers, concerns, etc.)

なし
