### PR TITLE
📝 : Q&Aアプリ初期設定のWarn修正

### DIFF
--- a/website/docs/react-native/learn/qa-app/app-project-desc.md
+++ b/website/docs/react-native/learn/qa-app/app-project-desc.md
@@ -369,6 +369,7 @@ export const useAppInitialize = () => {
 
 ```typescript jsx title="src/apps/app/AppWithInitialization.tsx"
 import {NavigationContainer} from '@react-navigation/native';
+import {RuntimeError} from 'bases/core/errors/RuntimeError';
 import React, {useEffect, useState} from 'react';
 import {Alert} from 'react-native';
 
@@ -389,7 +390,7 @@ export const AppWithInitialization: React.FC = () => {
   useEffect(() => {
     // 初期化処理に失敗した場合はアプリをクラッシュ扱いで終了
     if (initializationError) {
-      throw initializationError;
+      throw new RuntimeError('Failed to initialize app.', initializationError);
     }
   }, [initializationError]);
 

--- a/website/docs/react-native/learn/qa-app/app-project-desc.md
+++ b/website/docs/react-native/learn/qa-app/app-project-desc.md
@@ -320,7 +320,7 @@ import {enhanceValidator} from "bases/validator";
 import {activateKeepAwakeAsync} from "expo-keep-awake";
 import {useCallback, useMemo, useState} from "react";
 
-import { loadBundledMessagesAsync } from "../services/loadBundledMessagesAsync";
+import {loadBundledMessagesAsync} from "../services/loadBundledMessagesAsync";
 
 type Initializing = {
   code: 'Initializing';


### PR DESCRIPTION
## ✅ What's done

- 不要なスペースを削除(prettier警告対策)
- no-throw-literal warn 修正

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 対象ドキュメント
[Q&Aアプリプロジェクトの説明 | Fintan » Mobile App Development](https://ws-4020.github.io/mobile-app-crib-notes/react-native/learn/qa-app/app-project-desc#qa%E3%82%A2%E3%83%97%E3%83%AA%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E8%A8%AD%E5%AE%9A)
- `src/apps/app/use-cases/useAppInitializer.ts`
- `src/apps/app/AppWithInitialization.tsx`

### 関連PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/883
- https://github.com/ws-4020/mobile-app-crib-notes/pull/956
  - https://github.com/ws-4020/mobile-app-crib-notes/commit/9d7235a6835075804559d80d4189c046678895a0 ``fix @typescript-eslint/no-throw-literal warning``
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1269
  - ↑の動作確認中に検知