### PR TITLE
📝 ディープリンクの画面遷移に関するADRでLinking.openURLを使用している箇所を修正

### DIFF
--- a/website/docs/react-native/santoku/decisions/linking-feasibility.mdx
+++ b/website/docs/react-native/santoku/decisions/linking-feasibility.mdx
@@ -105,8 +105,15 @@ const config = isLoggedIn ? {
 - ディープリンクを受け取った時点で、そのディープリンクをグローバルなStateに保持
   - コールド、ウォームスタートの場合は、[linking.getInitialURL](https://reactnavigation.org/docs/navigation-container#linkinggetinitialurl)内でStateに設定
   - ホットスタートの場合は、[linking.subscribe](https://reactnavigation.org/docs/navigation-container#linkingsubscribe)内でStateに設定
-- 認証後にStateからディープリンクを取得し、[Linking.openURL](https://reactnative.dev/docs/linking#openurl)を使用してそのディープリンクを開く
-  - `Linking.openURL`を使用してアプリ内からディープリンクを開くことにより、`linking`に設定したURLと遷移先画面のマッピングに従って画面遷移が行われる
+- 認証後にStateからディープリンクを取得し、ディープリンクに応じた画面へ遷移
+  - `linking`のマッピング定義に従って自動遷移させる方法はないため、独自実装で画面を遷移させる必要がある
+
+:::note
+認証後にStateからディープリンクを取得し、[Linking.openURL](https://docs.expo.dev/versions/latest/sdk/linking/#linkingopenurlurl)を使用してそのディープリンクを開く方法も検討しました。
+`Linking.openURL`を使用してアプリ内からディープリンクを開くことにより、`linking`に設定したURLと遷移先画面のマッピングに従って画面遷移が行われると考えたためです。
+
+しかし、この方法ではiOSの場合に画面遷移が行われず、ブラウザでディープリンクが開かれてしまいました。
+:::
 
 ## ディープリンクの遷移先画面で戻るボタンをタップした場合の動作
 

--- a/website/docs/react-native/santoku/decisions/non-linking-feasibility.mdx
+++ b/website/docs/react-native/santoku/decisions/non-linking-feasibility.mdx
@@ -9,53 +9,64 @@ title: React Navigationのlinkingを使用しない画面遷移の検討
 ディープリンクの受信と、URLの解析には[Expo Linking](https://docs.expo.dev/versions/latest/sdk/linking/)を使用しています。
 
 ```tsx
-type Props = {
-  navigation: NavigationContainerRef<RootStackParamList>;
+/**
+ * ディープリンクURLに応じた画面に遷移させる処理です。
+ */
+const handleDeepLink = (url: string, navigation: NavigationContainerRef<RootStackParamList>) => {
+  const parsedURL = Linking.parse(url);
+
+  if (parsedURL.path?.startsWith('screen-a')) {
+    navigation.dispatch(StackActions.push('StackNavigator1', {screen: 'ScreenA'}));
+  } else if (parsedURL.path?.startsWith('screen-b')) {
+    navigation.navigate('StackNavigator1', {screen: 'ScreenB'});
+  } else if (parsedURL.path?.startsWith('screen-d')) {
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [
+          {
+            name: 'TabNavigator2',
+            state: {
+              index: 0,
+              routes: [{name: 'ScreenD'}],
+            },
+          },
+        ],
+      }),
+    );
+  }
 };
 
-export const DeepLinkHandlers: React.FC<Props> = ({navigation}) => {
+/**
+ * ディープリンクを受信するコンポーネントです。
+ *
+ * このコンポーネントは、NavigationContainerの親コンポーネント（もしくはそれより上位のコンポーネント）として、
+ * 配置する必要があります。
+ * NavigationContainerよりも上位に配置することで、NavigationContainerの初期化が完了した後に、
+ * このコンポーネントのuseEffectが処理されます。
+ * useEffect内では、NavigationContainerのnavigationRefを使用して、ディープリンクURLに応じた画面遷移を行います。
+ */
+export const DeepLinkHandlers: React.FC<
+  PropsWithChildren<{navigation: NavigationContainerRef<RootStackParamList>}>
+> = ({navigation, children}) => {
   // コールド・ウォームスタート
   useEffect(() => {
     Linking.getInitialURL().then(url => {
       if (url) {
-        // ディープリンクを受信した場合は、アプリ内からディープリンクURLを開き、Linking.addEventListenerで再度受信する。
-        // このように実装することで、アプリの初期画面が表示された後にディープリンクに応じた画面に遷移するため、
-        // 遷移先画面から戻るボタンタップなどで、前の画面に戻ることができる。
-        Linking.openURL(url);
+        handleDeepLink(url, navigation);
       }
     });
-  }, []);
+  }, [navigation]);
 
   // ホットスタート
   useEffect(() => {
     const subscription = Linking.addEventListener('url', event => {
-      const parsedURL = Linking.parse(event.url);
-
-      if (parsedURL.path?.startsWith('screen-a')) {
-        navigation.dispatch(StackActions.push('StackNavigator1', {screen: 'ScreenA'}));
-      } else if (parsedURL.path?.startsWith('screen-b')) {
-        navigation.navigate('StackNavigator1', {screen: 'ScreenB'});
-      } else if (parsedURL.path?.startsWith('screen-d')) {
-        navigation.dispatch(
-          CommonActions.reset({
-            index: 0,
-            routes: [
-              {
-                name: 'TabNavigator2',
-                state: {
-                  index: 0,
-                  routes: [{name: 'ScreenD'}],
-                },
-              },
-            ],
-          }),
-        );
-      }
+      handleDeepLink(event.url, navigation);
     });
     return () => subscription.remove();
   }, [navigation]);
 
-  return null;
+  return <>{children}</>;
 };
 ```
 

--- a/website/docs/react-native/santoku/decisions/non-linking-feasibility.mdx
+++ b/website/docs/react-native/santoku/decisions/non-linking-feasibility.mdx
@@ -46,7 +46,7 @@ const handleDeepLink = (url: string, navigation: NavigationContainerRef<RootStac
  * このコンポーネントのuseEffectが処理されます。
  * useEffect内では、NavigationContainerのnavigationRefを使用して、ディープリンクURLに応じた画面遷移を行います。
  */
-export const DeepLinkHandlers: React.FC<
+export const DeepLinkHandler: React.FC<
   PropsWithChildren<{navigation: NavigationContainerRef<RootStackParamList>}>
 > = ({navigation, children}) => {
   // コールド・ウォームスタート

--- a/website/docs/react-native/santoku/decisions/non-linking-feasibility.mdx
+++ b/website/docs/react-native/santoku/decisions/non-linking-feasibility.mdx
@@ -80,6 +80,5 @@ export const DeepLinkHandlers: React.FC<
 - ディープリンクを受け取った時点で、そのディープリンクをStateに保持
   - コールド、ウォームスタートの場合は、[Linking.getInitialURL](https://docs.expo.dev/versions/latest/sdk/linking/#linkinggetinitialurl)内でStateに設定
   - ホットスタートの場合は、[Linking.addEventListener](https://docs.expo.dev/versions/latest/sdk/linking/#linkingaddeventlistenertype-handler)内でStateに設定
-- 認証後にStateからディープリンクを取得し、[Linking.openURL](https://docs.expo.dev/versions/latest/sdk/linking/#linkingopenurlurl)を使用してそのディープリンクを開く
-  - `Linking.openURL`を使用してアプリ内からディープリンクを開くことにより、`Linking.addEventListener`でディープリンクを再度受信する
-    :::
+- 認証後にStateからディープリンクを取得し、ディープリンクに応じた画面へ遷移
+:::


### PR DESCRIPTION
## ✅ What's done

`Linking.openURL`を実行して`Linking.addEventListener`を呼び出すような記載をしている箇所がありましたが、iOSの場合は`Linking.openURL`を実行するとブラウザが開いてしまうため、それに関する記載を見直しました。

- [x] 未認証時に受け取ったディープリンクの遷移先画面を、認証後に表示する方法の修正
- [x] `linking`を使用しない場合のコード例の修正
---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] コード例をIDEに持ってきて、構文エラーなどがないことを確認

## Other (messages to reviewers, concerns, etc.)

なし
