### PR TITLE
📝: 開発用プロビジョニングプロファイルのType表現修正

### DIFF
--- a/website/docs/distribution/app-build/ios-build-setting.md
+++ b/website/docs/distribution/app-build/ios-build-setting.md
@@ -108,7 +108,7 @@ Mac端末にダウンロードした証明書をダブルクリックすると�
 1. Xcodeの左ペインでプロジェクトをクリック＞「TARGETS」で通常の（TestsやtvOSなどではない）TARGETを指定＞「Signing & Capabilities」＞「All」を選択
 1. 「Automatically manage signing」のチェックを外す
 1. 「Provisioning Profile」のプルダウンで「Import Profile…」を選択
-1. 開発用プロビジョニングプロファイル（Apple Development）を指定
+1. 開発用プロビジョニングプロファイル（Development）を指定
 1. 「Bundle Identifier」にアプリ管理者から教えてもらったApp IDを指定
 
 ##### トラブルシューティング


### PR DESCRIPTION
## ✅ What's done

- 開発用プロビジョニングプロファイルのType表現を修正
  - :x: Apple Development
  - :o: Development

※ Apple Developmentは証明書のType

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 該当ドキュメント
[iOSプロジェクトのビルド設定 | Fintan » Mobile App Development](https://fintan-contents.github.io/mobile-app-crib-notes/distribution/app-build/ios-build-setting/#configuration%E3%81%AE%E8%A8%AD%E5%AE%9A)
> 開発用プロビジョニングプロファイル（Apple Development）を指定

### 関連
- https://developer.apple.com/account/resources/certificates/add
  - > Apple Development
- https://developer.apple.com/account/resources/profiles/add