### PR TITLE
🐛: isLoading設定誤りを修正

### DIFF
--- a/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
+++ b/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
@@ -34,6 +34,6 @@ export const useAccountCommands = () => {
     agreeTerms: agreeTermsMutation.mutateAsync,
     isLoadingAccountData: loadAccountDataMutation.isLoading,
     isAgreeingTerms: agreeTermsMutation.isLoading,
-    isProcessing: agreeTermsMutation.isLoading || agreeTermsMutation.isLoading,
+    isProcessing: agreeTermsMutation.isLoading,
   };
 };

--- a/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
+++ b/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
@@ -34,6 +34,7 @@ export const useAccountCommands = () => {
     agreeTerms: agreeTermsMutation.mutateAsync,
     isLoadingAccountData: loadAccountDataMutation.isLoading,
     isAgreeingTerms: agreeTermsMutation.isLoading,
-    isProcessing: agreeTermsMutation.isLoading,
+    isProcessing:
+      loadAccountDataMutation.isLoading || updateDeviceTokenMutation.isLoading || agreeTermsMutation.isLoading,
   };
 };

--- a/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
+++ b/example-app/SantokuApp/src/features/account/services/account/useAccountCommands.ts
@@ -32,7 +32,7 @@ export const useAccountCommands = () => {
     loadAccountData: loadAccountDataMutation.mutateAsync,
     updateDeviceToken: updateDeviceTokenMutation.mutateAsync,
     agreeTerms: agreeTermsMutation.mutateAsync,
-    isLoadingAccountData: agreeTermsMutation.isLoading,
+    isLoadingAccountData: loadAccountDataMutation.isLoading,
     isAgreeingTerms: agreeTermsMutation.isLoading,
     isProcessing: agreeTermsMutation.isLoading || agreeTermsMutation.isLoading,
   };


### PR DESCRIPTION
## ✅ What's done

- [x] `isLoadingAccountData: agreeTermsMutation.isLoading` → `isLoadingAccountData: loadAccountDataMutation.isLoading`に変更
- [x] `isProcessing: agreeTermsMutation.isLoading || agreeTermsMutation.isLoading`は同じ値(boolean)なので、`isProcessing: agreeTermsMutation.isLoading`に修正

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone 14 Pro/iOS 16.2)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel XL/Android 13)
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

なし