### PR TITLE
📝: rnSpoilerTagを更新

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,7 +22,7 @@ const copyright = `<div class="no-content">
 
 const injectOptions = {
   organization,
-  rnSpoilerTag: 'master',
+  rnSpoilerTag: 'v2023.9.0',
 };
 
 module.exports = {


### PR DESCRIPTION
## ✅ What's done

- rnSpoilerTagをmasterからv2023.9.0に変更（固定）
  - masterのままだとrn-spoilerにmergeしたものが即座に使用されてしまい、ドキュメントと不整合になるため

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] `npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#v2023.9.0` がエラー無く実行できること
  - ※ `--npm`無しのyarnを使った場合、post-installが動きません。元（`patch-package`が入ったとき）から。
- [x] `npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#v2023.6.0` の結果が`v2023.9.0`と違いexpo48になっていること

## Other (messages to reviewers, concerns, etc.)
### 関連Issue
- https://github.com/ws-4020/rn-spoiler/pull/71
  - > RN Spoilerのバージョニングは、セマンティックバージョニングに従う必要はありません。ただ、Yarnがインストールされた環境でreact-native initするとデフォルトではYarnが選択されてしまい、エラーになってしまう
  - :memo: ↑は2023/10に `npx react-native -v: 9.3.2`, `yarn: 1.22.19`, `rn-spoiler tag: v2023.09.0` で試したところ問題なかった。おそらく、タグ名ではなく、package.jsonのversionのことと思われる。
- https://github.com/ws-4020/mobile-app-crib-notes/pull/367
- https://github.com/ws-4020/mobile-app-crib-notes/pull/967

### その他
- タグ一覧: [Tags · ws-4020/rn-spoiler](https://github.com/ws-4020/rn-spoiler/tags)
  - `v2023.09.0`形式(月が0始まり)のやつは間違えたものですが、リンク切れ回避のため残してあるものです
  - 今後のタグは0無しの`v2023.9.0`形式で。
  - :memo: hotfixが必要になった場合は、タグの付替えではなく、`v2023.9.1` のようにパッチバージョンアップで対応
- ↓で変更されてた`website/docs/docusaurus/plugins.md` は変更してないです。formatは変更されてないため。
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/367