### PR TITLE
📝: react-navigation: 型エラーの説明を改善

### DIFF
--- a/website/docs/react-native/learn/basic-concepts/react-navigation-basics/param.mdx
+++ b/website/docs/react-native/learn/basic-concepts/react-navigation-basics/param.mdx
@@ -37,7 +37,7 @@ const Screen2: React.FC = () => {
 };
 ```
 
-ただし、TypeScriptを使用している場合は次のエラーが発生します。
+ただし、TypeScriptを使用している場合は`route.params.message`の部分で次のエラーが発生します。
 
 ```bash
 TS18048: 'route.params' is possibly 'undefined'.

--- a/website/docs/react-native/learn/basic-concepts/react-navigation-basics/param.mdx
+++ b/website/docs/react-native/learn/basic-concepts/react-navigation-basics/param.mdx
@@ -40,7 +40,7 @@ const Screen2: React.FC = () => {
 ただし、TypeScriptを使用している場合は次のエラーが発生します。
 
 ```bash
-TS2532: Object is possibly 'undefined'.
+TS18048: 'route.params' is possibly 'undefined'.
 TS2339: Property 'message' does not exist on type 'object'.
 ```
 


### PR DESCRIPTION
## ✅ What's done

- 型エラーを現状と揃える
- エラーの発生場所を明示

理由：紛らわしいため

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 関連PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/202
  - 「応用編」追加
- https://github.com/ws-4020/mobile-app-crib-notes/pull/503
  - `React Navigation` v5 -> v6
- https://github.com/ws-4020/mobile-app-crib-notes/pull/609
  - 「概要」の `型チェックを実質的に無効化して利用しています ` 追加
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1255#discussion_r1357810721