### PR TITLE
📝: pod-install方法をnpm runに統一

### DIFF
--- a/website/docs/react-native/learn/qa-app/app-project-desc.md
+++ b/website/docs/react-native/learn/qa-app/app-project-desc.md
@@ -53,7 +53,7 @@ npx expo install <package-name> -- -D
 iOSアプリを開発をする場合は、macOSで次のコマンドを実行して必要なライブラリをインストールしてください。
 
 ```bash
-npx pod-install
+npm run pod-install
 ```
 
 :::info


### PR DESCRIPTION
## ✅ What's done

- npx pod-install → npm run pod-install
  - 過去に変更していたものの漏れに対応

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->


## Other (messages to reviewers, concerns, etc.)
rn-spoilerには `pod-install` scriptが定義済み
```
"pod-install": "cd ios && bundle exec pod install --repo-update",
```
https://github.com/ws-4020/rn-spoiler/blob/v2023.6.0/template/package.json#L18
### 関連PR（過去の修正commit）
- https://github.com/ws-4020/mobile-app-crib-notes/pull/967
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/967/commits/10df043894cc1d489c30d73674deef6e4d84b830 `change pod install from npx to npm scripts`
