### PR TITLE
✨: for-in文を禁止するESLintルールを追加

### DIFF
--- a/example-app/SantokuApp/.eslintrc.js
+++ b/example-app/SantokuApp/.eslintrc.js
@@ -135,7 +135,7 @@ module.exports = {
       {
         selector: 'ForInStatement',
         message:
-          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. For Array, use array.{forEach,map} instead. For Object, use Object.{keys,values,entries}, and iterate over the resulting array. If it is difficult to describe in method, use for...of.',
       },
     ],
     // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html

--- a/example-app/SantokuApp/.eslintrc.js
+++ b/example-app/SantokuApp/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
       extends: ['universe/shared/typescript-analysis', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
       rules: {
         // no-restricted-syntaxでfor-in文を禁止しているので、@typescript-eslint/no-for-in-arrayを無効化する
+        // （no-restricted-syntaxはObjectのfor-in文も禁止にできる）
         '@typescript-eslint/no-for-in-array': 'off',
       },
       parserOptions: {

--- a/example-app/SantokuApp/.eslintrc.js
+++ b/example-app/SantokuApp/.eslintrc.js
@@ -124,6 +124,15 @@ module.exports = {
     ],
     // https://eslint.org/docs/latest/rules/curly
     curly: ['error', 'all'],
+    // https://eslint.org/docs/latest/rules/no-restricted-syntax
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message:
+          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+    ],
     // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html
     'eslint-comments/no-unused-disable': 'error',
     // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-use.html

--- a/example-app/SantokuApp/.eslintrc.js
+++ b/example-app/SantokuApp/.eslintrc.js
@@ -27,6 +27,10 @@ module.exports = {
       // universe/shared/typescript-analysis: https://github.com/expo/expo/tree/master/packages/eslint-config-universe
       // recommended-requiring-type-checking: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules
       extends: ['universe/shared/typescript-analysis', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
+      rules: {
+        // no-restricted-syntaxでfor-in文を禁止しているので、@typescript-eslint/no-for-in-arrayを無効化する
+        '@typescript-eslint/no-for-in-array': 'off',
+      },
       parserOptions: {
         project: './tsconfig.json',
       },


### PR DESCRIPTION
## ✅ What's done

- [x] `for-in`文は`prototype`まで取得してループしてしまうため、`no-restricted-syntax`ルールを追加して、禁止するようにしました。
- [x] `@typescript-eslint/no-for-in-array`を無効化
  - チェック内容が重複したため（`no-restricted-syntax`はObjectの`for-in`文もチェックしてくれるので、そっちを採用）

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

以下のコードでLintエラーになることを確認

```typescript
const a = ['a', 'b', 'c'];
for (const v in a) { } // ESLint: for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.(no-restricted-syntax)

const b = {a: '1'};
for (const v in b) { } // ESLint: for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.(no-restricted-syntax)
```

## Other (messages to reviewers, concerns, etc.)

### 関連

- https://github.com/ws-4020/mobile-app-crib-notes/pull/1201

### 参考

- https://eslint.org/docs/latest/rules/no-restricted-syntax
- https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L340


