### PR TITLE
📝: 脚注の順番が不正な問題に対応するpluginを追加

### DIFF
--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
       },
     },
     {
-      files: ['src/plugins/medium-zoom-docusaurus-plugin/index.js'],
+      files: ['src/plugins/medium-zoom-docusaurus-plugin/index.js', 'src/plugins/fix-footnote-order-plugin/index.js'],
       env: {
         node: true,
       },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -245,6 +245,7 @@ module.exports = {
       },
     ],
     './src/plugins/medium-zoom-docusaurus-plugin',
+    './src/plugins/fix-footnote-order-plugin',
   ],
   scripts: [
     // Add plausible script only when built on GitHub Actions.

--- a/website/src/plugins/fix-footnote-order-plugin/fix-footnote-order.js
+++ b/website/src/plugins/fix-footnote-order-plugin/fix-footnote-order.js
@@ -1,0 +1,37 @@
+export default (function () {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return {
+    onRouteDidUpdate() {
+      const idRegExp = /^fn-([0-9]+)$/;
+      const checkKey = 'data-already-sorted';
+      document.querySelectorAll('.footnotes ol').forEach((ol) => {
+        if (ol.hasAttribute(checkKey)) return;
+        ol.setAttribute(checkKey, '');
+
+        [...ol.querySelectorAll('li[id]')]
+          .flatMap((li) => {
+            // 念のため入れ子チェック
+            if (li.parentNode !== ol) return [];
+
+            const str = (idRegExp.exec(li.id) || [])[1];
+            // id形式が想定外
+            if (!str) return [];
+
+            const num = Number(str);
+            return [{li, num}];
+          })
+          .sort((a, b) => {
+            if (a.num < b.num) return -1;
+            if (a.num > b.num) return 1;
+            return 0;
+          })
+          .forEach(({li}) => {
+            ol.appendChild(li);
+          });
+      });
+    },
+  };
+})();

--- a/website/src/plugins/fix-footnote-order-plugin/index.js
+++ b/website/src/plugins/fix-footnote-order-plugin/index.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+module.exports = function () {
+  return {
+    name: 'fix-footnote-order-plugin',
+    getClientModules() {
+      return [path.resolve(__dirname, './fix-footnote-order')];
+    },
+  };
+};


### PR DESCRIPTION
## ✅ What's done

- 脚注の順番が不正な問題に対応するpluginを追加

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] `npm run start` して脚注のあるページを閲覧してソートされていること・エラーが出てないことを確認
  - `/mobile-app-crib-notes/react-native/santoku/decisions/adr-004-deep-link/#fnref-2`
- [x] `npm run start` して脚注の無いページを閲覧してエラーが出てないことを確認

## Other (messages to reviewers, concerns, etc.)
### 動作
1. ページ表示更新時 (`onRouteDidUpdate`) に2〜を実行
   - 参考：[Client architecture | Docusaurus](https://docusaurus.io/docs/advanced/client#client-module-lifecycles)
1. 脚注 `.footnotes ol li` を配列にして id `fn-([0-9]+)` を元に、番号順にソート
2. 順番に `appendChild`
   - 無駄に append することもあるが簡略化のため。
 
※ hashが変わっただけで  `onRouteDidUpdate` が呼ばれるので、効率化のため、HTMLが変わってなくて2回目実行はSKIPするように data 属性でチェック

### 関連
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1199
- 現状確認：[ディープリンクの実現方式 | Fintan » Mobile App Development](https://ws-4020.github.io/mobile-app-crib-notes/react-native/santoku/decisions/adr-004-deep-link/#fnref-2)
  - 2と3が入れ替わっている
- 根本対応には Docusaurus 3 が必要
  - [Footnotes in tables rendered out of order · Issue #6625 · facebook/docusaurus](https://togithub.com/facebook/docusaurus/issues/6625)