### PR TITLE
📝: ドキュメントのコード欄にTypeエラーを修正

### DIFF
--- a/website/docs/react-native/santoku/application-architecture/error-handling/how-to-handle-error.mdx
+++ b/website/docs/react-native/santoku/application-architecture/error-handling/how-to-handle-error.mdx
@@ -99,16 +99,20 @@ const Component = () => {
 
 ```typescript jsx title=await式を使用した場合のtry...catchの例
 const Component = () => {
-  useEffect(() => {
-    (async () => {
-      try {
-        const result = await asyncFunction();
-        // 正常時の処理
-      } catch(e) {
-        // エラー処理
-      }
-    })();
+  const callAsyncFunction = useCallback(async () => {
+    try {
+      const result = await asyncFunction();
+      // 正常時の処理
+    } catch (e) {
+      // エラー処理
+    }
   }, [asyncFunction]);
+
+  useEffect(() => {
+    callAsyncFunction().catch(() => {
+      // callAsyncFunctionでエラーハンドリングを実施しているので、ここでは特に何もしない
+    });
+  }, [callAsyncFunction]);
 
   /* ～省略～ */
 };

--- a/website/docs/react-native/santoku/application-architecture/error-handling/how-to-handle-error.mdx
+++ b/website/docs/react-native/santoku/application-architecture/error-handling/how-to-handle-error.mdx
@@ -100,12 +100,14 @@ const Component = () => {
 ```typescript jsx title=await式を使用した場合のtry...catchの例
 const Component = () => {
   useEffect(() => {
-    try {
-      const result = await asyncFunction();
-      // 正常時の処理
-    } catch(e) {
-      // エラー処理
-    }
+    (async () => {
+      try {
+        const result = await asyncFunction();
+        // 正常時の処理
+      } catch(e) {
+        // エラー処理
+      }
+    })();
   }, [asyncFunction]);
 
   /* ～省略～ */


### PR DESCRIPTION
## ✅ What's done

- [x] コード欄に`async`、`await`使い方を修正しました。

## ⏸ What's not done

- 他のコード欄にもTypeエラーを修正する必要があります。

- [typescript-docs-verifier](https://github.com/bbc/typescript-docs-verifier)ライブラリを使用して確認した内容は以下のなります。

  - 下記のスクリプトを追加し、コマンドを実行すると「importエラー」などを誤検知しています。
   ```
   "scripts": {
     "verifier-doc": "find docs -type f -name '*.mdx' -o -name '*.md' | xargs typescript-docs-verifier --input-files"
   }
   ```
  - 下記のようにコード欄にタイトルがあるとエラーの場合でも検知できない状態です。 
   https://github.com/ws-4020/mobile-app-crib-notes/blob/31b075ea63a6eaaaba22399351e35cd1dc0c1861/website/docs/react-native/santoku/application-architecture/error-handling/how-to-handle-error.mdx#L100

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] `npm run lint`コマンド実行

## Other (messages to reviewers, concerns, etc.)

なし
