### PR TITLE
📝: activateKeepAwake -> activateKeepAwakeAsync

### DIFF
--- a/website/docs/react-native/learn/qa-app/app-project-desc.md
+++ b/website/docs/react-native/learn/qa-app/app-project-desc.md
@@ -318,7 +318,7 @@ export const yup = Yup;
 
 ```typescript title="src/apps/app/use-cases/useAppInitializer.ts"
 import {enhanceValidator} from "bases/validator";
-import {activateKeepAwake} from "expo-keep-awake";
+import {activateKeepAwakeAsync} from "expo-keep-awake";
 import {useCallback, useMemo, useState} from "react";
 
 import { loadBundledMessagesAsync } from "../services/loadBundledMessagesAsync";
@@ -340,7 +340,7 @@ type InitializationResult = Initializing | InitializeSuccessResult | InitializeF
 const initializeCoreFeatures = async () => {
   // 開発中は画面がスリープしないように設定
   if (__DEV__) {
-    await activateKeepAwake();
+    await activateKeepAwakeAsync();
   }
 
   // アプリ内で使用するメッセージのロード


### PR DESCRIPTION
## ✅ What's done

- `expo-keep-awake`の`activateKeepAwake` → `activateKeepAwakeAsync`
  - activateKeepAwakeはdeprecatedでありwarningがでるため

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- `git grep --word-regexp activateKeepAwake` で [Expo48記事](https://ws-4020.github.io/mobile-app-crib-notes/react-native/santoku/maintenance/enhance/expo-48-upgrade#expo-keep-awake)しかhitしないことを確認
- `cd website` && `npm start`
- http://localhost:3000/mobile-app-crib-notes/react-native/learn/qa-app/app-project-desc の `src/apps/app/use-cases/useAppInitializer.ts` ファイルを新規プロジェクトに追加
- `activateKeepAwakeAsync` 行の警告が消えることを確認

## Other (messages to reviewers, concerns, etc.)
そもそも、`activateKeepAwakeAsync`は`DEV`の場合expoが呼んでいそうなので不要かもしれないが、それは別で対応する。
- [expo/packages/expo/src/launch/registerRootComponent.tsx at 1f98cdd7a0a365e1e2b2569ae813fa1a2d9409f1 · expo/expo](https://github.com/expo/expo/blob/1f98cdd7a0a365e1e2b2569ae813fa1a2d9409f1/packages/expo/src/launch/registerRootComponent.tsx#L22-L25)
- [expo/packages/expo/src/launch/withDevTools.tsx at 1f98cdd7a0a365e1e2b2569ae813fa1a2d9409f1 · expo/expo](https://github.com/expo/expo/blob/1f98cdd7a0a365e1e2b2569ae813fa1a2d9409f1/packages/expo/src/launch/withDevTools.tsx#L20-L21)