### PR TITLE
🩹: 学習コンテンツで、コードに対する説明文章が適切ではない箇所があったので修正

### DIFF
--- a/website/docs/react-native/learn/todo-app/screens/welcome.mdx
+++ b/website/docs/react-native/learn/todo-app/screens/welcome.mdx
@@ -78,7 +78,7 @@ const styles = StyleSheet.create({
   };
 ```
 
-[アプリの実装前に](../../basic-concepts.mdx)で得た知識があれば、上記コードは理解できるでしょう。
+[アプリの実装前に](../../basic-concepts/react-navigation-basics.mdx#3-レンダリングを定義)で述べたとおり、`initialRouteName`属性に画面名（`nav.Screen`の`name`属性の値）を指定すると、対応する画面が初期表示の画面になります。
 
 修正できたら実行してください。
 次の画面が表示できたら成功です。


### PR DESCRIPTION
## ✅ What's done

- [x] Welcomeページの「[アプリの実装前に](https://ws-4020.github.io/mobile-app-crib-notes/react-native/learn/basic-concepts)で得た知識があれば、上記コードは理解できるでしょう。」という表現とリンク先を修正
  - 修正したコードに対する説明文章を追記 
  - 「アプリの実装前に」に設定していたリンク先は`initialRouteName`の説明をしているセクションに変更

---

## Other (messages to reviewers, concerns, etc.)

学習コンテンツを一通り確認しましたが、以前の学習コンテンツに丸投げ感のある表現はWelcomeページだけでした。
