### PR TITLE
📝: fix: npx react-native init が失敗する問題に暫定対処

### DIFF
--- a/website/docs/react-native/learn/getting-started/create-project.md
+++ b/website/docs/react-native/learn/getting-started/create-project.md
@@ -21,7 +21,7 @@ title: プロジェクトの作成
 :::
 
 ```bash
-npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
+npx react-native@0.75.4 init --npm --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
 ```
 
 RN Spoilerは、Expoの[テンプレート](https://github.com/expo/expo/tree/master/templates)をベースにしているので、このあとの[アプリの実行](./launch-created-app.mdx)で紹介しているExpo Goで動作します。
@@ -30,13 +30,13 @@ RN Spoilerは、Expoの[テンプレート](https://github.com/expo/expo/tree/ma
 [npm](https://www.npmjs.com/)ではなく[Yarn](https://yarnpkg.com/)を利用したい場合は、`--npm`というオプションを削除してください。Yarnがインストールされている場合は、Yarnを利用してパッケージがインストールされます。
 
 ```bash
-npx react-native init --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
+npx react-native@0.75.4 init --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
 ```
 
 :::
 
 :::info
-初めて`npx react-native init ...`を実行すると、次のように不足しているパッケージをインストールするかと聞かれます。`react-native`をインストールしようとしていれば問題ないので、エンターキーを押して実行してください。
+初めて`npx react-native@0.75.4 init ...`を実行すると、次のように不足しているパッケージをインストールするかと聞かれます。`react-native`をインストールしようとしていれば問題ないので、エンターキーを押して実行してください。
 
 ```console
 Need to install the following packages:


### PR DESCRIPTION
## ✅ What's done

- [x] [プロジェクトの作成 | Fintan » Mobile App Development](https://ws-4020.github.io/mobile-app-crib-notes/react-native/learn/getting-started/create-project/) の `npx react-native`コマンドにversionを明示(`@0.75.4`)
   - 理由: v0.76.0以降だと失敗するようになったため


## ⏸ What's not done

- 恒久対応(2024/12/31までに必要)

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] 変更前のコマンド `npx react-native init ～`だと失敗することを確認(後述)
- [x] 変更後のコマンド `npx react-native@0.75.4 init ～`だと成功することを確認(後述)
- [x] `create-project.md`以外のファイルに`react-native init`がないこと

```
$ git grep 'react-native init' v2024.10
v2024.10:website/docs/react-native/learn/getting-started/create-project.md:npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
v2024.10:website/docs/react-native/learn/getting-started/create-project.md:npx react-native init --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
v2024.10:website/docs/react-native/learn/getting-started/create-project.md:初めて`npx react-native init ...`を実行すると、次のように不足しているパッケージをインストールするかと聞かれます。`react-native`をインストールしようとしていれば問題ないので、エンターキーを押して実行してください。

$ git grep 'react-native init' | wc --lines
0
```

### 変更前
```
$ npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#v2024.10.0 dummy

⚠️ The `init` command is deprecated.
The behavior will be changed on 2024/12/31 (39 days).

- Switch to npx @react-native-community/cli init for the identical behavior.
- Refer to the documentation for information about alternative tools: https://reactnative.dev/docs/getting-started

Running: npx @react-native-community/cli init

node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: spawn npx ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:292:12)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npx',
  path: 'npx',
  spawnargs: [
    '@react-native-community/cli@latest',
    'init',
    '--npm',
    '--template',
    'https://github.com/ws-4020/rn-spoiler#v2024.10.0',
    'dummy'
  ]
}

Node.js v20.17.0
```

### 変更後
```
$ npx react-native@0.75.4 init --npm --template https://github.com/ws-4020/rn-spoiler#v2024.10.0 dummy

⚠️ The `init` command is deprecated.
The behavior will be changed on 2024/12/31 (39 days).

- Switch to npx @react-native-community/cli init for the identical behavior.
- Refer to the documentation for information about alternative tools: https://reactnative.dev/docs/getting-started

Running: npx @react-native-community/cli init


               ######                ######
             ###     ####        ####     ###
            ##          ###    ###          ##
            ##             ####             ##
            ##             ####             ##
            ##           ##    ##           ##
            ##         ###      ###         ##
             ##  ########################  ##
          ######    ###            ###    ######
      ###     ##    ##              ##    ##     ###
   ###         ## ###      ####      ### ##         ###
  ##           ####      ########      ####           ##
 ##             ###     ##########     ###             ##
  ##           ####      ########      ####           ##
   ###         ## ###      ####      ### ##         ###
      ###     ##    ##              ##    ##     ###
          ######    ###            ###    ######
             ##  ########################  ##
            ##         ###      ###         ##
            ##           ##    ##           ##
            ##             ####             ##
            ##             ####             ##
            ##          ###    ###          ##
             ###     ####        ####     ###
               ######                ######


                  Welcome to React Native!
                 Learn once, write anywhere

warn Flag --npm is deprecated and will be removed soon. In the future, please use --pm npm instead.
- Downloading template
√ Downloading template
- Copying template
√ Copying template
- Processing template
√ Processing template
i Executing post init script
  ⏭️ Failed to generate debug.keystore file. You need to generate debug.keystore manually.
- Installing dependencies
√ Installing dependencies
- Initializing Git repository
√ Initializing Git repository


  Run instructions for Android:
    • Have an Android emulator running (quickest way to get started), or a device connected.
    • cd "path-to\dummy" && npx react-native run-android

  Run instructions for Windows:
    • See https://aka.ms/ReactNativeGuideWindows for the latest up-to-date instructions.
```

## Other (messages to reviewers, concerns, etc.)

- `rn-spoiler#v2024.10.0`がExpo SDK51と古い件(最新は52)は別途対応します
- 別途2024/12/31までに恒久対応します