### PR TITLE
【動作確認用のためmergeしない】chore: 配布用証明書の動作確認用に設定変更

### DIFF
--- a/.azure-pipelines/deploy.yaml
+++ b/.azure-pipelines/deploy.yaml
@@ -17,6 +17,7 @@ variables:
 - group: deployGate
 - group: santokuAppStg
 - group: santokuAppDev
+- group: temp-cert-test-2025-06-02
 - name: appDir
   value: '$(System.DefaultWorkingDirectory)/example-app/SantokuApp'
 - name: branchName
@@ -149,8 +150,8 @@ stages:
       - task: InstallAppleCertificate@2
         displayName: 'Install an Apple certificate for ${{environment.name}}'
         inputs:
-          certSecureFile: $(apple_DistributionCertificateSecureFileName)
-          certPwd: $(apple_DistributionCertificatePassword)
+          certSecureFile: $(apple_DistributionCertificateSecureFileName_for_cert_test_2025_06_02)
+          certPwd: $(apple_DistributionCertificatePassword_for_cert_test_2025_06_02)
       - task: InstallAppleProvisioningProfile@1
         displayName: 'Install an Apple provisioning profile for ${{environment.name}}'
         inputs:
@@ -158,7 +159,7 @@ stages:
       - task: InstallAppleProvisioningProfile@1
         displayName: 'Install an Apple provisioning profile for ${{environment.name}}'
         inputs:
-          provProfileSecureFile: $(${{environment.name}}_AppleDistributionProvisioningProfileSecureFileName)
+          provProfileSecureFile: $(${{environment.name}}_AppleDistributionProvisioningProfileSecureFileName_for_cert_test_2025_06_02)
       - task: CmdLine@2
         displayName: 'Use Xcode 15.4'
         inputs:

--- a/example-app/SantokuApp/fastlane/Fastfile.build_santoku_app_ios
+++ b/example-app/SantokuApp/fastlane/Fastfile.build_santoku_app_ios
@@ -4,7 +4,7 @@ bundle_identifier_base = "jp.fintan.mobile.SantokuApp"
 
 provisioning_profiles = {
   "#{bundle_identifier_base}" => "SantokuApp AppStore Distribution",
-  "#{bundle_identifier_base}.stg" => "SantokuApp Stg Distribution",
+  "#{bundle_identifier_base}.stg" => "SantokuApp Stg Distribution for_cert_test_2025_06",
   "#{bundle_identifier_base}.dev" => "SantokuApp Dev Distribution",
 }
 


### PR DESCRIPTION
現在動いているものに影響を与えないように以下を新規で追加
・ファイル
　・配布用証明書＆秘密鍵(.p12）
　・プロビジョニングプロファイル（.mobileprovision ）
・環境変数
　・apple_DistributionCertificatePassword_for_cert_test_2025_06_02 　・apple_DistributionCertificateSecureFileName_for_cert_test_2025_06_02 　・stg_AppleDistributionProvisioningProfileSecureFileName_for_cert_test_2025_06_02

備考
・temp-cert-test-2025-06-02 変数グループを追加してまとめてある
・stg環境用のみ追加(dev環境用ビルドすると配布用証明書・秘密鍵が無いためexportに失敗するはず）

## Tests

- [ ] 実施した動作確認の内容をチェック付きの箇条書きで記載してください
- [ ] 作業着手前に列挙して TODO リストのようにも使用できます
- [ ] やり終わったらチェックを付けてください

以下のコマンドをこのプルリクエストのコメントとして投稿すると、
Azure Pipeline上でSantokuAppをビルドしてDeployGateへアップロードできます。

- /azp run deploy-stg
- /azp run deploy-dev
- /azp run deploy-all
  - `stg`, `dev` の両方

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

何かあれば記載してください。
なければ「なし」と記載してください。
