### PR TITLE
🐛: app.config.jsに設定したintentFilterがAndroidManifest.xmlに反映されない問題の対応

### DIFF
--- a/example-app/SantokuApp/app.config.js
+++ b/example-app/SantokuApp/app.config.js
@@ -75,6 +75,10 @@ module.exports = ({config}) => {
         UIBackgroundModes: ['fetch', 'remote-notification'],
       },
     },
+    disabledPlugins: [
+      // default plugin を無効化するために patch-package を使用して機能拡張している
+      'withScheme', // カスタムスキーマ 削除
+    ],
     plugins: [
       [
         'expo-build-properties',

--- a/example-app/SantokuApp/config/plugin/src/android/withAndroidAddAppActivityAndroidManifest.ts
+++ b/example-app/SantokuApp/config/plugin/src/android/withAndroidAddAppActivityAndroidManifest.ts
@@ -17,17 +17,12 @@ export const withAndroidAddAppActivityAndroidManifest: ConfigPlugin = config => 
       throw new Error('MainActivity does not exist in AndroidManifest application.');
     }
     const mainActivity = {
+      ...originalMainActivity,
       $: {
         'android:name': '.MainActivity',
         'android:theme': '@style/Theme.App.SplashScreen',
         'android:exported': 'true' as 'true',
       },
-      'intent-filter': [
-        {
-          action: [{$: {'android:name': 'android.intent.action.MAIN'}}],
-          category: [{$: {'android:name': 'android.intent.category.LAUNCHER'}}],
-        },
-      ],
     };
     const restApplication =
       androidManifest.manifest.application?.filter(a => a.$['android:name'] !== '.MainApplication') ?? [];

--- a/example-app/SantokuApp/patches/@expo+config-plugins+6.0.2.patch
+++ b/example-app/SantokuApp/patches/@expo+config-plugins+6.0.2.patch
@@ -38,7 +38,7 @@ index 8a1fc4e..a72436c 100644
  export declare function getApplicationNativeTarget({ project, projectName, }: {
      project: XcodeProject;
 diff --git a/node_modules/@expo/config-plugins/build/ios/utils/Xcodeproj.js b/node_modules/@expo/config-plugins/build/ios/utils/Xcodeproj.js
-index f2ff872..1795bff 100644
+index f2ff872..f39fd90 100644
 --- a/node_modules/@expo/config-plugins/build/ios/utils/Xcodeproj.js
 +++ b/node_modules/@expo/config-plugins/build/ios/utils/Xcodeproj.js
 @@ -146,7 +146,9 @@ function addResourceFileToGroup({
@@ -91,3 +91,15 @@ index f2ff872..1795bff 100644
    addFileToProject({
      project,
      file
+diff --git a/node_modules/@expo/config-plugins/build/plugins/withPlugins.js b/node_modules/@expo/config-plugins/build/plugins/withPlugins.js
+index 3623bd4..e389145 100644
+--- a/node_modules/@expo/config-plugins/build/plugins/withPlugins.js
++++ b/node_modules/@expo/config-plugins/build/plugins/withPlugins.js
+@@ -27,6 +27,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
+  */
+ const withPlugins = (config, plugins) => {
+   (0, _assert().default)(Array.isArray(plugins), 'withPlugins expected a valid array of plugins or plugin module paths');
++  plugins = plugins.filter(p => !(config.disabledPlugins || []).includes(p.name));
+   return plugins.reduce((prev, plugin) => (0, _withStaticPlugin().withStaticPlugin)(prev, {
+     plugin
+   }), config);

--- a/example-app/SantokuApp/patches/README.md
+++ b/example-app/SantokuApp/patches/README.md
@@ -63,6 +63,15 @@ node_modules/
 
 この対応により、パッチを適用するパスは常に`node_modules/@expo/config-plugins`になります。
 
+## [@expo/config-plugins] デフォルトpluginを無効化できるようにするパッチ
+
+`expo prebuild`時にデフォルトpluginに含まれる`withScheme`pluginによってカスタムスキーマが追加されてしまいます。
+追加されたカスタムスキーマの記述を削除するためのpluginを新規作成するより、該当pluginを無効化したほうがシンプルなためExpo Config Pluginsにパッチを当てて機能拡張しました。
+
+※ 現在は `withPlugins` に渡されている plugin のみが対象です(`withRunOnce`, `withStaticPlugin` は対象外)。
+
+`app.config.js`の`disabledPlugins`にpluginの`name`を追加すれば除外できます。
+
 ## [react-native] FlatListでデータが0件の場合に`scrollToEnd`を呼び出すとエラーが発生する問題に対処するパッチ
 
 FlatListでデータが0件の場合に`scrollToEnd`を呼び出すと以下のエラーが発生します。

--- a/example-app/SantokuApp/prebuild/local/android/app/src/main/AndroidManifest.xml
+++ b/example-app/SantokuApp/prebuild/local/android/app/src/main/AndroidManifest.xml
@@ -25,13 +25,6 @@
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="jp.fintan.mobile.SantokuApp.local"/>
-        <data android:scheme="exp+santoku-app"/>
-      </intent-filter>
     </activity>
     <activity android:name=".AppActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="false"/>
     <uses-library android:name="org.apache.http.legacy" android:required="false"/>

--- a/example-app/SantokuApp/prebuild/local/android/app/src/main/AndroidManifest.xml
+++ b/example-app/SantokuApp/prebuild/local/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="jp.fintan.mobile.SantokuApp.local"/>
+        <data android:scheme="exp+santoku-app"/>
+      </intent-filter>
     </activity>
     <activity android:name=".AppActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="false"/>
     <uses-library android:name="org.apache.http.legacy" android:required="false"/>


### PR DESCRIPTION
## ✅ What's done

原因: `withAndroidAddAppActivityAndroidManifest.ts`で`MainActivity`の`intent-filter`に固定値を設定していたため

- [x] `withAndroidAddAppActivityAndroidManifest.ts`で、manifestの値を引き継ぐように変更
- [x] ↑の変更をすると、Expoのデフォルトプラグインの[withScheme](https://github.com/expo/expo/blob/sdk-48/packages/%40expo/config-plugins/src/android/Scheme.ts#L16)がカスタムスキーマを設定してしまうので、`withScheme`を`disable`
  - [x] rn-spoilerに入れている、指定したConfigPluginをdisableにするパッチを追加
    - https://github.com/ws-4020/rn-spoiler/blob/v2023.06.0/template/patches/%40expo%2Bconfig-plugins%2B6.0.1.patch#L102

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- `npm run prebuild`を実行して差分がないことを確認
- `app.config.js`に`intentFilters`を設定後、`AndroidManifest.xml`に指定した値が反映されることを確認

`app.config.js`に`intentFilters`を設定
```
      intentFilters: [
        {
          autoVerify: true,
          action: 'VIEW',
          data: [
            {
              scheme: 'https',
              host: 'example.com',
            },
          ],
          category: ['BROWSABLE', 'DEFAULT'],
        },
      ],
```

`AndroidManifest.xml`のdiff
```diff
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
+      <intent-filter android:autoVerify="true" data-generated="true">
+        <action android:name="android.intent.action.VIEW"/>
+        <data android:scheme="https" android:host="example.com"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
     </activity>
     <activity android:name=".AppActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="false"/>
     <uses-library android:name="org.apache.http.legacy" android:required="false"/>
```

以下のコマンドをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。

- /azp run deploy-stg
- /azp run deploy-dev
- /azp run deploy-all
  - `stg`, `dev` の両方

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし
