### PR TITLE
📌: ドキュメントから参照するrn-spoilerのタグを更新

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,7 +22,7 @@ const copyright = `<div class="no-content">
 
 const injectOptions = {
   organization,
-  rnSpoilerTag: 'v2023.12.0',
+  rnSpoilerTag: 'v2024.10.0',
 };
 
 module.exports = {


### PR DESCRIPTION
## ✅ What's done

- [x] [`v2024.10.0`](https://togithub.com/ws-4020/rn-spoiler/releases/tag/v2024.10.0)に固定

---

## Other (messages to reviewers, concerns, etc.)

なし