### PR TITLE
🤡: App.test.tsxの自動テスト実行時にエラーログが出力されていたので対応

### DIFF
--- a/example-app/SantokuApp/jest/__mocks__/expo-linking.ts
+++ b/example-app/SantokuApp/jest/__mocks__/expo-linking.ts
@@ -1,0 +1,12 @@
+/*
+  eslint-disable-next-line @typescript-eslint/no-unsafe-assignment --
+  expo-linkingのすべてのNamed Exportを列挙するのは大変なので、
+  ES6のexport/import形式ではなく、module.exportsを使ってexportする。
+ */
+module.exports = {
+  ...jest.requireActual('expo-linking'),
+  addEventListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
+  getInitialURL: jest.fn().mockResolvedValue(null),
+};


### PR DESCRIPTION
## ✅ What's done

`expo-linking`の`addEventListener`から返却される`subscription`が`undefined`のためエラーログが出力されている模様（テストは成功してる）

```
  console.error
    Warning: Internal React error: Attempted to capture a commit phase error inside a detached tree. This indicates a bug in React. Likely causes include deleting the same fiber more than once, committing an already-finished tree, or an inconsistent return pointer.

    Error message:

    TypeError: Cannot read properties of undefined (reading 'remove')
```

- [x] `expo-linking`のmock化

## ⏸ What's not done

- とりあえず、SantokuAppで使用している関数でNativeにアクセスしているものをmock化しています

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `npm run test`でエラーログが出力されていないことを確認

## Other (messages to reviewers, concerns, etc.)
### 関連PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1213