### PR TITLE
📝: 学習コンテンツのプロジェクトの作成ページにVisual Studio Code用の推奨設定について追記

### DIFF
--- a/website/docs/react-native/learn/getting-started/create-project.md
+++ b/website/docs/react-native/learn/getting-started/create-project.md
@@ -87,3 +87,5 @@ npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
 - ファイル保存時の自動フォーマット・自動修正
 
 インストールした拡張機能は違うプロジェクトでも引き継がれるので、この作業は初回のみで十分です。
+
+その他の有用な拡張機能については[開発に利用するツールの「Visual Studio Code」ページ](../../santoku/development/tools/vscode.md)を参照ください。

--- a/website/docs/react-native/learn/getting-started/create-project.md
+++ b/website/docs/react-native/learn/getting-started/create-project.md
@@ -73,3 +73,17 @@ npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
 1. `cd <YourAppName>`（`<YourAppName>`は実際に作成したときの値に変更してください）
 2. `npm install --legacy-peer-deps`
 :::
+
+### Visual Studio Code用の推奨設定
+
+作成されたプロジェクトにはVisual Studio Code用のファイルが含まれています。
+
+- 拡張機能一覧（`.vscode/extensions.json`）
+- 推奨設定（`.vscode/settings.json`）
+
+`Extensions`→`Recommended`で表示される`WORKSPACE RECOMMENDATIONS`に表示される拡張機能をインストールすると、以下のメリットがあります。
+
+- エディター上での警告表示
+- ファイル保存時の自動フォーマット・自動修正
+
+インストールした拡張機能は違うプロジェクトでも引き継がれるので、この作業は初回のみで十分です。

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,7 +22,7 @@ const copyright = `<div class="no-content">
 
 const injectOptions = {
   organization,
-  rnSpoilerTag: 'v2023.9.0',
+  rnSpoilerTag: 'master',
 };
 
 module.exports = {


### PR DESCRIPTION
## ✅ What's done

- プロジェクトの作成ページにVisual Studio Code用の推奨設定について追記

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 「rnSpoilerTagをmasterに変更」コミットについて
- `.vscode/` は`v2023.9.0`タグには存在しなく`master`ブランチに存在するため
- すでに以下PRでmasterブランチに入っていますが、関係性のわかりやすさ・rnSpoilerTagの更新についての周知のためにcommitに含めています（mergeするときに差分は消えます）
  - https://github.com/ws-4020/mobile-app-crib-notes/pull/1269

### 該当ページ
- [プロジェクトの作成 | Fintan » Mobile App Development](https://ws-4020.github.io/mobile-app-crib-notes/react-native/learn/getting-started/create-project)

### 関連PR
- https://github.com/ws-4020/rn-spoiler/pull/151