### PR TITLE
🧑‍💻: renovate対象外を追加（expo-dev-client）

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,7 @@
         'expo',
         'expo-build-properties',
         'expo-crypto',
+        'expo-dev-client',
         'expo-keep-awake',
         'expo-linking',
         'expo-local-authentication',


### PR DESCRIPTION
## ✅ What's done
expoによる管理対象であるため`expo-dev-client`をrenovate対象外に指定

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 関連PR

- https://github.com/ws-4020/mobile-app-crib-notes/pull/1207
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1219#discussion_r1320909027