### PR TITLE
chore: gh-pages用actions/upload-artifactをv4に更新

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -147,7 +147,7 @@ jobs:
           args: --conf website/.htmltest.yaml website/build
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mobile-app-crib-notes
           path: ./website/build/mobile-app-crib-notes


### PR DESCRIPTION
## ✅ What's done

- @actions/upload-artifactで指定していたバージョン3が非推奨になりCIがエラーになったためバージョン4にアップデート

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## 発生している問題
- masterブランチにmerge後にGitHub Pagesを更新するCIが動く予定だが、それが失敗するので、[（動作確認用）GitHub Pages](https://ws-4020.github.io/mobile-app-crib-notes/)が更新されない

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] 修正前だとgh-pagesのビルドCIが失敗すること
   - https://github.com/ws-4020/mobile-app-crib-notes/actions/runs/15414208587/job/43373043392#step:1:43
      - > `Error: Missing download info for actions/upload-artifact@v3`
- [ ] ~gh-pages用ビルド結果に隠しファイルが無いことを確認する~（おそらく問題ない）
   - v4では隠しファイルが除外されるようになったため
   - → コスパを考慮して、PRのmerge後のCIで動作確認する（ws-4020側はGitHub Pagesが壊れても問題ないため）


## Other (messages to reviewers, concerns, etc.)
### 関連PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1334#pullrequestreview-2891582311

### 関連ドキュメント
* [actions/upload-artifact](https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact)
   * > actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
* [Deprecation notice: v3 of the artifact actions - GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
   * > there are [key differences](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) from previous versions that may require updates to your workflows. Please see [the documentation](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) in the project repositories for guidance on how to migrate your workflows.
* [actions/upload-artifact](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes)
   * > **Breaking Changes**
   * （詳細はリンク先参照）
   * **With v4.4 and later, hidden files are excluded by default.** (このPRに関係ありそうな重要なもの）
* [upload-artifact/docs/MIGRATION.md at main · actions/upload-artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
