### PR TITLE
📸: expo-template-bare-minimumが更新されたのでPrebuildを実施

### DIFF
--- a/example-app/SantokuApp/prebuild/dev/android/app/src/debug/AndroidManifest.xml
+++ b/example-app/SantokuApp/prebuild/dev/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning">
+  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic">
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
   </application>
 </manifest>

--- a/example-app/SantokuApp/prebuild/local/android/app/src/debug/AndroidManifest.xml
+++ b/example-app/SantokuApp/prebuild/local/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning">
+  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic">
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
   </application>
 </manifest>

--- a/example-app/SantokuApp/prebuild/prod/android/app/src/debug/AndroidManifest.xml
+++ b/example-app/SantokuApp/prebuild/prod/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning">
+  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic">
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
   </application>
 </manifest>

--- a/example-app/SantokuApp/prebuild/stg/android/app/src/debug/AndroidManifest.xml
+++ b/example-app/SantokuApp/prebuild/stg/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning">
+  <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic">
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
   </application>
 </manifest>


### PR DESCRIPTION
## ✅ What's done

- [x] `npm run prebuild:[環境]`
  - ref: expo/expo@93b8858485243e1bd310ca6a79187b0b8973e235 `[templates][android] update template to replace usesCleartextTraffic`

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

### 関連PR

- https://github.com/ws-4020/mobile-app-crib-notes/pull/1221

