### PR TITLE
🔧: tsconfigに設定している一部項目をexpo-template-blank-typescriptの設定に合わせる

### DIFF
--- a/example-app/SantokuApp/tsconfig.json
+++ b/example-app/SantokuApp/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["dom", "esnext"],                 /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/example-app/SantokuApp/tsconfig.json
+++ b/example-app/SantokuApp/tsconfig.json
@@ -43,7 +43,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 

--- a/example-app/SantokuApp/tsconfig.json
+++ b/example-app/SantokuApp/tsconfig.json
@@ -43,7 +43,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 

--- a/example-app/SantokuApp/tsconfig.json
+++ b/example-app/SantokuApp/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    // "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "module": "commonjs",                  /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["dom", "esnext"],                 /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
## ✅ What's done

- [x] 以下の項目は、`expo-template-blank-typescript`に合わせてSantokuAppでもコメントアウトしました
  - [module]( https://www.typescriptlang.org/tsconfig#module)
    - `target`を`esnext`に指定している場合（SantokuAppの設定の場合）は、デフォルトで`es6/es2015`が指定されます
    - 元々`commonjs`が指定されていましたが、React NativeでもExpoでも`es6/es2015`が使われているので問題ない認識です。
      - https://github.com/facebook/react-native/blob/main/packages/typescript-config/tsconfig.json#L6
      - https://github.com/expo/expo/blob/sdk-48/packages/expo/tsconfig.base.json
  - [allowSyntheticDefaultImports](https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports)
    - [esModuleInterop](https://www.typescriptlang.org/tsconfig#esModuleInterop)が`true`の場合は`allowSyntheticDefaultImports`もデフォルトでtrueになるので、コメントアウトしても特に影響はありません

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `npm run lint:tsc`
- [x] `npm run android`

以下のコマンドをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。

- /azp run deploy-stg
- /azp run deploy-dev
- /azp run deploy-all
  - `stg`, `dev` の両方

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

### 関連PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1201
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1226