### PR TITLE
📝: 商標追加

### DIFF
--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -19,7 +19,7 @@ title: 商標について
 - Androidロボットは、Googleが作成および提供している作品から複製または変更したものであり、[クリエイティブ・コモンズ表示](https://creativecommons.org/licenses/by/3.0/) 3.0ライセンスに記載された条件に従って使用しています。
 - 「Amazon Cognito」「Amazon Pinpoint」は、米国および/またはその他の諸国における、Amazon.com, Inc. またはその関連会社の商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->
-- 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
+- 「Azure」「TypeScript」「Visual Studio Code」「VS Code」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->
 - 「Java」「JavaScript」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -40,7 +40,7 @@ title: 商標について
 - 「Adjust」は、Adjust GmbHの登録商標です。
 - 「AppsFlyer」は、AppsFlyer Ltd.の登録商標です。
 - 「Bitly」は、Bitly, Inc.の登録商標です。
-- 「Kochava」は、KOCHAVA, INC.の登録商標です。
+- 「Kochava」は、Kochava, Inc.の登録商標です。
 - 「JetBrains」「IntelliJ」「WebStorm」は、JetBrains s.r.oの登録商標です。
 - 「Sentry」は、Functional Software, Inc.の登録商標です。
 - 「Gradle」は、Gradle, Inc.の登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -21,7 +21,7 @@ title: 商標について
 <!-- textlint-disable ja-technical-writing/sentence-length-->
 - 「Azure」「Windows」は、 Microsoft Corporationの米国およびその他の国におけるMicrosoft Corporationおよび/またはその関連会社の登録商標または商標です。
 <!-- textlint-enable ja-technical-writing/sentence-length-->
-- 「Java」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
+- 「Java」「JavaScript」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->
 - 「ESLint」は、OpenJS Foundationの米国および/またはその他の国における登録商標です。
 - Postgres,PostgreSQL,Slonikロゴは、PostgreSQL Community Association of Canadaの商標または登録商標であり、その許可を得て使用しています。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -39,6 +39,7 @@ title: 商標について
 - 「Figma」は、FIGMA, INC.の商標です。
 - 「Adjust」は、ADJUST GMBHの登録商標です。
 - 「AppsFlyer」は、AppsFlyer Ltd.の登録商標です。
+- 「Bitly」は、Bitly, Inc.の登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -43,6 +43,7 @@ title: 商標について
 - 「Kochava」は、KOCHAVA, INC.の登録商標です。
 - 「JetBrains」「IntelliJ」「WebStorm」は、JetBrains s.r.oの登録商標です。
 - 「Sentry」は、Functional Software, Inc.の登録商標です。
+- 「Gradle」は、Gradle, Inc.の登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -37,6 +37,7 @@ title: 商標について
 <!-- textlint-disable jtf-style/1.2.1.句点(。)と読点(、)-->
 - 「Mapbox」は、Mapbox Inc.の米国およびその他の国における商標または登録商標です。
 - 「Figma」は、FIGMA, INC.の商標です。
+- 「Adjust」は、ADJUST GMBHの登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -38,6 +38,7 @@ title: 商標について
 - 「Mapbox」は、Mapbox Inc.の米国およびその他の国における商標または登録商標です。
 - 「Figma」は、FIGMA, INC.の商標です。
 - 「Adjust」は、ADJUST GMBHの登録商標です。
+- 「AppsFlyer」は、AppsFlyer Ltd.の登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -10,7 +10,7 @@ title: 商標について
 
 <!-- textlint-disable -->
 - 「React」、「React Native」は、Meta Platforms, Inc.の登録商標です。
-- 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPad」「iPadOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」「Dynamic Island」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
+- 「Apple」「Appleのロゴ」「iCloud」「Safari」「Keychain」「iOS」「iPad」「iPadOS」「iPhone」「Mac」「macOS」「watchOS」「tvOS」「Xcode」「App Store」「Instruments」「Objective-C」「Swift」「Dynamic Island」「TestFlight」は、米国およびその他の国で登録された Apple Inc. の商標です。<!-- textlint-enable -->
   ※iPhone商標は、アイホン株式会社のライセンスに基づき使用されています。  
   ※iOS商標は、 Cisco Systems, Inc. のライセンスに基づき使用されています。
 <!-- textlint-disable ja-technical-writing/sentence-length-->

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -23,7 +23,7 @@ title: 商標について
 <!-- textlint-enable ja-technical-writing/sentence-length-->
 - 「Java」「JavaScript」は、Oracle Corporationおよびその子会社、関連会社の米国およびその他の国における登録商標または商標です。
 <!-- textlint-disable ja-technical-writing/sentence-length-->
-- 「ESLint」は、OpenJS Foundationの米国および/またはその他の国における登録商標です。
+- 「ESLint」「Node.js」は、OpenJS Foundationの米国および/またはその他の国における登録商標です。
 - Postgres,PostgreSQL,Slonikロゴは、PostgreSQL Community Association of Canadaの商標または登録商標であり、その許可を得て使用しています。
 - 「Open Web Application Security Project」「OWASP」は、 OWASP Foundation, Inc. の登録商標です。
 - 「DeployGate」は、株式会社デプロイゲートの登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -40,6 +40,7 @@ title: 商標について
 - 「Adjust」は、ADJUST GMBHの登録商標です。
 - 「AppsFlyer」は、AppsFlyer Ltd.の登録商標です。
 - 「Bitly」は、Bitly, Inc.の登録商標です。
+- 「Kochava」は、KOCHAVA, INC.の登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -37,7 +37,7 @@ title: 商標について
 <!-- textlint-disable jtf-style/1.2.1.句点(。)と読点(、)-->
 - 「Mapbox」は、Mapbox Inc.の米国およびその他の国における商標または登録商標です。
 - 「Figma」は、FIGMA, INC.の商標です。
-- 「Adjust」は、ADJUST GMBHの登録商標です。
+- 「Adjust」は、Adjust GmbHの登録商標です。
 - 「AppsFlyer」は、AppsFlyer Ltd.の登録商標です。
 - 「Bitly」は、Bitly, Inc.の登録商標です。
 - 「Kochava」は、KOCHAVA, INC.の登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -42,6 +42,7 @@ title: 商標について
 - 「Bitly」は、Bitly, Inc.の登録商標です。
 - 「Kochava」は、KOCHAVA, INC.の登録商標です。
 - 「JetBrains」「IntelliJ」「WebStorm」は、JetBrains s.r.oの登録商標です。
+- 「Sentry」は、Functional Software, Inc.の登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。

--- a/website/src/pages/trademark.md
+++ b/website/src/pages/trademark.md
@@ -41,6 +41,7 @@ title: 商標について
 - 「AppsFlyer」は、AppsFlyer Ltd.の登録商標です。
 - 「Bitly」は、Bitly, Inc.の登録商標です。
 - 「Kochava」は、KOCHAVA, INC.の登録商標です。
+- 「JetBrains」「IntelliJ」「WebStorm」は、JetBrains s.r.oの登録商標です。
 <!-- textlint-enable jtf-style/1.2.1.句点(。)と読点(、)-->
 
 ※ その他、本サイトに記載されている会社名、商品・サービス名は、各社の商標または登録商標です。


### PR DESCRIPTION
## ✅ What's done

2023/9月公開用に追加・更新したページに含まれる商標を追加。
なお、一部すでにFintanにリリースされているページに含まれている単語で、商標ページに追加されていないものもあったので併せて追加。

- [x] 商標追加
  - Microsoft
    - [x] TypeScript
    - [x] Visual Studio Code
    - [x] VS Code
  - Oracle
    - [x] JavaScript
  - OpenJS Foundation
    - [x] Node.js
  - JetBrains
    - [x] JetBrains
    - [x] IntelliJ
    - [x] WebStorm
  - Firebase Dynamic Linksの代替えサービス関連
    - [x] Adjust
    - [x] AppsFlyer
    - [x] Bitly
    - [x] Kochava
  - Functional Software, Inc.
    - [x] Sentry
  - Apple
    - [x] TestFlight
  - Gradle, Inc.
    - [x] Gradle

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

### 関連PR

- ディープリンク
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1230
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1213
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1220
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1214
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1212
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1208

- Expo SDK 49
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1221

- スタイルガイド
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1226
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1201
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1206

- expo-dev-client
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1207