### PR TITLE
🩹: Pull Request Labelerのバージョンを固定

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Label according to modified files
         # https://github.com/marketplace/actions/labeler
-        uses: actions/labeler@master
+        uses: actions/labeler@v4
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           # Default is '.github/labeler.yml', but we use 'yaml' as an extension of YAML files.


### PR DESCRIPTION
## ✅ What's done

- [x] Pull Request Labelerの`master`にBreaking Changesがある更新が入って、CIで突然エラーが発生するのを防止

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

v5で[Breaking Changes](https://github.com/actions/labeler#breaking-changes-in-v5)があり、他のPRのCIがtriageで落ちています。

落ちているPR
  - https://github.com/ws-4020/mobile-app-crib-notes/actions/runs/7097456769/job/19317601218?pr=1308

このPRでは、一旦今まで使用していたであろうv4に固定します。